### PR TITLE
refactor(frontend): use base application shared types in mappers

### DIFF
--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -1,9 +1,175 @@
-import type { PickDeep } from 'type-fest';
+// Shared state field types for Public/Protected ApplicationState
+import type { PickDeep, ReadonlyDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
+import type { DeclaredChange } from '~/.server/routes/helpers/declared-change-type';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { EligibilityType } from '~/components/eligibility';
 import { getAgeFromDateString } from '~/utils/date-utils';
+
+/**
+ * The context of the application, either 'intake' for new applications or 'renewal' for renewal applications.
+ * Immutable and set at the start of the application process based on renewal period status.
+ */
+export type BaseApplicationContextState = 'intake' | 'renewal';
+
+/**
+ * The type of application being submitted.
+ * Can be 'adult', 'children', 'family', or 'delegate'.
+ */
+export type BaseApplicationTypeOfApplicationState = 'adult' | 'children' | 'family' | 'delegate';
+
+/**
+ * Applicant's personal information for the application state.
+ */
+export type BaseApplicationApplicantInformationState = ReadonlyDeep<{
+  memberId?: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  socialInsuranceNumber: string;
+}>;
+
+/**
+ * Application year information for the application state.
+ */
+export type BaseApplicationYearState = ReadonlyDeep<{
+  applicationYearId: string;
+  taxYear: string;
+  dependentEligibilityEndDate: string;
+}>;
+
+/**
+ * Child's personal information for the application state.
+ */
+export type BaseApplicationChildInformationState = ReadonlyDeep<{
+  memberId?: string;
+  firstName: string;
+  lastName: string;
+  dateOfBirth: string;
+  isParent: boolean;
+  hasSocialInsuranceNumber: boolean;
+  socialInsuranceNumber?: string;
+}>;
+
+/**
+ * Dental benefits information for the application state.
+ */
+export type BaseApplicationDentalBenefitsState = ReadonlyDeep<{
+  hasFederalBenefits: boolean;
+  federalSocialProgram?: string;
+  hasProvincialTerritorialBenefits: boolean;
+  provincialTerritorialSocialProgram?: string;
+  province?: string;
+}>;
+
+/**
+ * Dental benefits state wrapped in DeclaredChange for tracking changes in the application state.
+ */
+export type BaseApplicationDentalBenefitsDeclaredChangeState = ReadonlyDeep<DeclaredChange<BaseApplicationDentalBenefitsState>>;
+
+/**
+ * Dental insurance information for the application state.
+ */
+export type BaseApplicationDentalInsuranceState = ReadonlyDeep<{
+  hasDentalInsurance: boolean;
+  dentalInsuranceEligibilityConfirmation?: boolean;
+}>;
+
+/**
+ * Child state object for the application, including benefits and insurance.
+ */
+export type BaseApplicationChildState = ReadonlyDeep<{
+  id: string;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance?: BaseApplicationDentalInsuranceState;
+  information?: BaseApplicationChildInformationState;
+}>;
+
+/**
+ * Communication preferences for the application state.
+ */
+export type BaseApplicationCommunicationPreferencesState = ReadonlyDeep<{
+  preferredLanguage: string;
+  preferredMethod: string;
+  preferredNotificationMethod: string;
+}>;
+
+/**
+ * Communication preferences state wrapped in DeclaredChange for tracking changes in the application state.
+ */
+export type BaseApplicationCommunicationPreferencesDeclaredChangeState = ReadonlyDeep<DeclaredChange<BaseApplicationCommunicationPreferencesState>>;
+
+/**
+ * Address information for the application state.
+ */
+export type BaseApplicationAddressState = ReadonlyDeep<{
+  address: string;
+  city: string;
+  country: string;
+  postalCode?: string;
+  province?: string;
+}>;
+
+/**
+ * Address state wrapped in DeclaredChange for tracking changes in the application state.
+ */
+export type BaseApplicationAddressDeclaredChangeState = ReadonlyDeep<DeclaredChange<BaseApplicationAddressState>>;
+
+/**
+ * Phone number information for the application state.
+ */
+export type BaseApplicationPhoneNumberState = ReadonlyDeep<{
+  primary: string;
+  alternate?: string;
+}>;
+
+/**
+ * Phone number state wrapped in DeclaredChange for tracking changes in the application state.
+ */
+export type BaseApplicationPhoneNumberDeclaredChangeState = ReadonlyDeep<DeclaredChange<BaseApplicationPhoneNumberState>>;
+
+/**
+ * Partner's information for the application state.
+ */
+export type BaseApplicationPartnerInformationState = ReadonlyDeep<{
+  consentToSharePersonalInformation: true;
+  yearOfBirth: string;
+  socialInsuranceNumber: string;
+}>;
+
+/**
+ * Terms and conditions acceptance for the application state.
+ */
+export type BaseApplicationTermsAndConditionsState = ReadonlyDeep<{
+  acknowledgeTerms: boolean;
+  acknowledgePrivacy: boolean;
+  shareData: boolean;
+}>;
+
+/**
+ * Submission info for the application state.
+ */
+export type BaseApplicationSubmissionInfoState = ReadonlyDeep<{
+  confirmationCode: string;
+  submittedOn: string; // ISO 8601
+}>;
+
+/**
+ * Email verification state for the application.
+ */
+export type BaseApplicationVerifyEmailState = ReadonlyDeep<{
+  verificationCode: string;
+  verificationAttempts: number;
+}>;
+
+/**
+ * Terms acceptance for submitting the application.
+ */
+export type BaseApplicationSubmitTermsState = ReadonlyDeep<{
+  acknowledgeInfo: boolean;
+  acknowledgeCriteria: boolean;
+}>;
 
 /**
  * Age categories based on the age of the individual.

--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -174,7 +174,7 @@ export type BaseApplicationSubmitTermsState = ReadonlyDeep<{
 /**
  * Age categories based on the age of the individual.
  */
-export type AgeCategory = 'children' | 'youth' | 'adults' | 'seniors';
+type AgeCategory = 'children' | 'youth' | 'adults' | 'seniors';
 
 /**
  * Gets the age category based on the given date string and an optional reference date.

--- a/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
@@ -2,7 +2,7 @@ import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -184,7 +184,7 @@ export function validateProtectedApplicationIntakeChildStateForReview({ params, 
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: ProtectedApplicationChildrenState;
   params: ApplicationStateParams;
 }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
@@ -3,7 +3,7 @@ import { redirect } from 'react-router';
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -196,7 +196,7 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: ProtectedApplicationChildrenState;
   params: ApplicationStateParams;
 }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
@@ -1,5 +1,5 @@
 import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ChildState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import { isValidDateString } from '~/utils/date-utils';
 
@@ -68,7 +68,7 @@ export function isMaritalStatusSectionCompleted(state: Pick<ProtectedApplication
 /**
  * Checks if the child information section is completed for intake application.
  */
-export function isChildInformationSectionCompleted(child: Pick<ChildState, 'information'>): boolean {
+export function isChildInformationSectionCompleted(child: Pick<ProtectedApplicationChildState, 'information'>): boolean {
   // TODO: Check with age category and live independently status
   return (
     child.information !== undefined && //
@@ -81,13 +81,13 @@ export function isChildInformationSectionCompleted(child: Pick<ChildState, 'info
 /**
  * Checks if the child dental insurance section is completed for intake application.
  */
-export function isChildDentalInsuranceSectionCompleted(child: Pick<ChildState, 'dentalInsurance'>): boolean {
+export function isChildDentalInsuranceSectionCompleted(child: Pick<ProtectedApplicationChildState, 'dentalInsurance'>): boolean {
   return child.dentalInsurance !== undefined;
 }
 
 /**
  * Checks if the child dental benefits section is completed for intake application.
  */
-export function isChildDentalBenefitsSectionCompleted(child: Pick<ChildState, 'dentalBenefits'>): boolean {
+export function isChildDentalBenefitsSectionCompleted(child: Pick<ProtectedApplicationChildState, 'dentalBenefits'>): boolean {
   return child.dentalBenefits?.hasChanged === true;
 }

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
@@ -4,7 +4,7 @@ import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -202,7 +202,7 @@ export function validateProtectedApplicationRenewalChildStateForReview({ params,
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: ProtectedApplicationChildrenState;
   state: ProtectedApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
@@ -5,7 +5,7 @@ import { invariant } from '@dts-stn/invariant';
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -219,7 +219,7 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: ProtectedApplicationChildrenState;
   state: ProtectedApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-section-checks.ts
@@ -2,7 +2,7 @@ import type { PickDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { isChildClientNumberValid, isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ChildState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import { isValidDateString } from '~/utils/date-utils';
 
@@ -110,7 +110,7 @@ export function isMaritalStatusSectionCompleted(state: Pick<ProtectedApplication
 /**
  * Checks if the child information section is completed for renewal application.
  */
-export function isChildInformationSectionCompleted(child: Pick<ChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
+export function isChildInformationSectionCompleted(child: Pick<ProtectedApplicationChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
   // TODO: Check with age category and live independently status
   return (
     child.information !== undefined && //
@@ -124,27 +124,27 @@ export function isChildInformationSectionCompleted(child: Pick<ChildState, 'info
 /**
  * Checks if the child parent or legal guardian section is completed for renewal application.
  */
-export function isChildParentGuardianSectionCompleted(child: Pick<ChildState, 'information'>): boolean {
+export function isChildParentGuardianSectionCompleted(child: Pick<ProtectedApplicationChildState, 'information'>): boolean {
   return child.information?.isParent !== undefined;
 }
 
 /**
  * Checks if the child Social Insurance Number section is completed for renewal application.
  */
-export function isChildSinSectionCompleted(child: Pick<ChildState, 'information'>): boolean {
+export function isChildSinSectionCompleted(child: Pick<ProtectedApplicationChildState, 'information'>): boolean {
   return child.information?.socialInsuranceNumber !== undefined;
 }
 
 /**
  * Checks if the child dental insurance section is completed for renewal application.
  */
-export function isChildDentalInsuranceSectionCompleted(child: Pick<ChildState, 'dentalInsurance'>): boolean {
+export function isChildDentalInsuranceSectionCompleted(child: Pick<ProtectedApplicationChildState, 'dentalInsurance'>): boolean {
   return child.dentalInsurance !== undefined;
 }
 
 /**
  * Checks if the child dental benefits section is completed for renewal application.
  */
-export function isChildDentalBenefitsSectionCompleted(child: Pick<ChildState, 'dentalBenefits'>): boolean {
+export function isChildDentalBenefitsSectionCompleted(child: Pick<ProtectedApplicationChildState, 'dentalBenefits'>): boolean {
   return child.dentalBenefits !== undefined;
 }

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -26,8 +26,24 @@ import type {
   SunLifeCommunicationMethodService,
 } from '~/.server/domain/services';
 import { createLogger } from '~/.server/logging';
+import type {
+  BaseApplicationAddressDeclaredChangeState,
+  BaseApplicationApplicantInformationState,
+  BaseApplicationChildState,
+  BaseApplicationCommunicationPreferencesDeclaredChangeState,
+  BaseApplicationContextState,
+  BaseApplicationDentalBenefitsDeclaredChangeState,
+  BaseApplicationDentalInsuranceState,
+  BaseApplicationPartnerInformationState,
+  BaseApplicationPhoneNumberDeclaredChangeState,
+  BaseApplicationSubmissionInfoState,
+  BaseApplicationSubmitTermsState,
+  BaseApplicationTermsAndConditionsState,
+  BaseApplicationTypeOfApplicationState,
+  BaseApplicationVerifyEmailState,
+  BaseApplicationYearState,
+} from '~/.server/routes/helpers/base-application-route-helpers';
 import { getAgeCategoryFromAge, getAgeCategoryReferenceDate } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { DeclaredChange } from '~/.server/routes/helpers/declared-change-type';
 import { getEnv } from '~/.server/utils/env.utils';
 import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
@@ -43,137 +59,45 @@ export type ProtectedApplicationState = ReadonlyDeep<{
    * The unique identifier for the protected application.
    */
   id: string;
-
-  /**
-   * The context of the application, either 'intake' for new applications or 'renewal' for renewal applications.
-   * Immutable and set at the start of the application process based on renewal period status.
-   */
-  context: 'intake' | 'renewal';
-
+  context: BaseApplicationContextState;
   lastUpdatedOn: string;
-  applicantInformation?: {
-    memberId?: string;
-    firstName: string;
-    lastName: string;
-    dateOfBirth: string;
-    socialInsuranceNumber: string;
-  };
-  applicationYear: {
-    applicationYearId: string;
-    taxYear: string;
-    dependentEligibilityEndDate: string;
-  };
-  children: {
-    id: string;
-    dentalBenefits?: DeclaredChange<{
-      hasFederalBenefits: boolean;
-      federalSocialProgram?: string;
-      hasProvincialTerritorialBenefits: boolean;
-      provincialTerritorialSocialProgram?: string;
-      province?: string;
-    }>;
-    dentalInsurance?: {
-      hasDentalInsurance: boolean;
-      dentalInsuranceEligibilityConfirmation?: boolean;
-    };
-    information?: {
-      memberId?: string;
-      firstName: string;
-      lastName: string;
-      dateOfBirth: string;
-      isParent: boolean;
-      hasSocialInsuranceNumber: boolean;
-      socialInsuranceNumber?: string;
-    };
-  }[];
-  communicationPreferences?: DeclaredChange<{
-    preferredLanguage: string;
-    preferredMethod: string;
-    preferredNotificationMethod: string;
-  }>;
+  applicantInformation?: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  children: BaseApplicationChildState[];
+  communicationPreferences?: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
-  verifyEmail?: {
-    verificationCode: string;
-    verificationAttempts: number;
-  };
+  verifyEmail?: BaseApplicationVerifyEmailState;
   emailVerified?: boolean;
   maritalStatus?: string;
-  dentalBenefits?: DeclaredChange<{
-    hasFederalBenefits: boolean;
-    federalSocialProgram?: string;
-    hasProvincialTerritorialBenefits: boolean;
-    provincialTerritorialSocialProgram?: string;
-    province?: string;
-  }>;
-  dentalInsurance?: {
-    hasDentalInsurance: boolean;
-    dentalInsuranceEligibilityConfirmation: boolean;
-  };
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance?: BaseApplicationDentalInsuranceState;
   livingIndependently?: boolean;
-  partnerInformation?: {
-    consentToSharePersonalInformation: true;
-    yearOfBirth: string;
-    socialInsuranceNumber: string;
-  };
+  partnerInformation?: BaseApplicationPartnerInformationState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChange<{
-    address: string;
-    city: string;
-    country: string;
-    postalCode?: string;
-    province?: string;
-  }>;
-  homeAddress?: DeclaredChange<{
-    address: string;
-    city: string;
-    country: string;
-    postalCode?: string;
-    province?: string;
-  }>;
-  phoneNumber?: DeclaredChange<{
-    primary: string;
-    alternate?: string;
-  }>;
-  submitTerms?: {
-    acknowledgeInfo: boolean;
-    acknowledgeCriteria: boolean;
-  };
-  submissionInfo?: {
-    /**
-     * The confirmation code associated with the application submission.
-     */
-    confirmationCode: string;
-
-    /**
-     * The UTC date and time when the application was submitted.
-     * Format: ISO 8601 string (e.g., "YYYY-MM-DDTHH:mm:ss.sssZ")
-     */
-    submittedOn: string;
-  };
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
+  phoneNumber?: BaseApplicationPhoneNumberDeclaredChangeState;
+  submitTerms?: BaseApplicationSubmitTermsState;
+  submissionInfo?: BaseApplicationSubmissionInfoState;
   hasFiledTaxes?: boolean;
-  termsAndConditions?: {
-    acknowledgeTerms: boolean;
-    acknowledgePrivacy: boolean;
-    shareData: boolean;
-  };
-
-  typeOfApplication?: 'adult' | 'children' | 'family' | 'delegate';
+  termsAndConditions?: BaseApplicationTermsAndConditionsState;
+  typeOfApplication?: BaseApplicationTypeOfApplicationState;
   clientApplication?: ClientApplicationRenewalEligibleDto;
   applicantClientIdsToRenew?: string[];
 }>;
 
-export type ApplicantInformationState = NonNullable<ProtectedApplicationState['applicantInformation']>;
-type ApplicationYearState = ProtectedApplicationState['applicationYear'];
-export type ChildrenState = ProtectedApplicationState['children'];
-export type ChildState = ChildrenState[number];
-export type ChildInformationState = NonNullable<ChildState['information']>;
-export type ChildSinState = Pick<NonNullable<ChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
-export type CommunicationPreferencesState = NonNullable<NonNullable<ProtectedApplicationState['communicationPreferences']>['value']>;
-export type DentalFederalBenefitsState = Pick<NonNullable<NonNullable<ProtectedApplicationState['dentalBenefits']>['value']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
-export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<NonNullable<ProtectedApplicationState['dentalBenefits']>['value']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
-export type PartnerInformationState = NonNullable<ProtectedApplicationState['partnerInformation']>;
-export type ContextState = NonNullable<ProtectedApplicationState['context']>;
-export type TypeOfApplicationState = NonNullable<ProtectedApplicationState['typeOfApplication']>;
+export type ProtectedApplicationApplicantInformationState = NonNullable<ProtectedApplicationState['applicantInformation']>;
+export type ProtectedApplicationChildInformationState = NonNullable<ProtectedApplicationChildState['information']>;
+export type ProtectedApplicationChildrenState = ProtectedApplicationState['children'];
+export type ProtectedApplicationChildSinState = Pick<NonNullable<ProtectedApplicationChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
+export type ProtectedApplicationChildState = ProtectedApplicationChildrenState[number];
+export type ProtectedApplicationCommunicationPreferencesState = NonNullable<NonNullable<ProtectedApplicationState['communicationPreferences']>['value']>;
+export type ProtectedApplicationContextState = ProtectedApplicationState['context'];
+export type ProtectedApplicationDentalFederalBenefitsState = Pick<NonNullable<NonNullable<ProtectedApplicationState['dentalBenefits']>['value']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
+export type ProtectedApplicationDentalProvincialTerritorialBenefitsState = Pick<NonNullable<NonNullable<ProtectedApplicationState['dentalBenefits']>['value']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
+export type ProtectedApplicationPartnerInformationState = NonNullable<ProtectedApplicationState['partnerInformation']>;
+export type ProtectedApplicationTypeOfApplicationState = NonNullable<ProtectedApplicationState['typeOfApplication']>;
+
 /**
  * Gets the protected application flow session key.
  * @param id - The protected application flow ID.
@@ -280,7 +204,7 @@ interface StartProtectedApplicationStateArgs {
   /**
    * The application year data used to determine the application year. This is required to initialize the state
    */
-  applicationYear: ApplicationYearState;
+  applicationYear: BaseApplicationYearState;
 
   /**
    * The client application data used to determine the input model for renewal applications. This should be
@@ -345,7 +269,7 @@ export function getContextualAgeCategoryFromDate(date: string, context: 'intake'
   return getAgeCategoryFromAge(age);
 }
 
-export function isNewChildState(child: ChildState) {
+export function isNewChildState(child: ProtectedApplicationChildState) {
   return child.dentalInsurance === undefined || child.information === undefined || child.dentalBenefits === undefined;
 }
 
@@ -370,8 +294,8 @@ export function getChildrenState<TState extends Pick<ProtectedApplicationState, 
  * ```
  */
 type ExtractStateFromApplicationFlow<S extends string> = S extends `${infer I}-${infer T}` //
-  ? I extends ContextState
-    ? T extends TypeOfApplicationState
+  ? I extends ProtectedApplicationContextState
+    ? T extends ProtectedApplicationTypeOfApplicationState
       ? { context: I; typeOfApplication: T }
       : never
     : never
@@ -393,7 +317,7 @@ type ExtractStateFromApplicationFlow<S extends string> = S extends `${infer I}-$
  * validateApplicationFlow(state, params, ['intake-adult', 'renewal-children']);
  * ```
  */
-export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${ContextState}-${TypeOfApplicationState}`>>(
+export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${ProtectedApplicationContextState}-${ProtectedApplicationTypeOfApplicationState}`>>(
   state: ProtectedApplicationState,
   params: Params,
   allowedFlows: TAllowedFlows,
@@ -423,7 +347,7 @@ export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${C
   }
 }
 
-export type ApplicationFlow = 'entry' | `${ContextState}-${TypeOfApplicationState}`;
+export type ApplicationFlow = 'entry' | `${ProtectedApplicationContextState}-${ProtectedApplicationTypeOfApplicationState}`;
 
 /**
  * Determines the initial URL path based on the context and type of application.
@@ -536,7 +460,7 @@ export function isPrimaryApplicantChild(state: ProtectedApplicationState, client
   return state.clientApplication.children.some((child) => child.information.clientId === clientId);
 }
 
-export function getTypeOfApplicationFromRenewalSelectionClientIds(state: ProtectedApplicationState, clientIds: string[]): TypeOfApplicationState {
+export function getTypeOfApplicationFromRenewalSelectionClientIds(state: ProtectedApplicationState, clientIds: string[]): ProtectedApplicationTypeOfApplicationState {
   invariant(state.clientApplication, 'Expected clientApplication to be defined');
   const hasPrimaryApplicant = clientIds.some((id) => isPrimaryApplicant(state, id));
   const hasDependent = clientIds.some((id) => isPrimaryApplicantChild(state, id));

--- a/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
@@ -2,7 +2,7 @@ import { redirect } from 'react-router';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationStateParams, PublicApplicationChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -192,7 +192,7 @@ export function validatePublicApplicationFullChildStateForReview({ params, state
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: PublicApplicationChildrenState;
   state: PublicApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
@@ -3,7 +3,7 @@ import { redirect } from 'react-router';
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationStateParams, PublicApplicationChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -204,7 +204,7 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: PublicApplicationChildrenState;
   state: PublicApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/public-application-full-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-section-checks.ts
@@ -1,6 +1,6 @@
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { isChildClientNumberValid, isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ChildState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationChildState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import { isValidDateString } from '~/utils/date-utils';
 
@@ -79,7 +79,7 @@ export function isMaritalStatusSectionCompleted(state: Pick<PublicApplicationSta
 /**
  * Checks if the child information section is completed for full application.
  */
-export function isChildInformationSectionCompleted(context: 'intake' | 'renewal', child: Pick<ChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
+export function isChildInformationSectionCompleted(context: 'intake' | 'renewal', child: Pick<PublicApplicationChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
   // TODO: Check with age category and live independently status
   return (
     child.information !== undefined && //
@@ -93,13 +93,13 @@ export function isChildInformationSectionCompleted(context: 'intake' | 'renewal'
 /**
  * Checks if the child dental insurance section is completed for full application.
  */
-export function isChildDentalInsuranceSectionCompleted(child: Pick<ChildState, 'dentalInsurance'>): boolean {
+export function isChildDentalInsuranceSectionCompleted(child: Pick<PublicApplicationChildState, 'dentalInsurance'>): boolean {
   return child.dentalInsurance !== undefined;
 }
 
 /**
  * Checks if the child dental benefits section is completed for full application.
  */
-export function isChildDentalBenefitsSectionCompleted(child: Pick<ChildState, 'dentalBenefits'>): boolean {
+export function isChildDentalBenefitsSectionCompleted(child: Pick<PublicApplicationChildState, 'dentalBenefits'>): boolean {
   return child.dentalBenefits?.hasChanged === true;
 }

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -93,20 +93,11 @@ export type PublicApplicationChildInformationState = NonNullable<PublicApplicati
 export type PublicApplicationChildrenState = PublicApplicationState['children'];
 export type PublicApplicationChildSinState = Pick<NonNullable<PublicApplicationChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
 export type PublicApplicationChildState = PublicApplicationChildrenState[number];
-export type PublicApplicationCommunicationPreferencesDeclaredChangeState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>>;
 export type PublicApplicationCommunicationPreferencesState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>['value']>;
-export type PublicApplicationDentalFederalBenefitsDeclaredChangeState = NonNullable<PublicApplicationState['dentalBenefits']>;
 export type PublicApplicationDentalFederalBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
-export type PublicApplicationDentalInsuranceState = NonNullable<PublicApplicationState['dentalInsurance']>;
-export type PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState = NonNullable<PublicApplicationState['dentalBenefits']>;
 export type PublicApplicationDentalProvincialTerritorialBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
-export type PublicApplicationHomeAddressDeclaredChangeState = NonNullable<PublicApplicationState['homeAddress']>;
-export type PublicApplicationMailingAddressDeclaredChangeState = NonNullable<PublicApplicationState['mailingAddress']>;
 export type PublicApplicationPartnerInformationState = NonNullable<PublicApplicationState['partnerInformation']>;
-export type PublicApplicationPhoneNumberDeclaredChangeState = NonNullable<NonNullable<PublicApplicationState['phoneNumber']>>;
-export type PublicApplicationTermsAndConditionsState = NonNullable<PublicApplicationState['termsAndConditions']>;
 export type PublicApplicationTypeOfApplicationState = NonNullable<PublicApplicationState['typeOfApplication']>;
-export type PublicApplicationYearState = PublicApplicationState['applicationYear'];
 
 /**
  * Gets the public application flow session key.
@@ -211,7 +202,7 @@ export function clearPublicApplicationState({ params, session }: ClearStateArgs)
 }
 
 interface StartArgs {
-  applicationYear: PublicApplicationYearState;
+  applicationYear: BaseApplicationYearState;
   session: Session;
 }
 

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -26,8 +26,24 @@ import type {
   SunLifeCommunicationMethodService,
 } from '~/.server/domain/services';
 import { createLogger } from '~/.server/logging';
+import type {
+  BaseApplicationAddressDeclaredChangeState,
+  BaseApplicationApplicantInformationState,
+  BaseApplicationChildState,
+  BaseApplicationCommunicationPreferencesDeclaredChangeState,
+  BaseApplicationContextState,
+  BaseApplicationDentalBenefitsDeclaredChangeState,
+  BaseApplicationDentalInsuranceState,
+  BaseApplicationPartnerInformationState,
+  BaseApplicationPhoneNumberDeclaredChangeState,
+  BaseApplicationSubmissionInfoState,
+  BaseApplicationSubmitTermsState,
+  BaseApplicationTermsAndConditionsState,
+  BaseApplicationTypeOfApplicationState,
+  BaseApplicationVerifyEmailState,
+  BaseApplicationYearState,
+} from '~/.server/routes/helpers/base-application-route-helpers';
 import { getAgeCategoryFromAge, getAgeCategoryReferenceDate } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { DeclaredChange } from '~/.server/routes/helpers/declared-change-type';
 import { getEnv } from '~/.server/utils/env.utils';
 import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
@@ -38,149 +54,59 @@ import { getPathById } from '~/utils/route-utils';
 
 export type PublicApplicationStateSessionKey = `public-application-flow-${string}`;
 
+export type PublicApplicationInputModelState = 'full' | 'simplified';
+
 export type PublicApplicationState = ReadonlyDeep<{
   /**
    * The unique identifier for the public application.
    */
   id: string;
-
-  /**
-   * The context of the application, either 'intake' for new applications or 'renewal' for renewal applications.
-   * Immutable and set at the start of the application process based on renewal period status.
-   */
-  context: 'intake' | 'renewal';
-
+  context: BaseApplicationContextState;
+  inputModel?: PublicApplicationInputModelState;
   lastUpdatedOn: string;
-  applicantInformation?: {
-    memberId?: string;
-    firstName: string;
-    lastName: string;
-    dateOfBirth: string;
-    socialInsuranceNumber: string;
-  };
-  applicationYear: {
-    applicationYearId: string;
-    taxYear: string;
-    dependentEligibilityEndDate: string;
-  };
-  children: {
-    id: string;
-    dentalBenefits?: DeclaredChange<{
-      hasFederalBenefits: boolean;
-      federalSocialProgram?: string;
-      hasProvincialTerritorialBenefits: boolean;
-      provincialTerritorialSocialProgram?: string;
-      province?: string;
-    }>;
-    dentalInsurance?: {
-      hasDentalInsurance: boolean;
-      dentalInsuranceEligibilityConfirmation?: boolean;
-    };
-    information?: {
-      memberId?: string;
-      firstName: string;
-      lastName: string;
-      dateOfBirth: string;
-      isParent: boolean;
-      hasSocialInsuranceNumber: boolean;
-      socialInsuranceNumber?: string;
-    };
-  }[];
-  communicationPreferences?: DeclaredChange<{
-    preferredLanguage: string;
-    preferredMethod: string;
-    preferredNotificationMethod: string;
-  }>;
+  applicantInformation?: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  children: BaseApplicationChildState[];
+  communicationPreferences?: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
-  verifyEmail?: {
-    verificationCode: string;
-    verificationAttempts: number;
-  };
+  verifyEmail?: BaseApplicationVerifyEmailState;
   emailVerified?: boolean;
   maritalStatus?: string;
-  dentalBenefits?: DeclaredChange<{
-    hasFederalBenefits: boolean;
-    federalSocialProgram?: string;
-    hasProvincialTerritorialBenefits: boolean;
-    provincialTerritorialSocialProgram?: string;
-    province?: string;
-  }>;
-  dentalInsurance?: {
-    hasDentalInsurance: boolean;
-    dentalInsuranceEligibilityConfirmation: boolean;
-  };
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance?: BaseApplicationDentalInsuranceState;
   livingIndependently?: boolean;
-  partnerInformation?: {
-    consentToSharePersonalInformation: true;
-    yearOfBirth: string;
-    socialInsuranceNumber: string;
-  };
+  partnerInformation?: BaseApplicationPartnerInformationState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChange<{
-    address: string;
-    city: string;
-    country: string;
-    postalCode?: string;
-    province?: string;
-  }>;
-  homeAddress?: DeclaredChange<{
-    address: string;
-    city: string;
-    country: string;
-    postalCode?: string;
-    province?: string;
-  }>;
-  phoneNumber?: DeclaredChange<{
-    primary: string;
-    alternate?: string;
-  }>;
-  submitTerms?: {
-    acknowledgeInfo: boolean;
-    acknowledgeCriteria: boolean;
-  };
-  submissionInfo?: {
-    /**
-     * The confirmation code associated with the application submission.
-     */
-    confirmationCode: string;
-
-    /**
-     * The UTC date and time when the application was submitted.
-     * Format: ISO 8601 string (e.g., "YYYY-MM-DDTHH:mm:ss.sssZ")
-     */
-    submittedOn: string;
-  };
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
+  phoneNumber?: BaseApplicationPhoneNumberDeclaredChangeState;
+  submitTerms?: BaseApplicationSubmitTermsState;
+  submissionInfo?: BaseApplicationSubmissionInfoState;
   hasFiledTaxes?: boolean;
-  termsAndConditions?: {
-    acknowledgeTerms: boolean;
-    acknowledgePrivacy: boolean;
-    shareData: boolean;
-  };
-  inputModel?: 'full' | 'simplified';
-  typeOfApplication?: 'adult' | 'children' | 'family' | 'delegate';
+  termsAndConditions?: BaseApplicationTermsAndConditionsState;
+  typeOfApplication?: BaseApplicationTypeOfApplicationState;
   clientApplication?: ClientApplicationRenewalEligibleDto;
 }>;
 
-export type ApplicantInformationState = NonNullable<PublicApplicationState['applicantInformation']>;
-export type ApplicationYearState = PublicApplicationState['applicationYear'];
-export type ChildrenState = PublicApplicationState['children'];
-export type ChildState = ChildrenState[number];
-export type ChildInformationState = NonNullable<ChildState['information']>;
-export type ChildSinState = Pick<NonNullable<ChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
-export type DeclaredChangeCommunicationPreferencesState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>>;
-export type CommunicationPreferencesState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>['value']>;
-export type DeclaredChangePhoneNumberState = NonNullable<NonNullable<PublicApplicationState['phoneNumber']>>;
-export type DeclaredChangeDentalFederalBenefitsState = NonNullable<PublicApplicationState['dentalBenefits']>;
-export type DentalFederalBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
-export type DentalInsuranceState = NonNullable<PublicApplicationState['dentalInsurance']>;
-export type DeclaredChangeDentalProvincialTerritorialBenefitsState = NonNullable<PublicApplicationState['dentalBenefits']>;
-export type DentalProvincialTerritorialBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
-export type PartnerInformationState = NonNullable<PublicApplicationState['partnerInformation']>;
-export type TermsAndConditionsState = NonNullable<PublicApplicationState['termsAndConditions']>;
-export type InputModelState = NonNullable<PublicApplicationState['inputModel']>;
-export type TypeOfApplicationState = NonNullable<PublicApplicationState['typeOfApplication']>;
-export type DeclaredChangeHomeAddressState = NonNullable<PublicApplicationState['homeAddress']>;
-export type DeclaredChangeMailingAddressState = NonNullable<PublicApplicationState['mailingAddress']>;
+export type PublicApplicationApplicantInformationState = NonNullable<PublicApplicationState['applicantInformation']>;
+export type PublicApplicationChildInformationState = NonNullable<PublicApplicationChildState['information']>;
+export type PublicApplicationChildrenState = PublicApplicationState['children'];
+export type PublicApplicationChildSinState = Pick<NonNullable<PublicApplicationChildState['information']>, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>;
+export type PublicApplicationChildState = PublicApplicationChildrenState[number];
+export type PublicApplicationCommunicationPreferencesDeclaredChangeState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>>;
+export type PublicApplicationCommunicationPreferencesState = NonNullable<NonNullable<PublicApplicationState['communicationPreferences']>['value']>;
+export type PublicApplicationDentalFederalBenefitsDeclaredChangeState = NonNullable<PublicApplicationState['dentalBenefits']>;
+export type PublicApplicationDentalFederalBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'federalSocialProgram' | 'hasFederalBenefits'>;
+export type PublicApplicationDentalInsuranceState = NonNullable<PublicApplicationState['dentalInsurance']>;
+export type PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState = NonNullable<PublicApplicationState['dentalBenefits']>;
+export type PublicApplicationDentalProvincialTerritorialBenefitsState = Pick<NonNullable<NonNullable<PublicApplicationState['dentalBenefits']>['value']>, 'hasProvincialTerritorialBenefits' | 'province' | 'provincialTerritorialSocialProgram'>;
+export type PublicApplicationHomeAddressDeclaredChangeState = NonNullable<PublicApplicationState['homeAddress']>;
+export type PublicApplicationMailingAddressDeclaredChangeState = NonNullable<PublicApplicationState['mailingAddress']>;
+export type PublicApplicationPartnerInformationState = NonNullable<PublicApplicationState['partnerInformation']>;
+export type PublicApplicationPhoneNumberDeclaredChangeState = NonNullable<NonNullable<PublicApplicationState['phoneNumber']>>;
+export type PublicApplicationTermsAndConditionsState = NonNullable<PublicApplicationState['termsAndConditions']>;
+export type PublicApplicationTypeOfApplicationState = NonNullable<PublicApplicationState['typeOfApplication']>;
+export type PublicApplicationYearState = PublicApplicationState['applicationYear'];
 
 /**
  * Gets the public application flow session key.
@@ -285,7 +211,7 @@ export function clearPublicApplicationState({ params, session }: ClearStateArgs)
 }
 
 interface StartArgs {
-  applicationYear: ApplicationYearState;
+  applicationYear: PublicApplicationYearState;
   session: Session;
 }
 
@@ -327,7 +253,7 @@ export function getContextualAgeCategoryFromDate(date: string, context: 'intake'
   return getAgeCategoryFromAge(age);
 }
 
-export function isNewChildState(child: ChildState) {
+export function isNewChildState(child: PublicApplicationChildState) {
   return child.dentalInsurance === undefined || child.information === undefined || child.dentalBenefits === undefined;
 }
 
@@ -352,8 +278,8 @@ export function getChildrenState<TState extends Pick<PublicApplicationState, 'ch
  * ```
  */
 type ExtractStateFromApplicationFlow<S extends string> = S extends `${infer I}-${infer T}` //
-  ? I extends InputModelState
-    ? T extends TypeOfApplicationState
+  ? I extends PublicApplicationInputModelState
+    ? T extends PublicApplicationTypeOfApplicationState
       ? { inputModel: I; typeOfApplication: T }
       : never
     : never
@@ -375,7 +301,7 @@ type ExtractStateFromApplicationFlow<S extends string> = S extends `${infer I}-$
  * validateApplicationFlow(state, params, ['full-adult', 'simplified-children']);
  * ```
  */
-export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${InputModelState}-${TypeOfApplicationState}`>>(
+export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${PublicApplicationInputModelState}-${PublicApplicationTypeOfApplicationState}`>>(
   state: PublicApplicationState,
   params: Params,
   allowedFlows: TAllowedFlows,
@@ -406,7 +332,7 @@ export function validateApplicationFlow<TAllowedFlows extends ReadonlyArray<`${I
   }
 }
 
-export type ApplicationFlow = 'entry' | `${InputModelState}-${TypeOfApplicationState}`;
+export type ApplicationFlow = 'entry' | `${PublicApplicationInputModelState}-${PublicApplicationTypeOfApplicationState}`;
 
 /**
  * Determines the initial URL path based on the input model and type of application.

--- a/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
@@ -4,7 +4,7 @@ import { invariant } from '@dts-stn/invariant';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationStateParams, PublicApplicationChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
@@ -204,7 +204,7 @@ export function validatePublicApplicationSimplifiedChildStateForReview({ params,
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: PublicApplicationChildrenState;
   state: PublicApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
@@ -5,7 +5,7 @@ import { invariant } from '@dts-stn/invariant';
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { ApplicationStateParams, ChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationStateParams, PublicApplicationChildrenState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
@@ -221,7 +221,7 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
 
 interface ValidateChildrenStateForReviewArgs {
   context: 'intake' | 'renewal';
-  childrenState: ChildrenState;
+  childrenState: PublicApplicationChildrenState;
   state: PublicApplicationState;
   params: ApplicationStateParams;
 }

--- a/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-section-checks.ts
@@ -2,7 +2,7 @@ import type { PickDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { isChildClientNumberValid, isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ChildState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationChildState, PublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
 import { isValidDateString } from '~/utils/date-utils';
 
@@ -106,7 +106,7 @@ export function isDentalBenefitsSectionCompleted(state: PickDeep<PublicApplicati
 /**
  * Checks if the child information section is completed for simplified application.
  */
-export function isChildInformationSectionCompleted(context: 'intake' | 'renewal', child: Pick<ChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
+export function isChildInformationSectionCompleted(context: 'intake' | 'renewal', child: Pick<PublicApplicationChildState, 'information'>, clientApplication?: ClientApplicationRenewalEligibleDto): boolean {
   // TODO: Check with age category and live independently status
   return (
     child.information !== undefined && //
@@ -120,13 +120,13 @@ export function isChildInformationSectionCompleted(context: 'intake' | 'renewal'
 /**
  * Checks if the child dental insurance section is completed for simplified application.
  */
-export function isChildDentalInsuranceSectionCompleted(child: Pick<ChildState, 'dentalInsurance'>): boolean {
+export function isChildDentalInsuranceSectionCompleted(child: Pick<PublicApplicationChildState, 'dentalInsurance'>): boolean {
   return child.dentalInsurance !== undefined;
 }
 
 /**
  * Checks if the child dental benefits section is completed for simplified application.
  */
-export function isChildDentalBenefitsSectionCompleted(child: Pick<ChildState, 'dentalBenefits'>): boolean {
+export function isChildDentalBenefitsSectionCompleted(child: Pick<PublicApplicationChildState, 'dentalBenefits'>): boolean {
   return child.dentalBenefits !== undefined;
 }

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -4,121 +4,121 @@ import validator from 'validator';
 
 import type { ApplicantInformationDto, BenefitApplicationDto, CommunicationPreferencesDto } from '~/.server/domain/dtos';
 import type {
-  ApplicantInformationState,
-  ApplicationYearState,
-  ChildState,
-  DeclaredChangeCommunicationPreferencesState,
-  DeclaredChangeDentalFederalBenefitsState,
-  DeclaredChangeDentalProvincialTerritorialBenefitsState,
-  DeclaredChangeHomeAddressState,
-  DeclaredChangeMailingAddressState,
-  DeclaredChangePhoneNumberState,
-  DentalInsuranceState,
-  PartnerInformationState,
-  TermsAndConditionsState,
+  PublicApplicationApplicantInformationState,
+  PublicApplicationChildState,
+  PublicApplicationCommunicationPreferencesDeclaredChangeState,
+  PublicApplicationDentalFederalBenefitsDeclaredChangeState,
+  PublicApplicationDentalInsuranceState,
+  PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState,
+  PublicApplicationHomeAddressDeclaredChangeState,
+  PublicApplicationMailingAddressDeclaredChangeState,
+  PublicApplicationPartnerInformationState,
+  PublicApplicationPhoneNumberDeclaredChangeState,
+  PublicApplicationTermsAndConditionsState,
+  PublicApplicationYearState,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getContextualAgeCategoryFromDate } from '~/.server/routes/helpers/public-application-route-helpers';
 
 export interface ApplicationAdultState {
   context: 'intake' | 'renewal';
-  applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
-  dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
-  dentalInsurance: DentalInsuranceState;
+  applicantInformation: PublicApplicationApplicantInformationState;
+  applicationYear: PublicApplicationYearState;
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
+  dentalInsurance: PublicApplicationDentalInsuranceState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
-  phoneNumber: DeclaredChangePhoneNumberState;
-  termsAndConditions: TermsAndConditionsState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 export interface ApplicationFamilyState {
   context: 'intake' | 'renewal';
-  applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
-  children: ChildState[];
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
-  dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
-  dentalInsurance: DentalInsuranceState;
+  applicantInformation: PublicApplicationApplicantInformationState;
+  applicationYear: PublicApplicationYearState;
+  children: PublicApplicationChildState[];
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
+  dentalInsurance: PublicApplicationDentalInsuranceState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
-  phoneNumber: DeclaredChangePhoneNumberState;
-  termsAndConditions: TermsAndConditionsState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 export interface ApplicationChildrenState {
   context: 'intake' | 'renewal';
-  applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
-  children: ChildState[];
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
+  applicantInformation: PublicApplicationApplicantInformationState;
+  applicationYear: PublicApplicationYearState;
+  children: PublicApplicationChildState[];
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
-  phoneNumber: DeclaredChangePhoneNumberState;
-  termsAndConditions: TermsAndConditionsState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 interface ToBenefitApplicationDtoArgs {
   context: 'intake' | 'renewal';
-  applicantInformation: ApplicantInformationState;
-  applicationYear: ApplicationYearState;
-  children?: ChildState[];
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
+  applicantInformation: PublicApplicationApplicantInformationState;
+  applicationYear: PublicApplicationYearState;
+  children?: PublicApplicationChildState[];
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
-  dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
-  dentalInsurance?: DentalInsuranceState;
+  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
+  dentalInsurance?: PublicApplicationDentalInsuranceState;
   livingIndependently?: boolean;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
-  phoneNumber: DeclaredChangePhoneNumberState;
-  termsAndConditions: TermsAndConditionsState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
   typeOfApplication: 'adult' | 'adult-child' | 'child';
 }
 
 interface ToApplicantInformationArgs {
-  applicantInformation: ApplicantInformationState;
+  applicantInformation: PublicApplicationApplicantInformationState;
   maritalStatus?: string;
 }
 
 interface ToHomeAddressArgs {
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress: DeclaredChangeMailingAddressState;
+  mailingAddress: PublicApplicationMailingAddressDeclaredChangeState;
 }
 
 interface ToCommunicationPreferencesArgs {
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
 }
 
 interface ToContactInformationArgs {
-  phoneNumber: DeclaredChangePhoneNumberState;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
 }
 
 export interface BenefitApplicationStateMapper {
@@ -212,7 +212,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toChildren(children?: ChildState[]) {
+  private toChildren(children?: PublicApplicationChildState[]) {
     if (!children) return [];
 
     return children.map((child) => {
@@ -268,7 +268,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toDentalBenefits(dentalBenefitsState?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState) {
+  private toDentalBenefits(dentalBenefitsState?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState) {
     if (!dentalBenefitsState) return [];
 
     const dentalBenefits = [];
@@ -305,7 +305,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toMailingAddress(mailingAddress: DeclaredChangeMailingAddressState) {
+  private toMailingAddress(mailingAddress: PublicApplicationMailingAddressDeclaredChangeState) {
     return {
       mailingAddress: mailingAddress.value?.address ?? '',
       mailingApartment: undefined,

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -4,121 +4,119 @@ import validator from 'validator';
 
 import type { ApplicantInformationDto, BenefitApplicationDto, CommunicationPreferencesDto } from '~/.server/domain/dtos';
 import type {
-  PublicApplicationApplicantInformationState,
-  PublicApplicationChildState,
-  PublicApplicationCommunicationPreferencesDeclaredChangeState,
-  PublicApplicationDentalFederalBenefitsDeclaredChangeState,
-  PublicApplicationDentalInsuranceState,
-  PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState,
-  PublicApplicationHomeAddressDeclaredChangeState,
-  PublicApplicationMailingAddressDeclaredChangeState,
-  PublicApplicationPartnerInformationState,
-  PublicApplicationPhoneNumberDeclaredChangeState,
-  PublicApplicationTermsAndConditionsState,
-  PublicApplicationYearState,
-} from '~/.server/routes/helpers/public-application-route-helpers';
+  BaseApplicationAddressDeclaredChangeState,
+  BaseApplicationApplicantInformationState,
+  BaseApplicationChildState,
+  BaseApplicationCommunicationPreferencesDeclaredChangeState,
+  BaseApplicationDentalBenefitsDeclaredChangeState,
+  BaseApplicationDentalInsuranceState,
+  BaseApplicationPartnerInformationState,
+  BaseApplicationPhoneNumberDeclaredChangeState,
+  BaseApplicationTermsAndConditionsState,
+  BaseApplicationYearState,
+} from '~/.server/routes/helpers/base-application-route-helpers';
 import { getContextualAgeCategoryFromDate } from '~/.server/routes/helpers/public-application-route-helpers';
 
 export interface ApplicationAdultState {
   context: 'intake' | 'renewal';
-  applicantInformation: PublicApplicationApplicantInformationState;
-  applicationYear: PublicApplicationYearState;
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
-  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
-  dentalInsurance: PublicApplicationDentalInsuranceState;
+  applicantInformation: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance: BaseApplicationDentalInsuranceState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 export interface ApplicationFamilyState {
   context: 'intake' | 'renewal';
-  applicantInformation: PublicApplicationApplicantInformationState;
-  applicationYear: PublicApplicationYearState;
-  children: PublicApplicationChildState[];
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
-  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
-  dentalInsurance: PublicApplicationDentalInsuranceState;
+  applicantInformation: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  children: BaseApplicationChildState[];
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance: BaseApplicationDentalInsuranceState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 export interface ApplicationChildrenState {
   context: 'intake' | 'renewal';
-  applicantInformation: PublicApplicationApplicantInformationState;
-  applicationYear: PublicApplicationYearState;
-  children: PublicApplicationChildState[];
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  applicantInformation: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  children: BaseApplicationChildState[];
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   livingIndependently?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 interface ToBenefitApplicationDtoArgs {
   context: 'intake' | 'renewal';
-  applicantInformation: PublicApplicationApplicantInformationState;
-  applicationYear: PublicApplicationYearState;
-  children?: PublicApplicationChildState[];
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  applicantInformation: BaseApplicationApplicantInformationState;
+  applicationYear: BaseApplicationYearState;
+  children?: BaseApplicationChildState[];
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
-  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
-  dentalInsurance?: PublicApplicationDentalInsuranceState;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance?: BaseApplicationDentalInsuranceState;
   livingIndependently?: boolean;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
   typeOfApplication: 'adult' | 'adult-child' | 'child';
 }
 
 interface ToApplicantInformationArgs {
-  applicantInformation: PublicApplicationApplicantInformationState;
+  applicantInformation: BaseApplicationApplicantInformationState;
   maritalStatus?: string;
 }
 
 interface ToHomeAddressArgs {
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress: BaseApplicationAddressDeclaredChangeState;
 }
 
 interface ToCommunicationPreferencesArgs {
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
 }
 
 interface ToContactInformationArgs {
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
 }
 
 export interface BenefitApplicationStateMapper {
@@ -212,7 +210,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toChildren(children?: PublicApplicationChildState[]) {
+  private toChildren(children?: BaseApplicationChildState[]) {
     if (!children) return [];
 
     return children.map((child) => {
@@ -268,8 +266,10 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toDentalBenefits(dentalBenefitsState?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState) {
-    if (!dentalBenefitsState) return [];
+  private toDentalBenefits(dentalBenefitsState?: BaseApplicationDentalBenefitsDeclaredChangeState) {
+    if (!dentalBenefitsState) {
+      return [];
+    }
 
     const dentalBenefits = [];
 
@@ -305,7 +305,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toMailingAddress(mailingAddress: PublicApplicationMailingAddressDeclaredChangeState) {
+  private toMailingAddress(mailingAddress: BaseApplicationAddressDeclaredChangeState) {
     return {
       mailingAddress: mailingAddress.value?.address ?? '',
       mailingApartment: undefined,

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -19,70 +19,66 @@ import type {
 } from '~/.server/domain/dtos';
 import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type {
-  PublicApplicationChildState,
-  PublicApplicationCommunicationPreferencesDeclaredChangeState,
-  PublicApplicationDentalFederalBenefitsDeclaredChangeState,
-  PublicApplicationDentalFederalBenefitsState,
-  PublicApplicationDentalInsuranceState,
-  PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState,
-  PublicApplicationDentalProvincialTerritorialBenefitsState,
-  PublicApplicationHomeAddressDeclaredChangeState,
-  PublicApplicationMailingAddressDeclaredChangeState,
-  PublicApplicationPartnerInformationState,
-  PublicApplicationPhoneNumberDeclaredChangeState,
-  PublicApplicationTermsAndConditionsState,
-  PublicApplicationYearState,
-} from '~/.server/routes/helpers/public-application-route-helpers';
+  BaseApplicationAddressDeclaredChangeState,
+  BaseApplicationChildState,
+  BaseApplicationCommunicationPreferencesDeclaredChangeState,
+  BaseApplicationDentalBenefitsDeclaredChangeState,
+  BaseApplicationDentalInsuranceState,
+  BaseApplicationPartnerInformationState,
+  BaseApplicationPhoneNumberDeclaredChangeState,
+  BaseApplicationTermsAndConditionsState,
+  BaseApplicationYearState,
+} from '~/.server/routes/helpers/base-application-route-helpers';
 
 export interface BenefitRenewalAdultState {
-  applicationYear: PublicApplicationYearState;
+  applicationYear: BaseApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
-  dentalInsurance: PublicApplicationDentalInsuranceState;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance: BaseApplicationDentalInsuranceState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  communicationPreferences?: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalFamilyState {
-  applicationYear: PublicApplicationYearState;
-  children: PublicApplicationChildState[];
+  applicationYear: BaseApplicationYearState;
+  children: BaseApplicationChildState[];
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
-  dentalInsurance: PublicApplicationDentalInsuranceState;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  dentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
+  dentalInsurance: BaseApplicationDentalInsuranceState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  communicationPreferences?: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalChildState {
-  applicationYear: PublicApplicationYearState;
+  applicationYear: BaseApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  children: PublicApplicationChildState[];
-  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  children: BaseApplicationChildState[];
+  phoneNumber: BaseApplicationPhoneNumberDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PublicApplicationPartnerInformationState;
+  partnerInformation?: BaseApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
-  termsAndConditions: PublicApplicationTermsAndConditionsState;
+  communicationPreferences?: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: BaseApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalStateMapper {
@@ -98,12 +94,12 @@ interface ToApplicantInformationArgs {
 
 interface ToChildrenArgs {
   existingChildren: readonly ReadonlyDeep<ClientChildDto>[];
-  renewedChildren: PublicApplicationChildState[];
+  renewedChildren: BaseApplicationChildState[];
 }
 
 interface ToCommunicationPreferencesArgs {
   existingCommunicationPreferences: ReadonlyDeep<ClientCommunicationPreferencesDto>;
-  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
 }
@@ -111,35 +107,34 @@ interface ToCommunicationPreferencesArgs {
 interface ToContactInformationArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
   isHomeAddressSameAsMailingAddress: boolean | undefined;
-  renewedContactInformation: PublicApplicationPhoneNumberDeclaredChangeState | undefined;
-  renewedHomeAddress: PublicApplicationHomeAddressDeclaredChangeState | undefined;
-  renewedMailingAddress: PublicApplicationMailingAddressDeclaredChangeState | undefined;
+  renewedContactInformation: BaseApplicationPhoneNumberDeclaredChangeState | undefined;
+  renewedHomeAddress: BaseApplicationAddressDeclaredChangeState | undefined;
+  renewedMailingAddress: BaseApplicationAddressDeclaredChangeState | undefined;
   renewedEmailVerified: boolean | undefined;
   renewedEmail: string | undefined;
 }
 
 interface ToDentalBenefitsArgs {
   existingDentalBenefits?: readonly string[];
-  hasFederalProvincialTerritorialBenefitsChanged: boolean;
-  renewedDentalBenefits?: PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState;
+  renewedDentalBenefits?: BaseApplicationDentalBenefitsDeclaredChangeState;
 }
 
 interface ToHomeAddressArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
-  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
+  homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
 }
 
 interface ToMailingAddressArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
-  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
+  mailingAddress?: BaseApplicationAddressDeclaredChangeState;
 }
 
 interface ToPartnerInformationArgs {
   effectiveMaritalStatus?: string;
   existingPartnerInformation?: ReadonlyDeep<ClientPartnerInformationDto>;
-  renewedPartnerInformation?: PublicApplicationPartnerInformationState;
+  renewedPartnerInformation?: BaseApplicationPartnerInformationState;
 }
 
 interface HasEmailChangedArgs {
@@ -208,8 +203,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: dentalBenefits?.hasChanged === true,
-        renewedDentalBenefits: dentalBenefits?.value,
+        renewedDentalBenefits: dentalBenefits,
       }),
       dentalInsurance,
       partnerInformation: this.toPartnerInformation({
@@ -285,8 +279,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       }),
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
-        hasFederalProvincialTerritorialBenefitsChanged: dentalBenefits?.hasChanged === true,
-        renewedDentalBenefits: dentalBenefits?.value,
+        renewedDentalBenefits: dentalBenefits,
       }),
       dentalInsurance,
       partnerInformation: this.toPartnerInformation({
@@ -414,8 +407,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         clientNumber: existingChild.information.clientNumber,
         dentalBenefits: this.toDentalBenefits({
           existingDentalBenefits: existingChild.dentalBenefits,
-          hasFederalProvincialTerritorialBenefitsChanged: renewedChild.dentalBenefits?.hasChanged === true,
-          renewedDentalBenefits: renewedChild.dentalBenefits?.value,
+          renewedDentalBenefits: renewedChild.dentalBenefits,
         }),
         dentalInsurance: renewedChild.dentalInsurance,
         information: {
@@ -575,22 +567,24 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toDentalBenefits({ existingDentalBenefits, hasFederalProvincialTerritorialBenefitsChanged, renewedDentalBenefits }: ToDentalBenefitsArgs): readonly string[] {
-    if (!hasFederalProvincialTerritorialBenefitsChanged) {
-      invariant(existingDentalBenefits, 'Expected existingDentalBenefits to be defined when hasFederalProvincialTerritorialBenefitsChanged is false');
+  private toDentalBenefits({ existingDentalBenefits, renewedDentalBenefits }: ToDentalBenefitsArgs): readonly string[] {
+    if (!renewedDentalBenefits) {
+      return [];
+    }
+
+    if (!renewedDentalBenefits.hasChanged) {
+      invariant(existingDentalBenefits, 'Expected existingDentalBenefits to be defined when renewedDentalBenefits.hasChanged is false');
       return existingDentalBenefits;
     }
 
-    if (!renewedDentalBenefits) return [];
-
     const dentalBenefits = [];
 
-    if (renewedDentalBenefits.hasFederalBenefits && renewedDentalBenefits.federalSocialProgram && !validator.isEmpty(renewedDentalBenefits.federalSocialProgram)) {
-      dentalBenefits.push(renewedDentalBenefits.federalSocialProgram);
+    if (renewedDentalBenefits.value.hasFederalBenefits && renewedDentalBenefits.value.federalSocialProgram && !validator.isEmpty(renewedDentalBenefits.value.federalSocialProgram)) {
+      dentalBenefits.push(renewedDentalBenefits.value.federalSocialProgram);
     }
 
-    if (renewedDentalBenefits.hasProvincialTerritorialBenefits && renewedDentalBenefits.provincialTerritorialSocialProgram && !validator.isEmpty(renewedDentalBenefits.provincialTerritorialSocialProgram)) {
-      dentalBenefits.push(renewedDentalBenefits.provincialTerritorialSocialProgram);
+    if (renewedDentalBenefits.value.hasProvincialTerritorialBenefits && renewedDentalBenefits.value.provincialTerritorialSocialProgram && !validator.isEmpty(renewedDentalBenefits.value.provincialTerritorialSocialProgram)) {
+      dentalBenefits.push(renewedDentalBenefits.value.provincialTerritorialSocialProgram);
     }
 
     return dentalBenefits;

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -19,70 +19,70 @@ import type {
 } from '~/.server/domain/dtos';
 import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type {
-  ApplicationYearState,
-  ChildState,
-  DeclaredChangeCommunicationPreferencesState,
-  DeclaredChangeDentalFederalBenefitsState,
-  DeclaredChangeDentalProvincialTerritorialBenefitsState,
-  DeclaredChangeHomeAddressState,
-  DeclaredChangeMailingAddressState,
-  DeclaredChangePhoneNumberState,
-  DentalFederalBenefitsState,
-  DentalInsuranceState,
-  DentalProvincialTerritorialBenefitsState,
-  PartnerInformationState,
-  TermsAndConditionsState,
+  PublicApplicationChildState,
+  PublicApplicationCommunicationPreferencesDeclaredChangeState,
+  PublicApplicationDentalFederalBenefitsDeclaredChangeState,
+  PublicApplicationDentalFederalBenefitsState,
+  PublicApplicationDentalInsuranceState,
+  PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState,
+  PublicApplicationDentalProvincialTerritorialBenefitsState,
+  PublicApplicationHomeAddressDeclaredChangeState,
+  PublicApplicationMailingAddressDeclaredChangeState,
+  PublicApplicationPartnerInformationState,
+  PublicApplicationPhoneNumberDeclaredChangeState,
+  PublicApplicationTermsAndConditionsState,
+  PublicApplicationYearState,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 
 export interface BenefitRenewalAdultState {
-  applicationYear: ApplicationYearState;
+  applicationYear: PublicApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  phoneNumber: DeclaredChangePhoneNumberState;
-  dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
-  dentalInsurance: DentalInsuranceState;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
+  dentalInsurance: PublicApplicationDentalInsuranceState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: DeclaredChangeCommunicationPreferencesState;
-  termsAndConditions: TermsAndConditionsState;
+  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalFamilyState {
-  applicationYear: ApplicationYearState;
-  children: ChildState[];
+  applicationYear: PublicApplicationYearState;
+  children: PublicApplicationChildState[];
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  phoneNumber: DeclaredChangePhoneNumberState;
-  dentalBenefits?: DeclaredChangeDentalFederalBenefitsState & DeclaredChangeDentalProvincialTerritorialBenefitsState;
-  dentalInsurance: DentalInsuranceState;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  dentalBenefits?: PublicApplicationDentalFederalBenefitsDeclaredChangeState & PublicApplicationDentalProvincialTerritorialBenefitsDeclaredChangeState;
+  dentalInsurance: PublicApplicationDentalInsuranceState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: DeclaredChangeCommunicationPreferencesState;
-  termsAndConditions: TermsAndConditionsState;
+  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalChildState {
-  applicationYear: ApplicationYearState;
+  applicationYear: PublicApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
-  children: ChildState[];
-  phoneNumber: DeclaredChangePhoneNumberState;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  children: PublicApplicationChildState[];
+  phoneNumber: PublicApplicationPhoneNumberDeclaredChangeState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
   maritalStatus?: string;
-  partnerInformation?: PartnerInformationState;
+  partnerInformation?: PublicApplicationPartnerInformationState;
   email?: string;
   emailVerified?: boolean;
-  communicationPreferences?: DeclaredChangeCommunicationPreferencesState;
-  termsAndConditions: TermsAndConditionsState;
+  communicationPreferences?: PublicApplicationCommunicationPreferencesDeclaredChangeState;
+  termsAndConditions: PublicApplicationTermsAndConditionsState;
 }
 
 export interface BenefitRenewalStateMapper {
@@ -98,12 +98,12 @@ interface ToApplicantInformationArgs {
 
 interface ToChildrenArgs {
   existingChildren: readonly ReadonlyDeep<ClientChildDto>[];
-  renewedChildren: ChildState[];
+  renewedChildren: PublicApplicationChildState[];
 }
 
 interface ToCommunicationPreferencesArgs {
   existingCommunicationPreferences: ReadonlyDeep<ClientCommunicationPreferencesDto>;
-  communicationPreferences: DeclaredChangeCommunicationPreferencesState;
+  communicationPreferences: PublicApplicationCommunicationPreferencesDeclaredChangeState;
   email?: string;
   emailVerified?: boolean;
 }
@@ -111,9 +111,9 @@ interface ToCommunicationPreferencesArgs {
 interface ToContactInformationArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
   isHomeAddressSameAsMailingAddress: boolean | undefined;
-  renewedContactInformation: DeclaredChangePhoneNumberState | undefined;
-  renewedHomeAddress: DeclaredChangeHomeAddressState | undefined;
-  renewedMailingAddress: DeclaredChangeMailingAddressState | undefined;
+  renewedContactInformation: PublicApplicationPhoneNumberDeclaredChangeState | undefined;
+  renewedHomeAddress: PublicApplicationHomeAddressDeclaredChangeState | undefined;
+  renewedMailingAddress: PublicApplicationMailingAddressDeclaredChangeState | undefined;
   renewedEmailVerified: boolean | undefined;
   renewedEmail: string | undefined;
 }
@@ -121,25 +121,25 @@ interface ToContactInformationArgs {
 interface ToDentalBenefitsArgs {
   existingDentalBenefits?: readonly string[];
   hasFederalProvincialTerritorialBenefitsChanged: boolean;
-  renewedDentalBenefits?: DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState;
+  renewedDentalBenefits?: PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState;
 }
 
 interface ToHomeAddressArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
-  homeAddress?: DeclaredChangeHomeAddressState;
+  homeAddress?: PublicApplicationHomeAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
 }
 
 interface ToMailingAddressArgs {
   existingContactInformation: ReadonlyDeep<ClientContactInformationDto>;
-  mailingAddress?: DeclaredChangeMailingAddressState;
+  mailingAddress?: PublicApplicationMailingAddressDeclaredChangeState;
 }
 
 interface ToPartnerInformationArgs {
   effectiveMaritalStatus?: string;
   existingPartnerInformation?: ReadonlyDeep<ClientPartnerInformationDto>;
-  renewedPartnerInformation?: PartnerInformationState;
+  renewedPartnerInformation?: PublicApplicationPartnerInformationState;
 }
 
 interface HasEmailChangedArgs {

--- a/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
@@ -13,7 +13,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalAdultState } from '~/.server/routes/helpers/protected-application-renewal-adult-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
@@ -58,7 +58,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const federalGovernmentInsurancePlans = await federalGovernmentInsurancePlanService.listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provincialGovernmentInsurancePlans = await provincialGovernmentInsurancePlanService.listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState>(
+  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<ProtectedApplicationDentalFederalBenefitsState & ProtectedApplicationDentalProvincialTerritorialBenefitsState>(
     (benefits, planId) => {
       const federalProgram = federalGovernmentInsurancePlans.find(({ id }) => id === planId);
       if (federalProgram) {
@@ -80,7 +80,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
       return benefits;
     },
-    {} as DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState,
+    {} as ProtectedApplicationDentalFederalBenefitsState & ProtectedApplicationDentalProvincialTerritorialBenefitsState,
   );
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram ? federalGovernmentInsurancePlans.find(({ id }) => id === state.dentalBenefits?.value?.federalSocialProgram) : undefined;

--- a/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
@@ -13,7 +13,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalFamilyState } from '~/.server/routes/helpers/protected-application-renewal-family-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
@@ -58,7 +58,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const federalGovernmentInsurancePlans = await federalGovernmentInsurancePlanService.listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provincialGovernmentInsurancePlans = await provincialGovernmentInsurancePlanService.listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState>(
+  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<ProtectedApplicationDentalFederalBenefitsState & ProtectedApplicationDentalProvincialTerritorialBenefitsState>(
     (benefits, planId) => {
       const federalProgram = federalGovernmentInsurancePlans.find(({ id }) => id === planId);
       if (federalProgram) {
@@ -80,7 +80,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
       return benefits;
     },
-    {} as DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState,
+    {} as ProtectedApplicationDentalFederalBenefitsState & ProtectedApplicationDentalProvincialTerritorialBenefitsState,
   );
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram ? federalGovernmentInsurancePlans.find(({ id }) => id === state.dentalBenefits?.value?.federalSocialProgram) : undefined;

--- a/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/child-federal-provincial-territorial-benefi
 
 import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -115,7 +115,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+    }) satisfies z.ZodType<ProtectedApplicationDentalFederalBenefitsState>;
 
   const provincialTerritorialBenefitsSchema = z
     .object({
@@ -139,7 +139,7 @@ export async function action({ context: { appContainer, session }, params, reque
         province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
         provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+    }) satisfies z.ZodType<ProtectedApplicationDentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
     hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,

--- a/frontend/app/routes/protected/application/spokes/child-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-information.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/child-information';
 
 import { TYPES } from '~/.server/constants';
 import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ChildInformationState, ChildSinState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildInformationState, ProtectedApplicationChildSinState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -155,7 +155,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
       };
-    }) satisfies z.ZodType<OmitStrict<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
+    }) satisfies z.ZodType<OmitStrict<ProtectedApplicationChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
 
   const childSinSchema = z
     .object({
@@ -178,7 +178,7 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: 'custom', message: t('protected-application-spokes:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'] });
         }
       }
-    }) satisfies z.ZodType<ChildSinState>;
+    }) satisfies z.ZodType<ProtectedApplicationChildSinState>;
 
   const parsedDataResult = childInformationSchema.safeParse({
     firstName: String(formData.get('firstName') ?? ''),

--- a/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import type { Route } from './+types/child-social-insurance-number';
 
 import { TYPES } from '~/.server/constants';
-import type { ChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -122,7 +122,7 @@ export async function action({ context: { appContainer, session }, params, reque
           information: {
             ...child.information,
             socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
-          } as ChildInformationState,
+          } as ProtectedApplicationChildInformationState,
         };
       }),
     },

--- a/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/communication-preferences';
 
 import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { ApplicationFlow, CommunicationPreferencesState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationFlow, ProtectedApplicationCommunicationPreferencesState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -103,7 +103,7 @@ export async function action({ context: { appContainer, session }, params, reque
     preferredLanguage: z.string().trim().min(1, t('protected-application-spokes:communication-preferences.error-message.preferred-language-required')),
     preferredMethod: z.string().trim().min(1, t('protected-application-spokes:communication-preferences.error-message.preferred-method-required')),
     preferredNotificationMethod: z.string().trim().min(1, t('protected-application-spokes:communication-preferences.error-message.preferred-notification-method-required')),
-  }) satisfies z.ZodType<CommunicationPreferencesState>;
+  }) satisfies z.ZodType<ProtectedApplicationCommunicationPreferencesState>;
 
   const parsedDataResult = communicationPreferencesSchema.safeParse({
     preferredLanguage: String(formData.get('preferredLanguage') ?? ''),

--- a/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -103,7 +103,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+    }) satisfies z.ZodType<ProtectedApplicationDentalFederalBenefitsState>;
 
   const provincialTerritorialBenefitsSchema = z
     .object({
@@ -127,7 +127,7 @@ export async function action({ context: { appContainer, session }, params, reque
         province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
         provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+    }) satisfies z.ZodType<ProtectedApplicationDentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
     hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationFlow, PartnerInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ApplicationFlow, ProtectedApplicationPartnerInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -122,7 +122,7 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: 'custom', message: t('protected-application-spokes:marital-status.error-message.sin-unique') });
         }
       }),
-  }) satisfies z.ZodType<PartnerInformationState>;
+  }) satisfies z.ZodType<ProtectedApplicationPartnerInformationState>;
 
   const maritalStatusData = {
     maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,

--- a/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
@@ -7,7 +7,7 @@ import type { Route } from './+types/parent-guardian';
 
 import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { ChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -93,7 +93,7 @@ export async function action({ context: { appContainer, session }, params, reque
           information: {
             ...child.information,
             isParent: parsedDataResult.data.isParent,
-          } as ChildInformationState,
+          } as ProtectedApplicationChildInformationState,
         };
       }),
     },

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -6,7 +6,7 @@ import { z } from 'zod';
 import type { Route } from './+types/personal-information';
 
 import { TYPES } from '~/.server/constants';
-import type { ApplicantInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationApplicantInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getProtectedApplicationState, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -125,7 +125,7 @@ export async function action({ context: { appContainer, session }, params, reque
       // At this point the year, month and day should have been validated as positive integer
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       return { ...val, dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}` };
-    }) satisfies z.ZodType<ApplicantInformationState>;
+    }) satisfies z.ZodType<ProtectedApplicationApplicantInformationState>;
 
   const parsedDataResult = applicantInformationSchema.safeParse({
     socialInsuranceNumber: String(formData.get('socialInsuranceNumber') ?? ''),

--- a/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
+++ b/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
@@ -14,7 +14,7 @@ import {
   saveProtectedApplicationState,
   validateProtectedApplicationContext,
 } from '~/.server/routes/helpers/protected-application-route-helpers';
-import type { ChildInformationState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
+import type { ProtectedApplicationChildInformationState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -169,7 +169,7 @@ function getChildren(state: ProtectedApplicationState, selectedClientIds: string
         firstName: child.information.firstName,
         lastName: child.information.lastName,
         dateOfBirth: child.information.dateOfBirth,
-      } as ChildInformationState,
+      } as ProtectedApplicationChildInformationState,
     };
   });
 }

--- a/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
@@ -11,7 +11,7 @@ import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const federalGovernmentInsurancePlans = await federalGovernmentInsurancePlanService.listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provincialGovernmentInsurancePlans = await provincialGovernmentInsurancePlanService.listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState>(
+  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState>(
     (benefits, planId) => {
       const federalProgram = federalGovernmentInsurancePlans.find(({ id }) => id === planId);
       if (federalProgram) {
@@ -77,7 +77,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
       return benefits;
     },
-    {} as DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState,
+    {} as PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState,
   );
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram ? federalGovernmentInsurancePlans.find(({ id }) => id === state.dentalBenefits?.value?.federalSocialProgram) : undefined;

--- a/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
@@ -11,7 +11,7 @@ import type { Route } from './+types/dental-insurance';
 
 import { TYPES } from '~/.server/constants';
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const federalGovernmentInsurancePlans = await federalGovernmentInsurancePlanService.listAndSortLocalizedFederalGovernmentInsurancePlans(locale);
   const provincialGovernmentInsurancePlans = await provincialGovernmentInsurancePlanService.listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
-  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState>(
+  const clientDentalBenefits = state.clientApplication.dentalBenefits?.reduce<PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState>(
     (benefits, planId) => {
       const federalProgram = federalGovernmentInsurancePlans.find(({ id }) => id === planId);
       if (federalProgram) {
@@ -77,7 +77,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
       return benefits;
     },
-    {} as DentalFederalBenefitsState & DentalProvincialTerritorialBenefitsState,
+    {} as PublicApplicationDentalFederalBenefitsState & PublicApplicationDentalProvincialTerritorialBenefitsState,
   );
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram ? federalGovernmentInsurancePlans.find(({ id }) => id === state.dentalBenefits?.value?.federalSocialProgram) : undefined;

--- a/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import type { Route } from './+types/child-federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getPublicApplicationState, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -111,7 +111,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+    }) satisfies z.ZodType<PublicApplicationDentalFederalBenefitsState>;
 
   const provincialTerritorialBenefitsSchema = z
     .object({
@@ -135,7 +135,7 @@ export async function action({ context: { appContainer, session }, params, reque
         province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
         provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+    }) satisfies z.ZodType<PublicApplicationDentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
     hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,

--- a/frontend/app/routes/public/application/spokes/child-information.tsx
+++ b/frontend/app/routes/public/application/spokes/child-information.tsx
@@ -12,7 +12,7 @@ import type { Route } from './+types/child-information';
 import { TYPES } from '~/.server/constants';
 import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getPublicApplicationState, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { ChildInformationState, ChildSinState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationChildInformationState, PublicApplicationChildSinState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -171,7 +171,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}`,
       };
-    }) satisfies z.ZodType<OmitStrict<ChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
+    }) satisfies z.ZodType<OmitStrict<PublicApplicationChildInformationState, 'hasSocialInsuranceNumber' | 'socialInsuranceNumber'>>;
 
   const childSinSchema = z
     .object({
@@ -194,7 +194,7 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: 'custom', message: t('application-spokes:children.information.error-message.sin-unique'), path: ['socialInsuranceNumber'] });
         }
       }
-    }) satisfies z.ZodType<ChildSinState>;
+    }) satisfies z.ZodType<PublicApplicationChildSinState>;
 
   const parsedDataResult = childInformationSchema.safeParse({
     memberId: formData.get('memberId')?.toString(),

--- a/frontend/app/routes/public/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/public/application/spokes/communication-preferences.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/communication-preferences';
 
 import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
-import type { ApplicationFlow, CommunicationPreferencesState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationFlow, PublicApplicationCommunicationPreferencesState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -98,7 +98,7 @@ export async function action({ context: { appContainer, session }, params, reque
     preferredLanguage: z.string().trim().min(1, t('application-spokes:communication-preferences.error-message.preferred-language-required')),
     preferredMethod: z.string().trim().min(1, t('application-spokes:communication-preferences.error-message.preferred-method-required')),
     preferredNotificationMethod: z.string().trim().min(1, t('application-spokes:communication-preferences.error-message.preferred-notification-method-required')),
-  }) satisfies z.ZodType<CommunicationPreferencesState>;
+  }) satisfies z.ZodType<PublicApplicationCommunicationPreferencesState>;
 
   const parsedDataResult = communicationPreferencesSchema.safeParse({
     preferredLanguage: String(formData.get('preferredLanguage') ?? ''),

--- a/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -9,7 +9,7 @@ import { z } from 'zod';
 import type { Route } from './+types/federal-provincial-territorial-benefits';
 
 import { TYPES } from '~/.server/constants';
-import type { DentalFederalBenefitsState, DentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -99,7 +99,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ...val,
         federalSocialProgram: val.hasFederalBenefits ? val.federalSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalFederalBenefitsState>;
+    }) satisfies z.ZodType<PublicApplicationDentalFederalBenefitsState>;
 
   const provincialTerritorialBenefitsSchema = z
     .object({
@@ -123,7 +123,7 @@ export async function action({ context: { appContainer, session }, params, reque
         province: val.hasProvincialTerritorialBenefits ? val.province : undefined,
         provincialTerritorialSocialProgram: val.hasProvincialTerritorialBenefits ? val.provincialTerritorialSocialProgram : undefined,
       };
-    }) satisfies z.ZodType<DentalProvincialTerritorialBenefitsState>;
+    }) satisfies z.ZodType<PublicApplicationDentalProvincialTerritorialBenefitsState>;
 
   const dentalBenefits = {
     hasFederalBenefits: formData.get('hasFederalBenefits') ? formData.get('hasFederalBenefits') === HAS_FEDERAL_BENEFITS_OPTION.yes : undefined,

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -10,7 +10,7 @@ import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
 import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
-import type { ApplicationFlow, PartnerInformationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { ApplicationFlow, PublicApplicationPartnerInformationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -115,7 +115,7 @@ export async function action({ context: { appContainer, session }, params, reque
           ctx.addIssue({ code: 'custom', message: t('application-spokes:marital-status.error-message.sin-unique') });
         }
       }),
-  }) satisfies z.ZodType<PartnerInformationState>;
+  }) satisfies z.ZodType<PublicApplicationPartnerInformationState>;
 
   const maritalStatusData = {
     maritalStatus: formData.get('maritalStatus') ? String(formData.get('maritalStatus')) : undefined,

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -9,7 +9,7 @@ import type { Route } from './+types/personal-information';
 
 import { TYPES } from '~/.server/constants';
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
-import type { ApplicantInformationState, InputModelState } from '~/.server/routes/helpers/public-application-route-helpers';
+import type { PublicApplicationApplicantInformationState, PublicApplicationInputModelState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -129,7 +129,7 @@ export async function action({ context: { appContainer, session }, params, reque
       // At this point the year, month and day should have been validated as positive integer
       const dateOfBirthParts = extractDateParts(`${val.dateOfBirthYear}-${val.dateOfBirthMonth}-${val.dateOfBirthDay}`);
       return { ...val, dateOfBirth: `${dateOfBirthParts.year}-${dateOfBirthParts.month}-${dateOfBirthParts.day}` };
-    }) satisfies z.ZodType<ApplicantInformationState>;
+    }) satisfies z.ZodType<PublicApplicationApplicantInformationState>;
 
   const parsedDataResult = applicantInformationSchema.safeParse({
     memberId: formData.get('memberId')?.toString(),
@@ -147,7 +147,7 @@ export async function action({ context: { appContainer, session }, params, reque
   }
 
   // Determine input model based on context and data. 'intake' applications always use 'full' model
-  let inputModel: InputModelState = 'full';
+  let inputModel: PublicApplicationInputModelState = 'full';
   let clientApplication: ClientApplicationRenewalEligibleDto | undefined;
 
   // For renewal applications, use the provided member ID, first name, last name, date of birth and SIN to check if the


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request introduces a set of foundational, strongly-typed state definitions for application data in `base-application-route-helpers.ts` and updates all relevant helpers to use these new types. The changes improve type safety and maintainability by replacing loosely-typed or duplicated child and children state types with new, shared base types throughout the protected application route helpers and section checks.

**Type System Improvements**

* Added comprehensive, immutable base state types for all major application data fields in `base-application-route-helpers.ts`, including applicant, child, address, communication preferences, dental benefits, and more. These types use `ReadonlyDeep` for immutability and are well-documented for clarity.
* Exported new base types and imported them into `protected-application-route-helpers.ts` for use in downstream helpers.

**Refactoring of Child and Children State Types**

* Replaced all usages of legacy `ChildState` and `ChildrenState` types in protected application intake and renewal route helpers and section checks with the new `ProtectedApplicationChildState` and `ProtectedApplicationChildrenState` types, which are based on the new base types. [[1]](diffhunk://#diff-ff1770c74467fb76b2954de585388f45d4f5e16ead89cba83bf12a6bb22fba83L5-R5) [[2]](diffhunk://#diff-ff1770c74467fb76b2954de585388f45d4f5e16ead89cba83bf12a6bb22fba83L187-R187) [[3]](diffhunk://#diff-8f683d28b7f1b9c4c9c0f66233398a8c7d29ad99d1f624f71bf201dc7acc253fL6-R6) [[4]](diffhunk://#diff-8f683d28b7f1b9c4c9c0f66233398a8c7d29ad99d1f624f71bf201dc7acc253fL199-R199) [[5]](diffhunk://#diff-3482be4a7fbc1ac55eae42d3873521f272bac9af34c8fff769c903f655a43970L2-R2) [[6]](diffhunk://#diff-3482be4a7fbc1ac55eae42d3873521f272bac9af34c8fff769c903f655a43970L71-R71) [[7]](diffhunk://#diff-3482be4a7fbc1ac55eae42d3873521f272bac9af34c8fff769c903f655a43970L84-R91) [[8]](diffhunk://#diff-b30fd1daa4bf5fd1566f9455a09b86a8767cee43937f2a78e45c21c40c9f5f1eL7-R7) [[9]](diffhunk://#diff-b30fd1daa4bf5fd1566f9455a09b86a8767cee43937f2a78e45c21c40c9f5f1eL205-R205) [[10]](diffhunk://#diff-882915c495ddd48ae815f658d68cabd95f944d2843bb9cdd62d1651cbc0ddaeeL8-R8) [[11]](diffhunk://#diff-882915c495ddd48ae815f658d68cabd95f944d2843bb9cdd62d1651cbc0ddaeeL222-R222) [[12]](diffhunk://#diff-c86d429f88423306632d126ee01265e18f9b747252073356f18ac3a239b154a6L5-R5) [[13]](diffhunk://#diff-c86d429f88423306632d126ee01265e18f9b747252073356f18ac3a239b154a6L113-R113) [[14]](diffhunk://#diff-c86d429f88423306632d126ee01265e18f9b747252073356f18ac3a239b154a6L127-R148)

**Section Check Function Updates**

* Updated all section check helper functions to use the new, strongly-typed `ProtectedApplicationChildState` for their child argument types, ensuring consistent type safety and reducing the risk of runtime errors. [[1]](diffhunk://#diff-3482be4a7fbc1ac55eae42d3873521f272bac9af34c8fff769c903f655a43970L71-R71) [[2]](diffhunk://#diff-3482be4a7fbc1ac55eae42d3873521f272bac9af34c8fff769c903f655a43970L84-R91) [[3]](diffhunk://#diff-c86d429f88423306632d126ee01265e18f9b747252073356f18ac3a239b154a6L113-R113) [[4]](diffhunk://#diff-c86d429f88423306632d126ee01265e18f9b747252073356f18ac3a239b154a6L127-R148)

These changes lay the groundwork for more robust and maintainable application state management across the codebase.