### PR TITLE
chore(gitops): bump prod frontend to 7.2.0 and enable maintenance mode

### DIFF
--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  - ./ingresses.yaml
-  # - ./ingresses-maintenance.yaml
+  # - ./ingresses.yaml
+  - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml
@@ -60,6 +60,11 @@ configMapGenerator:
       - ./configs/oauth-proxy/config.conf
   - name: maintenance
     behavior: merge
+    literals:
+      - startTimeEn=April 22, 2026, at 6:00 a.m.
+      - startTimeFr=22 avril 2026 à 06 h 00
+      - endTimeEn=April 22, 2026, at 7:00 a.m. (EST)
+      - endTimeFr=22 avril 2026 à 07 h 00 (HNE)
     # TODO :: GjB :: this is a temporary override of the maintenance page HTML
     #                it should be removed when the letters are brought back online
     # TODO :: GjB :: I am commenting this out but leaving the updated 503 page in

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.1.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.2.0
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
## Description

### Changes

- Bump prod frontend image from `7.1.0` to `7.2.0`
- Enable full maintenance mode (public traffic → maintenance page)
- Configure maintenance window times (April 22, 2026, 6:00–7:00 a.m. EST)

### ⚠️ NOTE

> **This PR is planned to be merged on April 22, 2026, at 6:00 a.m. (EST).**
>
> ⚠️ **DO NOT merge this PR before that date/time.** ⚠️
>
> Merging early will activate maintenance mode and take down the public-facing application prematurely.

### Post-deployment

After the maintenance window (7:00 a.m. EST), a follow-up change will be needed to:
1. Re-enable `./ingresses.yaml`
2. Comment out `./ingresses-maintenance.yaml`