### PR TITLE
chore(gitops): update frontend image version to 7.2.1 in production deployment

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.2.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.2.1
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
## Description

### Changes

- Bump prod frontend image from `7.2.0` to `7.2.1`

### ⚠️ NOTE

> **This PR is planned to be merged on April 28, 2026, at 7:00 a.m. (EST).**
>
> ⚠️ **DO NOT merge this PR before that date/time.** ⚠️
>
> “There are only two hard things in Computer Science: cache invalidation, naming things, and off-by-one errors.” — Phil Karlton