### PR TITLE
fix(frontend): consentToSharePersonalInformation in partnerInformation and DTOs

### DIFF
--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -76,7 +76,7 @@ export type TermsAndConditionsDto = ReadonlyDeep<{
 }>;
 
 export type PartnerInformationDto = ReadonlyDeep<{
-  consentToSharePersonalInformation: boolean;
+  consentToSharePersonalInformation: true;
   yearOfBirth: string;
   socialInsuranceNumber: string;
 }>;

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -79,24 +79,12 @@ export type RenewalContactInformationDto = ReadonlyDeep<{
   email?: string;
 }>;
 
-/** Partner information provided during a full benefit renewal. */
-export type FullRenewalPartnerInformationDto = ReadonlyDeep<{
-  clientId?: never;
-  consentToSharePersonalInformation: boolean;
+export type RenewalPartnerInformationDto = ReadonlyDeep<{
+  clientId?: string;
+  consentToSharePersonalInformation: true;
   socialInsuranceNumber: string;
   yearOfBirth: string;
 }>;
-
-/** Partner information for a simplified benefit renewal. */
-export type SimplifiedRenewalPartnerInformationDto = ReadonlyDeep<{
-  clientId: string;
-  consentToSharePersonalInformation?: never;
-  socialInsuranceNumber: string;
-  yearOfBirth: string;
-}>;
-
-/** Partner information provided during a benefit renewal. */
-export type RenewalPartnerInformationDto = FullRenewalPartnerInformationDto | SimplifiedRenewalPartnerInformationDto;
 
 export type RenewalTypeOfApplicationDto = 'adult' | 'adult-child' | 'child';
 

--- a/frontend/app/.server/domain/dtos/client-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/client-application.dto.ts
@@ -91,7 +91,7 @@ export type ClientPartnerInformationDto = ReadonlyDeep<{
   yearOfBirth: string;
   firstName?: string;
   lastName?: string;
-  socialInsuranceNumber?: string;
+  socialInsuranceNumber: string;
 }>;
 
 export type ClientApplicationBasicInfoRequestDto = Readonly<{

--- a/frontend/app/.server/domain/entities/benefit-application.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-application.entity.ts
@@ -83,7 +83,7 @@ export type BenefitApplicationRequestEntity = ReadonlyDeep<{
               IdentificationID?: string;
             }[];
           }[];
-          ConsentToSharePersonalInformationIndicator?: boolean;
+          ConsentToSharePersonalInformationIndicator?: true;
           AttestParentOrGuardianIndicator?: boolean;
         };
         PersonBirthDate: {

--- a/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
+++ b/frontend/app/.server/domain/entities/benefit-renewal.entity.ts
@@ -87,14 +87,14 @@ export type BenefitRenewalRequestEntity = ReadonlyDeep<{
         IdentificationID: string;
       };
       RelatedPerson: {
-        ApplicantDetail?: {
+        ApplicantDetail: {
           PrivateDentalInsuranceIndicator?: boolean;
           InsurancePlan?: {
             InsurancePlanIdentification?: {
               IdentificationID?: string;
             }[];
           }[];
-          ConsentToSharePersonalInformationIndicator?: boolean;
+          ConsentToSharePersonalInformationIndicator?: true;
           AttestParentOrGuardianIndicator?: boolean;
         };
         BenefitApplicationDetail?: {

--- a/frontend/app/.server/domain/entities/client-application.entity.ts
+++ b/frontend/app/.server/domain/entities/client-application.entity.ts
@@ -110,7 +110,7 @@ export type ClientApplicationEntity = ReadonlyDeep<{
           ReferenceDataName: 'Spouse' | 'Dependant';
         };
         PersonSINIdentification: {
-          IdentificationID?: string;
+          IdentificationID: string;
         };
         ApplicantDetail: {
           PrivateDentalInsuranceIndicator?: boolean;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -318,19 +318,9 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
   }
 
   private toRelatedPersonSpouse(renewalPartnerInformation: RenewalPartnerInformationDto) {
-    if (renewalPartnerInformation.consentToSharePersonalInformation !== undefined) {
-      // Full partner information is provided during a full renewal
-      return {
-        ApplicantDetail: { ConsentToSharePersonalInformationIndicator: renewalPartnerInformation.consentToSharePersonalInformation },
-        PersonBirthDate: { YearDate: renewalPartnerInformation.yearOfBirth },
-        PersonRelationshipCode: { ReferenceDataName: 'Spouse' as const },
-        PersonSINIdentification: { IdentificationID: sanitizeSin(renewalPartnerInformation.socialInsuranceNumber) },
-      };
-    }
-
-    // Simplified partner information is provided during a simplified renewal
     return {
-      ClientIdentification: [{ IdentificationID: renewalPartnerInformation.clientId, IdentificationCategoryText: 'Client ID' }],
+      ApplicantDetail: { ConsentToSharePersonalInformationIndicator: renewalPartnerInformation.consentToSharePersonalInformation },
+      ClientIdentification: renewalPartnerInformation.clientId ? [{ IdentificationID: renewalPartnerInformation.clientId, IdentificationCategoryText: 'Client ID' }] : undefined,
       PersonBirthDate: { YearDate: renewalPartnerInformation.yearOfBirth },
       PersonRelationshipCode: { ReferenceDataName: 'Spouse' as const },
       PersonSINIdentification: { IdentificationID: sanitizeSin(renewalPartnerInformation.socialInsuranceNumber) },

--- a/frontend/app/.server/locales/en/application-full-adult.json
+++ b/frontend/app/.server/locales/en/application-full-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "your-application": "Your application",

--- a/frontend/app/.server/locales/en/application-full-child.json
+++ b/frontend/app/.server/locales/en/application-full-child.json
@@ -13,7 +13,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "phone-number": "Phone number",

--- a/frontend/app/.server/locales/en/application-full-family.json
+++ b/frontend/app/.server/locales/en/application-full-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "your-application": "Your application",

--- a/frontend/app/.server/locales/en/protected-application-intake-adult.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "prev-btn": "Your application",

--- a/frontend/app/.server/locales/en/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.json
@@ -13,7 +13,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "phone-number": "Phone number",

--- a/frontend/app/.server/locales/en/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "your-application": "Your application",

--- a/frontend/app/.server/locales/en/protected-application-renewal-adult.json
+++ b/frontend/app/.server/locales/en/protected-application-renewal-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "prev-btn": "Renew your Canadian Dental Care Plan benefits",

--- a/frontend/app/.server/locales/en/protected-application-renewal-child.json
+++ b/frontend/app/.server/locales/en/protected-application-renewal-child.json
@@ -42,7 +42,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "next-btn": "Your child(ren)'s application",

--- a/frontend/app/.server/locales/en/protected-application-renewal-family.json
+++ b/frontend/app/.server/locales/en/protected-application-renewal-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Spouse or common-law partner's year of birth",
     "consent": "Consent",
     "consent-yes": "My spouse or common-law partner has agreed to share their personal information.",
-    "consent-no": "My spouse or common-law partner has not agreed to share their personal information.",
     "add-marital-status": "Add marital status",
     "edit-marital-status": "Edit marital status information",
     "prev-btn": "Renew your Canadian Dental Care Plan benefits",

--- a/frontend/app/.server/locales/fr/application-full-adult.json
+++ b/frontend/app/.server/locales/fr/application-full-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "your-application": "Votre demande",

--- a/frontend/app/.server/locales/fr/application-full-child.json
+++ b/frontend/app/.server/locales/fr/application-full-child.json
@@ -13,7 +13,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "phone-number": "Numéro de téléphone",

--- a/frontend/app/.server/locales/fr/application-full-family.json
+++ b/frontend/app/.server/locales/fr/application-full-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "your-application": "Votre demande",

--- a/frontend/app/.server/locales/fr/protected-application-intake-adult.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "prev-btn": "Votre demande",

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.json
@@ -13,7 +13,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "phone-number": "Numéro de téléphone",

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "your-application": "Votre demande",

--- a/frontend/app/.server/locales/fr/protected-application-renewal-adult.json
+++ b/frontend/app/.server/locales/fr/protected-application-renewal-adult.json
@@ -14,7 +14,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "prev-btn": "Renouveler votre demande de prestations du Régime canadien de soins dentaires",

--- a/frontend/app/.server/locales/fr/protected-application-renewal-child.json
+++ b/frontend/app/.server/locales/fr/protected-application-renewal-child.json
@@ -42,7 +42,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "prev-btn": "Renouveler vos prestations du Régime canadien de soins dentaires",

--- a/frontend/app/.server/locales/fr/protected-application-renewal-family.json
+++ b/frontend/app/.server/locales/fr/protected-application-renewal-family.json
@@ -15,7 +15,6 @@
     "spouse-yob": "Année de naissance de l'époux ou de l'épouse ou du conjoint ou de la conjointe de fait",
     "consent": "Consentement",
     "consent-yes": "Mon époux ou épouse ou conjoint ou conjointe de fait a consenti à la communication de ses renseignements personnels.",
-    "consent-no": "Mon époux ou épouse ou conjoint ou conjointe de fait n'a pas consenti à la communication de ses renseignements personnels.",
     "add-marital-status": "Ajouter l'état civil",
     "edit-marital-status": "Modifier l'état civil",
     "prev-btn": "Renouveler votre demande de prestations du Régime canadien de soins dentaires",

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -111,7 +111,7 @@ export type ProtectedApplicationState = ReadonlyDeep<{
   };
   livingIndependently?: boolean;
   partnerInformation?: {
-    consentToSharePersonalInformation: boolean;
+    consentToSharePersonalInformation: true;
     yearOfBirth: string;
     socialInsuranceNumber: string;
   };

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -111,7 +111,7 @@ export type PublicApplicationState = ReadonlyDeep<{
   };
   livingIndependently?: boolean;
   partnerInformation?: {
-    consentToSharePersonalInformation: boolean;
+    consentToSharePersonalInformation: true;
     yearOfBirth: string;
     socialInsuranceNumber: string;
   };

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -610,7 +610,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
           clientId: existingPartnerInformation.clientId,
           socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber,
           yearOfBirth: existingPartnerInformation.yearOfBirth,
-          // From a legal perspective it should be to true in all scenarios
+          // From a legal perspective, this should be true in all scenarios
           consentToSharePersonalInformation: true,
         }
       : undefined;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -608,8 +608,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return existingPartnerInformation
       ? {
           clientId: existingPartnerInformation.clientId,
-          socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber ?? '',
+          socialInsuranceNumber: existingPartnerInformation.socialInsuranceNumber,
           yearOfBirth: existingPartnerInformation.yearOfBirth,
+          // From a legal perspective it should be to true in all scenarios
+          consentToSharePersonalInformation: true,
         }
       : undefined;
   }

--- a/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
@@ -83,9 +83,7 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
                   <>
                     <DefinitionListItem term={t('protected-application-intake-adult:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('protected-application-intake-adult:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('protected-application-intake-adult:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-intake-adult:marital-status.consent-yes') : t('protected-application-intake-adult:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('protected-application-intake-adult:marital-status.consent')}>{t('protected-application-intake-adult:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
@@ -116,9 +116,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
                   <>
                     <DefinitionListItem term={t('protected-application-intake-child:parent-or-guardian.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('protected-application-intake-child:parent-or-guardian.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('protected-application-intake-child:parent-or-guardian.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-intake-child:parent-or-guardian.consent-yes') : t('protected-application-intake-child:parent-or-guardian.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('protected-application-intake-child:parent-or-guardian.consent')}>{t('protected-application-intake-child:parent-or-guardian.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/protected/application/intake-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-family/marital-status.tsx
@@ -83,9 +83,7 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
                   <>
                     <DefinitionListItem term={t('protected-application-intake-family:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('protected-application-intake-family:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('protected-application-intake-family:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-intake-family:marital-status.consent-yes') : t('protected-application-intake-family:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('protected-application-intake-family:marital-status.consent')}>{t('protected-application-intake-family:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
@@ -90,9 +90,7 @@ export default function ProtectedNewAdultMaritalStatus({ loaderData, params }: R
                   <>
                     <DefinitionListItem term={t('protected-application-renewal-adult:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('protected-application-renewal-adult:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('protected-application-renewal-adult:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-renewal-adult:marital-status.consent-yes') : t('protected-application-renewal-adult:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('protected-application-renewal-adult:marital-status.consent')}>{t('protected-application-renewal-adult:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
@@ -247,9 +247,7 @@ export default function ProtectedRenewChildParentOrGuardian({ loaderData, params
                     <>
                       <DefinitionListItem term={t('protected-application-renewal-child:parent-or-guardian.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                       <DefinitionListItem term={t('protected-application-renewal-child:parent-or-guardian.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                      <DefinitionListItem term={t('protected-application-renewal-child:parent-or-guardian.consent')}>
-                        {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-renewal-child:parent-or-guardian.consent-yes') : t('protected-application-renewal-child:parent-or-guardian.consent-no')}
-                      </DefinitionListItem>
+                      <DefinitionListItem term={t('protected-application-renewal-child:parent-or-guardian.consent')}>{t('protected-application-renewal-child:parent-or-guardian.consent-yes')}</DefinitionListItem>
                     </>
                   )}
                 </DefinitionList>

--- a/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
@@ -90,9 +90,7 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
                   <>
                     <DefinitionListItem term={t('protected-application-renewal-family:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('protected-application-renewal-family:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('protected-application-renewal-family:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('protected-application-renewal-family:marital-status.consent-yes') : t('protected-application-renewal-family:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('protected-application-renewal-family:marital-status.consent')}>{t('protected-application-renewal-family:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
-    consentToSharePersonalInformation: z.boolean().refine((val) => val === true, t('protected-application-spokes:marital-status.error-message.confirm-required')),
+    consentToSharePersonalInformation: z.literal(true, t('protected-application-spokes:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()

--- a/frontend/app/routes/public/application/full-adult/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-adult/marital-status.tsx
@@ -80,9 +80,7 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
                   <>
                     <DefinitionListItem term={t('application-full-adult:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('application-full-adult:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('application-full-adult:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('application-full-adult:marital-status.consent-yes') : t('application-full-adult:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('application-full-adult:marital-status.consent')}>{t('application-full-adult:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
@@ -113,9 +113,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
                   <>
                     <DefinitionListItem term={t('application-full-child:parent-or-guardian.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('application-full-child:parent-or-guardian.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('application-full-child:parent-or-guardian.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('application-full-child:parent-or-guardian.consent-yes') : t('application-full-child:parent-or-guardian.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('application-full-child:parent-or-guardian.consent')}>{t('application-full-child:parent-or-guardian.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/public/application/full-family/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-family/marital-status.tsx
@@ -80,9 +80,7 @@ export default function NewFamilyMaritalStatus({ loaderData, params }: Route.Com
                   <>
                     <DefinitionListItem term={t('application-full-family:marital-status.spouse-sin')}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
                     <DefinitionListItem term={t('application-full-family:marital-status.spouse-yob')}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t('application-full-family:marital-status.consent')}>
-                      {state.partnerInformation.consentToSharePersonalInformation ? t('application-full-family:marital-status.consent-yes') : t('application-full-family:marital-status.consent-no')}
-                    </DefinitionListItem>
+                    <DefinitionListItem term={t('application-full-family:marital-status.consent')}>{t('application-full-family:marital-status.consent-yes')}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -91,7 +91,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const currentYear = new Date().getFullYear();
   const partnerInformationSchema = z.object({
-    consentToSharePersonalInformation: z.boolean().refine((val) => val === true, t('application-spokes:marital-status.error-message.confirm-required')),
+    consentToSharePersonalInformation: z.literal(true, t('application-spokes:marital-status.error-message.confirm-required')),
     yearOfBirth: z
       .string()
       .trim()


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request makes several important changes to how partner information and consent are handled across benefit application and renewal flows. The main focus is to enforce that consent to share personal information is always explicitly true, simplify related types, and ensure that required fields like Social Insurance Number are always present. These changes improve data consistency and legal compliance throughout the application.

**Consent handling and enforcement:**

* Changed all relevant types and entities so that `consentToSharePersonalInformation` and `ConsentToSharePersonalInformationIndicator` can only ever be `true`, rather than a boolean, ensuring explicit consent is always required. [[1]](diffhunk://#diff-11782fa4b1be6ec365721d4ef3c691ad188623ecf175d568563f4ac2b377346dL79-R79) [[2]](diffhunk://#diff-d0eabee2b798970c1d3853c79941349b66f5fa6aef2994f519a509abb820007dL86-R86) [[3]](diffhunk://#diff-4b5ecbe825b44f78ffe6647a5c33f356fac14e8bf80d7d6e35024b28f6bbaeb5L90-R97) [[4]](diffhunk://#diff-039c8b364a90138a6c482f90803bfe32f2a2f52954c3e634141fd2cee3f68b9dL114-R114) [[5]](diffhunk://#diff-a4df438b0b3a9519e2893cc5e2341f86b025acb957475ddbe4a5d3aff65c27baL114-R114)
* Updated form validation to require `consentToSharePersonalInformation` as a literal `true`, rather than any boolean, making the consent check stricter in both protected and public application flows. [[1]](diffhunk://#diff-d91760209c6f933f8273ca31459e38737ce700311755bdcba2ddc93cceb740d6L101-R101) [[2]](diffhunk://#diff-bbd3b44a96446d2db627f22d69563c43569d5d892aca69fc597043262b4e3ba3L94-R94)

**Partner information and identification:**

* Simplified and unified partner information types for benefit renewal by removing separate full/simplified types and requiring all fields (including `clientId` and `socialInsuranceNumber`) as needed.
* Updated mappers to always set `consentToSharePersonalInformation: true` and ensure `socialInsuranceNumber` is always present when mapping partner information. [[1]](diffhunk://#diff-87a78b103d951b109e84639b4a9af17a59d9965d83066d14c72bbd2ca91c4803L321-R323) [[2]](diffhunk://#diff-a7cd9e15f37f1862ebfda970b77e8de761389f4033e91600afd4739263d5f6a3L611-R614)

**Required fields enforcement:**

* Made `socialInsuranceNumber` and `IdentificationID` required in all relevant DTOs and entities, ensuring these identifiers are always collected and stored. [[1]](diffhunk://#diff-c708e972c4ba5260ba24065dd33788d05fc62f22ec98e500b5f56e56ea02870bL94-R94) [[2]](diffhunk://#diff-65ad5e0284580075b59cd9089737184ea79664a19ad338bf0d5b3b1d020bbfffL113-R113)

