### PR TITLE
chore(gitops): disable maintenance mode in production

### DIFF
--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  # - ./ingresses.yaml
-  - ./ingresses-maintenance.yaml
+  - ./ingresses.yaml
+  # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml
@@ -63,8 +63,8 @@ configMapGenerator:
     literals:
       - startTimeEn=April 22, 2026, at 6:00 a.m.
       - startTimeFr=22 avril 2026 à 06 h 00
-      - endTimeEn=April 22, 2026, at 7:00 a.m. (EST)
-      - endTimeFr=22 avril 2026 à 07 h 00 (HNE)
+      - endTimeEn=April 22, 2026, at 7:00 a.m. (EDT)
+      - endTimeFr=22 avril 2026 à 07 h 00 (HAE)
     # TODO :: GjB :: this is a temporary override of the maintenance page HTML
     #                it should be removed when the letters are brought back online
     # TODO :: GjB :: I am commenting this out but leaving the updated 503 page in


### PR DESCRIPTION
## Description

### Changes

- Disable full maintenance mode (maintenance page -> public traffic)

### ⚠️ NOTE

> **This PR is planned to be merged on April 22, 2026, at 7:00 a.m. (EST).**