### PR TITLE
feat(frontend): Add new or returning member hub to the protected space

### DIFF
--- a/frontend/app/.server/locales/en/protected-application.json
+++ b/frontend/app/.server/locales/en/protected-application.json
@@ -100,7 +100,9 @@
     "add-type-application": "Add type of application",
     "edit-type-application": "Edit type of application",
     "add-personal-information": "Add personal information",
-    "edit-personal-information": "Edit personal information"
+    "edit-personal-information": "Edit personal information",
+    "new-or-returning-heading": "New or returning member",
+    "new-or-returning-description": "Select whether or not you have a Member ID."
   },
   "renewal-submitted": {
     "page-title": "Renewal application submitted",

--- a/frontend/app/.server/locales/fr/protected-application.json
+++ b/frontend/app/.server/locales/fr/protected-application.json
@@ -100,7 +100,9 @@
     "add-type-application": "Ajouter le type de demande",
     "edit-type-application": "Modifier le type de demande",
     "add-personal-information": "Ajouter des renseignements personnels",
-    "edit-personal-information": "Modifier des renseignements personnels"
+    "edit-personal-information": "Modifier des renseignements personnels",
+    "new-or-returning-heading": "Nouvelle inscription ou membre actuel",
+    "new-or-returning-description": "Indiquez si vous possédez déjà un numéro d'identification de membre."
   },
   "renewal-submitted": {
     "page-title": "Demande de renouvellement déjà soumise",

--- a/frontend/app/.server/routes/helpers/protected-application-entry-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-entry-section-checks.ts
@@ -33,8 +33,8 @@ export function isPersonalInformationSectionCompleted(state: Pick<ProtectedAppli
 /**
  * Checks if the new or returning member section is completed.
  */
-export function isNewOrReturningMemberSectionCompleted(state: Pick<ProtectedApplicationState, 'newOrReturningMember'>): boolean {
-  return state.newOrReturningMember?.isNewOrReturningMember !== undefined;
+export function isNewOrReturningMemberSectionCompleted(state: Pick<ProtectedApplicationState, 'context' | 'applicantInformation' | 'livingIndependently' | 'newOrReturningMember'>): boolean {
+  return state.context === 'intake' && isPersonalInformationSectionCompleted(state) && state.newOrReturningMember?.isNewOrReturningMember !== undefined;
 }
 
 /**

--- a/frontend/app/.server/routes/helpers/protected-application-entry-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-entry-section-checks.ts
@@ -31,6 +31,13 @@ export function isPersonalInformationSectionCompleted(state: Pick<ProtectedAppli
 }
 
 /**
+ * Checks if the new or returning member section is completed.
+ */
+export function isNewOrReturningMemberSectionCompleted(state: Pick<ProtectedApplicationState, 'newOrReturningMember'>): boolean {
+  return state.newOrReturningMember?.isNewOrReturningMember !== undefined;
+}
+
+/**
  * Checks if the terms and conditions section is completed.
  */
 export function isTermsAndConditionsSectionCompleted(state: Pick<ProtectedApplicationState, 'termsAndConditions'>): boolean {

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -48,7 +48,7 @@ import { getEnv } from '~/.server/utils/env.utils';
 import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
 import type { Session } from '~/.server/web/session';
-import { getAgeFromDateString } from '~/utils/date-utils';
+import { getAgeFromDateString, parseDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
 import { getPathById } from '~/utils/route-utils';
 
@@ -527,7 +527,7 @@ export function isNewOrReturningMember(state: PickDeep<ProtectedApplicationState
   if (state.context !== 'intake') return false;
   if (state.applicantInformation?.dateOfBirth === undefined) return false;
 
-  const yearOfBirth = Number(state.applicantInformation.dateOfBirth.slice(0, 4));
+  const yearOfBirth = parseDateString(state.applicantInformation.dateOfBirth).getFullYear();
   return yearOfBirth >= 2007;
 }
 

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -515,6 +515,27 @@ export function shouldSkipMaritalStatus(state: PickDeep<ProtectedApplicationStat
 }
 
 /**
+ * Determines whether the new or returning member section is available.
+ *
+ * The section is available only for intake applications after personal information is completed,
+ * and when the applicant birth year is 2007 or later.
+ *
+ * @param state - The protected application state containing the applicant date of birth and living independently answer.
+ * @returns `true` when the section is available; otherwise, `false`.
+ */
+export function isNewOrReturningMember(state: PickDeep<ProtectedApplicationState, 'context' | 'applicantInformation.dateOfBirth'>): boolean {
+  if (state.context !== 'intake') return false;
+  if (state.applicantInformation?.dateOfBirth === undefined) return false;
+
+  const yearOfBirth = Number(state.applicantInformation.dateOfBirth.slice(0, 4));
+  return yearOfBirth >= 2007;
+}
+
+export function shouldSkipNewOrReturningMember(state: PickDeep<ProtectedApplicationState, 'context' | 'applicantInformation.dateOfBirth' | 'livingIndependently'>): boolean {
+  return !isNewOrReturningMember(state);
+}
+
+/**
  * Resolves the effective communication preferences value for a renewal application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -169,7 +169,7 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
         </CardFooter>
       </Card>
 
-      {isNewOrReturningMember && (
+      {defaultState.context === 'intake' && isNewOrReturningMember && (
         <Card>
           <CardHeader>
             <CardTitle>{t('protected-application:your-application.new-or-returning-heading')}</CardTitle>

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -54,8 +54,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const nextRouteId = getInitialApplicationFlowUrl(applicationFlow, params);
 
   const ageCategory = state.applicantInformation?.dateOfBirth ? getContextualAgeCategoryFromDate(state.applicantInformation.dateOfBirth, state.context) : undefined;
-  const showNewOrReturningMemberSection = isNewOrReturningMember(state);
   const shouldSkipNewOrReturningMemberStep = shouldSkipNewOrReturningMember(state);
+  const showNewOrReturningMemberSection = !shouldSkipNewOrReturningMemberStep && isNewOrReturningMember(state);
 
   return {
     defaultState: {

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -173,10 +173,12 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
         <Card>
           <CardHeader>
             <CardTitle>{t('protected-application:your-application.new-or-returning-heading')}</CardTitle>
-            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+            <CardAction>{sections.newOrReturningMember.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           {/* TODO: Need to confirm the value to be displayed for new or returning member*/}
-          <CardContent>{defaultState.newOrReturningMember === undefined ? <p>{t('protected-application:your-application.new-or-returning-description')}</p> : <p>{defaultState.newOrReturningMember.isNewOrReturningMember}</p>}</CardContent>
+          <CardContent>
+            {defaultState.newOrReturningMember?.isNewOrReturningMember === undefined ? <p>{t('protected-application:your-application.new-or-returning-description')}</p> : <p>{defaultState.newOrReturningMember.isNewOrReturningMember}</p>}
+          </CardContent>
           <CardFooter className="border-t bg-zinc-100">
             <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
               {defaultState.newOrReturningMember === undefined ? t('protected-application:your-application.add-answer') : t('protected-application:your-application.edit-answer')}

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -1,5 +1,4 @@
 import { faCirclePlus, faPenToSquare } from '@fortawesome/free-solid-svg-icons';
-import { format, parseISO } from 'date-fns';
 import { useTranslation } from 'react-i18next';
 
 import type { Route } from './+types/your-application';
@@ -7,8 +6,15 @@ import type { Route } from './+types/your-application';
 import { TYPES } from '~/.server/constants';
 import { isNewOrReturningMemberSectionCompleted, isPersonalInformationSectionCompleted, isTypeOfApplicationSectionCompleted } from '~/.server/routes/helpers/protected-application-entry-section-checks';
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getFixedT } from '~/.server/utils/locale.utils';
+import {
+  getContextualAgeCategoryFromDate,
+  getInitialApplicationFlowUrl,
+  getProtectedApplicationState,
+  isNewOrReturningMember,
+  shouldSkipNewOrReturningMember,
+  validateProtectedApplicationContext,
+} from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -17,6 +23,7 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber } from '~/utils/application-code-utils';
+import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -47,6 +54,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const nextRouteId = getInitialApplicationFlowUrl(applicationFlow, params);
 
   const ageCategory = state.applicantInformation?.dateOfBirth ? getContextualAgeCategoryFromDate(state.applicantInformation.dateOfBirth, state.context) : undefined;
+  const showNewOrReturningMemberSection = isNewOrReturningMember(state);
+  const shouldSkipNewOrReturningMemberStep = shouldSkipNewOrReturningMember(state);
 
   return {
     defaultState: {
@@ -57,17 +66,19 @@ export async function loader({ context: { appContainer, session }, request, para
       newOrReturningMember: state.newOrReturningMember,
     },
     nextRouteId,
+    showNewOrReturningMemberSection,
     sections: {
       typeOfApplication: { completed: isTypeOfApplicationSectionCompleted(state) },
       personalInformation: { completed: isPersonalInformationSectionCompleted(state) },
-      newOrReturningMember: { completed: isNewOrReturningMemberSectionCompleted(state) },
+      ...(shouldSkipNewOrReturningMemberStep ? {} : { newOrReturningMember: { completed: isNewOrReturningMemberSectionCompleted(state) } }),
     },
     meta,
+    locale: getLocale(request),
   };
 }
 
 export default function TypeOfApplication({ loaderData, params }: Route.ComponentProps) {
-  const { defaultState, nextRouteId, sections } = loaderData;
+  const { defaultState, nextRouteId, sections, showNewOrReturningMemberSection, locale } = loaderData;
   const { t } = useTranslation(handle.i18nNamespaces);
 
   function getTypeOfApplication(typeOfApplication: string) {
@@ -87,11 +98,8 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
     }
   }
 
-  const formattedDate = defaultState.personalInformation ? format(parseISO(defaultState.personalInformation.dateOfBirth), 'MMMM d, yyyy') : undefined;
-
-  const yearOfBirth = defaultState.personalInformation ? parseISO(defaultState.personalInformation.dateOfBirth).getFullYear() : undefined;
-
-  const isNewOrReturningMember = yearOfBirth !== undefined && yearOfBirth >= 2007;
+  const parsedDateOfBirth = defaultState.personalInformation ? parseDateString(defaultState.personalInformation.dateOfBirth) : undefined;
+  const formattedDateOfBirth = parsedDateOfBirth ? toLocaleDateString(parsedDateOfBirth, locale) : undefined;
 
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
@@ -143,7 +151,7 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
             <DefinitionList layout="single-column">
               {defaultState.personalInformation.memberId && <DefinitionListItem term={t('protected-application:your-application.member-id')}>{formatClientNumber(defaultState.personalInformation.memberId)}</DefinitionListItem>}
               <DefinitionListItem term={t('protected-application:your-application.full-name')}>{`${defaultState.personalInformation.firstName} ${defaultState.personalInformation.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t('protected-application:your-application.date-of-birth')}>{formattedDate}</DefinitionListItem>
+              <DefinitionListItem term={t('protected-application:your-application.date-of-birth')}>{formattedDateOfBirth}</DefinitionListItem>
               <DefinitionListItem term={t('protected-application:your-application.sin')}>{formatSin(defaultState.personalInformation.socialInsuranceNumber)}</DefinitionListItem>
               {defaultState.livingIndependently !== undefined && (
                 <DefinitionListItem term={t('protected-application:your-application.living-independently')}>
@@ -169,11 +177,11 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
         </CardFooter>
       </Card>
 
-      {isNewOrReturningMember && (
+      {showNewOrReturningMemberSection && (
         <Card>
           <CardHeader>
             <CardTitle>{t('protected-application:your-application.new-or-returning-heading')}</CardTitle>
-            <CardAction>{sections.newOrReturningMember.completed && <StatusTag status="complete" />}</CardAction>
+            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           {/* TODO: Need to confirm the value to be displayed for new or returning member*/}
           <CardContent>
@@ -188,7 +196,6 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
       )}
 
       <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-        {/* TODO: if newOrReturningMember is undefined, allSectionsCompleted should be not include newOrReturningMember */}
         <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
           {t('protected-application:your-application.application')}
         </NavigationButtonLink>

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next';
 import type { Route } from './+types/your-application';
 
 import { TYPES } from '~/.server/constants';
-import { isPersonalInformationSectionCompleted, isTypeOfApplicationSectionCompleted } from '~/.server/routes/helpers/protected-application-entry-section-checks';
+import { isNewOrReturningMemberSectionCompleted, isPersonalInformationSectionCompleted, isTypeOfApplicationSectionCompleted } from '~/.server/routes/helpers/protected-application-entry-section-checks';
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -54,11 +54,13 @@ export async function loader({ context: { appContainer, session }, request, para
       typeOfApplication: state.typeOfApplication,
       personalInformation: state.applicantInformation,
       livingIndependently: ageCategory === 'youth' ? state.livingIndependently : undefined,
+      newOrReturningMember: state.newOrReturningMember,
     },
     nextRouteId,
     sections: {
       typeOfApplication: { completed: isTypeOfApplicationSectionCompleted(state) },
       personalInformation: { completed: isPersonalInformationSectionCompleted(state) },
+      newOrReturningMember: { completed: isNewOrReturningMemberSectionCompleted(state) },
     },
     meta,
   };
@@ -86,6 +88,10 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
   }
 
   const formattedDate = defaultState.personalInformation ? format(parseISO(defaultState.personalInformation.dateOfBirth), 'MMMM d, yyyy') : undefined;
+
+  const yearOfBirth = defaultState.personalInformation ? parseISO(defaultState.personalInformation.dateOfBirth).getFullYear() : undefined;
+
+  const isNewOrReturningMember = yearOfBirth !== undefined && yearOfBirth >= 2007;
 
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
@@ -162,6 +168,21 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
           </ButtonLink>
         </CardFooter>
       </Card>
+
+      {isNewOrReturningMember && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('protected-application:your-application.new-or-returning-heading')}</CardTitle>
+            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>{defaultState.newOrReturningMember === undefined ? <p>{t('protected-application:your-application.new-or-returning-description')}</p> : <p>{defaultState.newOrReturningMember.isNewOrReturningMember}</p>}</CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
+              {defaultState.newOrReturningMember === undefined ? t('protected-application:your-application.add-answer') : t('protected-application:your-application.edit-answer')}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+      )}
 
       <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
         <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -55,7 +55,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const ageCategory = state.applicantInformation?.dateOfBirth ? getContextualAgeCategoryFromDate(state.applicantInformation.dateOfBirth, state.context) : undefined;
   const shouldSkipNewOrReturningMemberStep = shouldSkipNewOrReturningMember(state);
-  const showNewOrReturningMemberSection = !shouldSkipNewOrReturningMemberStep && isNewOrReturningMember(state);
+  const showNewOrReturningMemberSection = !shouldSkipNewOrReturningMemberStep;
 
   return {
     defaultState: {

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -6,14 +6,7 @@ import type { Route } from './+types/your-application';
 import { TYPES } from '~/.server/constants';
 import { isNewOrReturningMemberSectionCompleted, isPersonalInformationSectionCompleted, isTypeOfApplicationSectionCompleted } from '~/.server/routes/helpers/protected-application-entry-section-checks';
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
-import {
-  getContextualAgeCategoryFromDate,
-  getInitialApplicationFlowUrl,
-  getProtectedApplicationState,
-  isNewOrReturningMember,
-  shouldSkipNewOrReturningMember,
-  validateProtectedApplicationContext,
-} from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getProtectedApplicationState, shouldSkipNewOrReturningMember, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -169,12 +169,13 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
         </CardFooter>
       </Card>
 
-      {defaultState.context === 'intake' && isNewOrReturningMember && (
+      {isNewOrReturningMember && (
         <Card>
           <CardHeader>
             <CardTitle>{t('protected-application:your-application.new-or-returning-heading')}</CardTitle>
             <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
+          {/* TODO: Need to confirm the value to be displayed for new or returning member*/}
           <CardContent>{defaultState.newOrReturningMember === undefined ? <p>{t('protected-application:your-application.new-or-returning-description')}</p> : <p>{defaultState.newOrReturningMember.isNewOrReturningMember}</p>}</CardContent>
           <CardFooter className="border-t bg-zinc-100">
             <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
@@ -185,6 +186,7 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
       )}
 
       <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+        {/* TODO: if newOrReturningMember is undefined, allSectionsCompleted should be not include newOrReturningMember */}
         <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
           {t('protected-application:your-application.application')}
         </NavigationButtonLink>

--- a/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
@@ -1,0 +1,1 @@
+export default function NewOrReturningMember() {}

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -7,7 +7,7 @@ import type { Route } from './+types/personal-information';
 
 import { TYPES } from '~/.server/constants';
 import type { ProtectedApplicationApplicantInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getContextualAgeCategoryFromDate, getProtectedApplicationState, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getProtectedApplicationState, isNewOrReturningMember, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { ButtonLink } from '~/components/buttons';
@@ -141,18 +141,24 @@ export async function action({ context: { appContainer, session }, params, reque
     return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
   }
 
-  const ageCategory = getContextualAgeCategoryFromDate(parsedDataResult.data.dateOfBirth, state.context);
+  const applicantInformation = {
+    firstName: parsedDataResult.data.firstName,
+    lastName: parsedDataResult.data.lastName,
+    dateOfBirth: parsedDataResult.data.dateOfBirth,
+    socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
+  };
+  const ageCategory = getContextualAgeCategoryFromDate(applicantInformation.dateOfBirth, state.context);
+  const showNewOrReturningMember = isNewOrReturningMember({
+    ...state,
+    applicantInformation,
+  });
 
   saveProtectedApplicationState({
     params,
     session,
     state: {
-      applicantInformation: {
-        firstName: parsedDataResult.data.firstName,
-        lastName: parsedDataResult.data.lastName,
-        dateOfBirth: parsedDataResult.data.dateOfBirth,
-        socialInsuranceNumber: parsedDataResult.data.socialInsuranceNumber,
-      },
+      applicantInformation,
+      newOrReturningMember: showNewOrReturningMember ? state.newOrReturningMember : undefined,
     },
   });
 

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -217,6 +217,11 @@ export const routes = [
             file: 'routes/protected/application/spokes/application-delegate.tsx',
             paths: { en: '/:lang/protected/application/:id/application-delegate', fr: '/:lang/protege/demande/:id/delegue-demande' },
           },
+          {
+            id: 'protected/application/$id/new-or-returning-member',
+            file: 'routes/protected/application/spokes/new-or-returning-member.tsx',
+            paths: { en: '/:lang/protected/application/:id/new-or-returning-member', fr: '/:lang/protege/demande/:id/new-or-returning-member' },
+          },
           { id: 'protected/application/$id/file-taxes', file: 'routes/protected/application/spokes/file-taxes.tsx', paths: { en: '/:lang/protected/application/:id/file-taxes', fr: '/:lang/protege/demande/:id/produire-declaration-revenus' } },
           { id: 'protected/application/$id/marital-status', file: 'routes/protected/application/spokes/marital-status.tsx', paths: { en: '/:lang/protected/application/:id/marital-status', fr: '/:lang/protege/demande/:id/etat-civil' } },
           { id: 'protected/application/$id/dental-insurance', file: 'routes/protected/application/spokes/dental-insurance.tsx', paths: { en: '/:lang/protected/application/:id/dental-insurance', fr: '/:lang/protege/demande/:id/assurance-dentaire' } },


### PR DESCRIPTION
### Description
Add `new or returning member` hub to /your-application route in the protected space,
The hub will show outside of renewal period and if the date of birth is greater than or equal to 2007


### Related Azure Boards Work Items
[AB#8661](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8661)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->