### PR TITLE
feat(frontend): Add new or returning member route to online application

### DIFF
--- a/frontend/app/.server/locales/en/application-spokes.json
+++ b/frontend/app/.server/locales/en/application-spokes.json
@@ -550,7 +550,7 @@
     "save-btn": "Save",
     "back-btn": "Back",
     "error-message": {
-      "is-new-or-existing-member-required": "Select whether you have ever been enrolled in the Canadian Dental Care Plan",
+      "is-new-or-existing-member-required": "Select whether you are currently, or have ever been, enrolled in the Canadian Dental Care Plan",
       "member-id-required": "Enter 11-digit Member ID",
       "member-id-valid": "Member ID must be 11 digits"
     }

--- a/frontend/app/.server/locales/en/application-spokes.json
+++ b/frontend/app/.server/locales/en/application-spokes.json
@@ -539,5 +539,20 @@
     "back-btn": "Back",
     "exit-btn": "Exit application",
     "exit-btn-link": "https://www.canada.ca/en/services/benefits/dental/dental-care-plan.html"
+  },
+  "new-or-returning-member": {
+    "page-title": "New or returning member",
+    "previously-enrolled": "Are you currently, or have you ever been enrolled in the Canadian Dental Care Plan?",
+    "yes": "Yes",
+    "no": "No",
+    "member-id": "Canadian Dental Care Plan Member ID",
+    "member-id-description": "You can find your 11-digit Member ID in the upper right corner of the letter from Service Canada or on your Canadian Dental Care Plan member card.",
+    "save-btn": "Save",
+    "back-btn": "Back",
+    "error-message": {
+      "is-new-or-existing-member-required": "Select whether you have ever been enrolled in the Canadian Dental Care Plan",
+      "member-id-required": "Enter 11-digit Member ID",
+      "member-id-valid": "Member ID must be 11 digits"
+    }
   }
 }

--- a/frontend/app/.server/locales/en/application.json
+++ b/frontend/app/.server/locales/en/application.json
@@ -84,6 +84,11 @@
     "edit-type-application": "Edit type of application",
     "add-personal-information": "Add personal information",
     "edit-personal-information": "Edit personal information",
-    "type-application-mismatch": "The type of application you selected doesn't match the information we have on file for you. Please choose another option."
+    "type-application-mismatch": "The type of application you selected doesn't match the information we have on file for you. Please choose another option.",
+    "new-or-returning-heading": "New or returning member",
+    "new-or-returning-description": "Select whether or not you have a Member ID.",
+    "previously-enrolled": "Previously enrolled in Canadian Dental Care Plan",
+    "yes": "Yes",
+    "non": "Non"
   }
 }

--- a/frontend/app/.server/locales/en/protected-application-spokes.json
+++ b/frontend/app/.server/locales/en/protected-application-spokes.json
@@ -564,7 +564,7 @@
     "save-btn": "Save",
     "back-btn": "Back",
     "error-message": {
-      "is-new-or-existing-member-required": "Select whether you have ever been enrolled in the Canadian Dental Care Plan",
+      "is-new-or-existing-member-required": "Select whether you are currently, or have ever been, enrolled in the Canadian Dental Care Plan",
       "member-id-required": "Enter 11-digit Member ID",
       "member-id-valid": "Member ID must be 11 digits"
     }

--- a/frontend/app/.server/locales/fr/application-spokes.json
+++ b/frontend/app/.server/locales/fr/application-spokes.json
@@ -539,5 +539,20 @@
     "back-btn": "Retour",
     "exit-btn": "Quitter la demande",
     "exit-btn-link": "https://www.canada.ca/fr/services/prestations/dentaire/regime-soins-dentaires.html"
+  },
+  "new-or-returning-member": {
+    "page-title": "Nouveau membre ou membre existant",
+    "previously-enrolled": "Êtes-vous actuellement, ou avez-vous déjà été inscrit au Régime canadien de soins dentaires?",
+    "yes": "Oui",
+    "no": "Non",
+    "member-id": "Numéro d'identification du membre du Régime canadien de soins dentaires",
+    "member-id-description": "Vous trouverez votre numéro d'identification du membre à 11 chiffres dans le coin supérieur droit de la lettre de Service Canada ou sur votre carte de membre du Régime canadien de soins dentaires.",
+    "save-btn": "Sauvegarder",
+    "back-btn": "Retour",
+    "error-message": {
+      "is-new-or-existing-member-required": "(FR) Sélectionnez si vous avez déjà été inscrit au Régime canadien de soins dentaires",
+      "member-id-required": "Entrez le numéro d'identification du membre à 11 chiffres",
+      "member-id-valid": "Le numéro d'identification du membre doit comporter 11 chiffres"
+    }
   }
 }

--- a/frontend/app/.server/locales/fr/application-spokes.json
+++ b/frontend/app/.server/locales/fr/application-spokes.json
@@ -550,7 +550,7 @@
     "save-btn": "Sauvegarder",
     "back-btn": "Retour",
     "error-message": {
-      "is-new-or-existing-member-required": "(FR) Sélectionnez si vous avez déjà été inscrit au Régime canadien de soins dentaires",
+      "is-new-or-existing-member-required": "Sélectionnez si vous êtes actuellement, ou vous avez déjà été inscrit au Programme canadien de soins dentaires",
       "member-id-required": "Entrez le numéro d'identification du membre à 11 chiffres",
       "member-id-valid": "Le numéro d'identification du membre doit comporter 11 chiffres"
     }

--- a/frontend/app/.server/locales/fr/application.json
+++ b/frontend/app/.server/locales/fr/application.json
@@ -84,6 +84,11 @@
     "edit-type-application": "Modifier le type de demande",
     "add-personal-information": "Ajouter des renseignements personnels",
     "edit-personal-information": "Modifier des renseignements personnels",
-    "type-application-mismatch": "Le type de demande que vous avez sélectionné ne correspond pas aux renseignements que nous avons dans votre dossier. Veuillez choisir une autre option."
+    "type-application-mismatch": "Le type de demande que vous avez sélectionné ne correspond pas aux renseignements que nous avons dans votre dossier. Veuillez choisir une autre option.",
+    "new-or-returning-heading": "Nouvelle inscription ou membre actuel",
+    "new-or-returning-description": "Indiquez si vous possédez déjà un numéro d'identification de membre.",
+    "previously-enrolled": "Précédemment inscrit au Régime canadien de soins dentaires",
+    "yes": "Oui",
+    "non": "Non"
   }
 }

--- a/frontend/app/.server/locales/fr/protected-application-spokes.json
+++ b/frontend/app/.server/locales/fr/protected-application-spokes.json
@@ -564,7 +564,7 @@
     "save-btn": "Sauvegarder",
     "back-btn": "Retour",
     "error-message": {
-      "is-new-or-existing-member-required": "(FR) Sélectionnez si vous avez déjà été inscrit au Régime canadien de soins dentaires",
+      "is-new-or-existing-member-required": "Sélectionnez si vous êtes actuellement, ou vous avez déjà été inscrit au Programme canadien de soins dentaires",
       "member-id-required": "Entrez le numéro d'identification du membre à 11 chiffres",
       "member-id-valid": "Le numéro d'identification du membre doit comporter 11 chiffres"
     }

--- a/frontend/app/.server/routes/helpers/public-application-entry-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/public-application-entry-section-checks.ts
@@ -87,3 +87,10 @@ export function isTermsAndConditionsSectionCompleted(state: Pick<PublicApplicati
 export function isTaxFilingSectionCompleted(state: Pick<PublicApplicationState, 'hasFiledTaxes'>): boolean {
   return state.hasFiledTaxes === true;
 }
+
+/**
+ * Checks if the new or returning member section is completed.
+ */
+export function isNewOrReturningMemberSectionCompleted(state: Pick<PublicApplicationState, 'context' | 'applicantInformation' | 'livingIndependently' | 'newOrReturningMember'>): boolean {
+  return state.context === 'intake' && isPersonalInformationSectionCompleted(state) && state.newOrReturningMember?.isNewOrReturningMember !== undefined;
+}

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -48,7 +48,7 @@ import { getEnv } from '~/.server/utils/env.utils';
 import { getLocaleFromParams } from '~/.server/utils/locale.utils';
 import { getCdcpWebsiteApplyUrl } from '~/.server/utils/url.utils';
 import type { Session } from '~/.server/web/session';
-import { getAgeFromDateString } from '~/utils/date-utils';
+import { getAgeFromDateString, parseDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
 import { getPathById } from '~/utils/route-utils';
 
@@ -740,4 +740,25 @@ export async function resolveSimplifiedStateChildDentalBenefitsValue(
     federalGovernmentInsurancePlan,
     provincialGovernmentInsurancePlan,
   };
+}
+
+/**
+ * Determines whether the new or returning member section is available.
+ *
+ * The section is available only for intake applications after personal information is completed,
+ * and when the applicant birth year is 2007 or later.
+ *
+ * @param state - The protected application state containing the applicant date of birth and living independently answer.
+ * @returns `true` when the section is available; otherwise, `false`.
+ */
+export function isNewOrReturningMember(state: PickDeep<PublicApplicationState, 'context' | 'applicantInformation.dateOfBirth'>): boolean {
+  if (state.context !== 'intake') return false;
+  if (state.applicantInformation?.dateOfBirth === undefined) return false;
+
+  const yearOfBirth = parseDateString(state.applicantInformation.dateOfBirth).getFullYear();
+  return yearOfBirth >= 2007;
+}
+
+export function shouldSkipNewOrReturningMember(state: PickDeep<PublicApplicationState, 'context' | 'applicantInformation.dateOfBirth' | 'livingIndependently'>): boolean {
+  return !isNewOrReturningMember(state);
 }

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -748,7 +748,7 @@ export async function resolveSimplifiedStateChildDentalBenefitsValue(
  * The section is available only for intake applications after personal information is completed,
  * and when the applicant birth year is 2007 or later.
  *
- * @param state - The protected application state containing the applicant date of birth and living independently answer.
+ * @param state - The public application state containing the applicant date of birth and living independently answer.
  * @returns `true` when the section is available; otherwise, `false`.
  */
 export function isNewOrReturningMember(state: PickDeep<PublicApplicationState, 'context' | 'applicantInformation.dateOfBirth'>): boolean {

--- a/frontend/app/routes/public/application/entry/your-application.tsx
+++ b/frontend/app/routes/public/application/entry/your-application.tsx
@@ -233,7 +233,7 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
+            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="public/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
               {defaultState.newOrReturningMember === undefined ? t('application:your-application.add-answer') : t('application:your-application.edit-answer')}
             </ButtonLink>
           </CardFooter>

--- a/frontend/app/routes/public/application/entry/your-application.tsx
+++ b/frontend/app/routes/public/application/entry/your-application.tsx
@@ -4,11 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import type { Route } from './+types/your-application';
 
-import { isNewOrReturningMemberSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
-import { getTypeOfApplicationSectionCompletionResult, isPersonalInformationSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
-import { shouldSkipNewOrReturningMember } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getTypeOfApplicationSectionCompletionResult, isNewOrReturningMemberSectionCompleted, isPersonalInformationSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
 import type { ApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
-import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getPublicApplicationState, shouldSkipNewOrReturningMember } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';

--- a/frontend/app/routes/public/application/entry/your-application.tsx
+++ b/frontend/app/routes/public/application/entry/your-application.tsx
@@ -4,7 +4,9 @@ import { useTranslation } from 'react-i18next';
 
 import type { Route } from './+types/your-application';
 
+import { isNewOrReturningMemberSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
 import { getTypeOfApplicationSectionCompletionResult, isPersonalInformationSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
+import { shouldSkipNewOrReturningMember } from '~/.server/routes/helpers/public-application-route-helpers';
 import type { ApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
@@ -44,6 +46,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const typeOfApplicationSectionCompletionResult = getTypeOfApplicationSectionCompletionResult(state);
 
   const ageCategory = state.applicantInformation?.dateOfBirth ? getContextualAgeCategoryFromDate(state.applicantInformation.dateOfBirth, state.context) : undefined;
+  const shouldSkipNewOrReturningMemberStep = shouldSkipNewOrReturningMember(state);
+  const showNewOrReturningMemberSection = !shouldSkipNewOrReturningMemberStep;
 
   return {
     defaultState: {
@@ -52,20 +56,23 @@ export async function loader({ context: { appContainer, session }, request, para
       typeOfApplication: state.typeOfApplication,
       personalInformation: state.applicantInformation,
       livingIndependently: ageCategory === 'youth' ? state.livingIndependently : undefined,
+      newOrReturningMember: state.newOrReturningMember,
     },
     isRenewalContext: state.context === 'renewal',
     nextRouteId,
+    showNewOrReturningMemberSection,
     typeOfApplicationSectionCompletionResult,
     sections: {
       typeOfApplication: { completed: typeOfApplicationSectionCompletionResult === 'COMPLETED' },
       personalInformation: { completed: isPersonalInformationSectionCompleted(state) },
+      ...(shouldSkipNewOrReturningMemberStep ? {} : { newOrReturningMember: { completed: isNewOrReturningMemberSectionCompleted(state) } }),
     },
     meta,
   };
 }
 
 export default function TypeOfApplication({ loaderData, params }: Route.ComponentProps) {
-  const { defaultState, isRenewalContext, nextRouteId, sections, typeOfApplicationSectionCompletionResult } = loaderData;
+  const { defaultState, isRenewalContext, nextRouteId, sections, showNewOrReturningMemberSection, typeOfApplicationSectionCompletionResult } = loaderData;
   const { t } = useTranslation(handle.i18nNamespaces);
 
   function getTypeOfApplication(typeOfApplication: string) {
@@ -192,6 +199,46 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
           </CardFooter>
         )}
       </Card>
+
+      {showNewOrReturningMemberSection && (
+        <Card>
+          <CardHeader>
+            <CardTitle>{t('application:your-application.new-or-returning-heading')}</CardTitle>
+            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {defaultState.newOrReturningMember?.isNewOrReturningMember === undefined ? (
+              <p>{t('application:your-application.new-or-returning-description')}</p>
+            ) : (
+              <>
+                {defaultState.newOrReturningMember.isNewOrReturningMember === false ? (
+                  <DefinitionList layout="single-column">
+                    <DefinitionListItem term={t('application:your-application.previously-enrolled')}>
+                      <p>{t('application:your-application.non')}</p>
+                    </DefinitionListItem>
+                  </DefinitionList>
+                ) : (
+                  <DefinitionList layout="single-column">
+                    <DefinitionListItem term={t('application:your-application.previously-enrolled')}>
+                      <p>{t('application:your-application.yes')}</p>
+                      <ul className="list-disc">
+                        <li className="ml-8">{defaultState.newOrReturningMember.memberId}</li>
+                      </ul>
+                    </DefinitionListItem>
+                    <DefinitionListItem term={t('application:your-application.full-name')}>{`${defaultState.personalInformation?.firstName} ${defaultState.personalInformation?.lastName}`}</DefinitionListItem>
+                    <DefinitionListItem term={t('application:your-application.date-of-birth')}>{formattedDate}</DefinitionListItem>
+                  </DefinitionList>
+                )}
+              </>
+            )}
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
+              {defaultState.newOrReturningMember === undefined ? t('application:your-application.add-answer') : t('application:your-application.edit-answer')}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+      )}
 
       <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
         <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Continue click">

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/public-application-full-adult-route-helpers';
-import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -71,7 +71,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryHome = await appContainer.get(TYPES.CountryService).getLocalizedCountryById(state.homeAddress.value.country, locale);
 
   const userInfo = {
-    memberId: state.applicantInformation.memberId,
+    memberId: shouldSkipNewOrReturningMember(state) ? undefined : state.newOrReturningMember?.memberId,
     firstName: state.applicantInformation.firstName,
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.phoneNumber.value.primary,

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/public-application-full-child-route-helpers';
-import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -66,7 +66,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryHome = await appContainer.get(TYPES.CountryService).getLocalizedCountryById(state.homeAddress.value.country, locale);
 
   const userInfo = {
-    memberId: state.applicantInformation.memberId,
+    memberId: shouldSkipNewOrReturningMember(state) ? undefined : state.newOrReturningMember?.memberId,
     firstName: state.applicantInformation.firstName,
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.phoneNumber.value.primary,

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/public-application-full-family-route-helpers';
-import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { Button, ButtonLink } from '~/components/buttons';
@@ -76,7 +76,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const countryHome = await appContainer.get(TYPES.CountryService).getLocalizedCountryById(state.homeAddress.value.country, locale);
 
   const userInfo = {
-    memberId: state.applicantInformation.memberId,
+    memberId: shouldSkipNewOrReturningMember(state) ? undefined : state.newOrReturningMember?.memberId,
     firstName: state.applicantInformation.firstName,
     lastName: state.applicantInformation.lastName,
     phoneNumber: state.phoneNumber.value.primary,

--- a/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
@@ -6,7 +6,7 @@ import { data, redirect, useFetcher } from 'react-router';
 import { invariant } from '@dts-stn/invariant';
 import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
 import { Trans, useTranslation } from 'react-i18next';
-import { z } from 'zod';
+import * as z from 'zod';
 
 import type { Route } from './+types/new-or-returning-member';
 
@@ -42,9 +42,6 @@ export const handle = {
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 
 export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
-  const securityHandler = appContainer.get(TYPES.SecurityHandler);
-  await securityHandler.validateAuthSession({ request, session });
-
   const state = getPublicApplicationState({ params, session });
   const t = await getFixedT(request, handle.i18nNamespaces);
 
@@ -60,7 +57,6 @@ export async function action({ context: { appContainer, session }, params, reque
   const formData = await request.formData();
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
-  await securityHandler.validateAuthSession({ request, session });
   securityHandler.validateCsrfToken({ formData, session });
 
   const t = await getFixedT(request, handle.i18nNamespaces);

--- a/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
@@ -1,0 +1,192 @@
+import { useState } from 'react';
+import type { ChangeEventHandler } from 'react';
+
+import { data, redirect, useFetcher } from 'react-router';
+
+import { invariant } from '@dts-stn/invariant';
+import { faChevronLeft, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { Trans, useTranslation } from 'react-i18next';
+import { z } from 'zod';
+
+import type { Route } from './+types/new-or-returning-member';
+
+import { TYPES } from '~/.server/constants';
+import { getContextualAgeCategoryFromDate, getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getFixedT } from '~/.server/utils/locale.utils';
+import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { ButtonLink } from '~/components/buttons';
+import { CsrfTokenInput } from '~/components/csrf-token-input';
+import { ErrorSummary } from '~/components/error-summary';
+import { ErrorSummaryProvider } from '~/components/error-summary-context';
+import { InputPatternField } from '~/components/input-pattern-field';
+import { InputRadios } from '~/components/input-radios';
+import type { InputRadiosProps } from '~/components/input-radios';
+import { LoadingButton } from '~/components/loading-button';
+import { pageIds } from '~/page-ids';
+import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+import { extractDigits } from '~/utils/string-utils';
+
+const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
+
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('application-spokes', 'application', 'gcweb'),
+  pageIdentifier: pageIds.public.application.spokes.newOrReturningMember,
+  pageTitleI18nKey: 'application-spokes:new-or-returning-member.page-title',
+} as const satisfies RouteHandleData;
+
+export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
+
+export async function loader({ context: { appContainer, session }, params, request }: Route.LoaderArgs) {
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+
+  const state = getPublicApplicationState({ params, session });
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const meta = { title: t('gcweb:meta.title.template', { title: t('application-spokes:new-or-returning-member.page-title') }) };
+
+  invariant(state.applicantInformation?.dateOfBirth, 'Expected applicantInformation.dateOfBirth to be defined');
+  const ageCategory = getContextualAgeCategoryFromDate(state.applicantInformation.dateOfBirth, state.context);
+
+  return { meta, defaultState: state.newOrReturningMember, userAgeCategory: ageCategory };
+}
+
+export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
+  const formData = await request.formData();
+
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  await securityHandler.validateAuthSession({ request, session });
+  securityHandler.validateCsrfToken({ formData, session });
+
+  const t = await getFixedT(request, handle.i18nNamespaces);
+
+  const newOrExistingMemberSchema = z
+    .object({
+      newOrExistingMember: z.enum(NEW_OR_EXISTING_MEMBER_OPTION, {
+        error: t('application-spokes:new-or-returning-member.error-message.is-new-or-existing-member-required'),
+      }),
+      memberId: z
+        .string()
+        .trim()
+        .optional()
+        .transform((code) => (code ? extractDigits(code) : undefined)),
+    })
+
+    .superRefine((val, ctx) => {
+      if (val.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes) {
+        if (!val.memberId) {
+          ctx.addIssue({
+            code: 'custom',
+            message: t('application-spokes:new-or-returning-member.error-message.member-id-required'),
+            path: ['memberId'],
+          });
+        } else if (!isValidClientNumberRenewal(val.memberId)) {
+          ctx.addIssue({
+            code: 'custom',
+            message: t('application-spokes:new-or-returning-member.error-message.member-id-valid'),
+            path: ['memberId'],
+          });
+        }
+      }
+    });
+
+  const parsedDataResult = newOrExistingMemberSchema.safeParse({
+    newOrExistingMember: formData.get('newOrExistingMember'),
+    memberId: formData.get('memberId') ? String(formData.get('memberId') ?? '') : undefined,
+  });
+
+  if (!parsedDataResult.success) {
+    return data({ errors: transformFlattenedError(z.flattenError(parsedDataResult.error)) }, { status: 400 });
+  }
+
+  savePublicApplicationState({
+    params,
+    session,
+    state: {
+      newOrReturningMember: {
+        isNewOrReturningMember: parsedDataResult.data.newOrExistingMember === NEW_OR_EXISTING_MEMBER_OPTION.yes,
+        memberId: parsedDataResult.data.memberId,
+      },
+    },
+  });
+
+  return redirect(getPathById('public/application/$id/your-application', params));
+}
+
+export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Route.ComponentProps) {
+  const { t } = useTranslation(handle.i18nNamespaces);
+  const { defaultState, userAgeCategory } = loaderData;
+
+  const fetcher = useFetcher<typeof action>();
+  const isSubmitting = fetcher.state !== 'idle';
+  const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
+  const [isNewOrReturningMember, setIsNewOrReturningMember] = useState(defaultState?.isNewOrReturningMember);
+
+  const handleNewOrReturningMemberSelection: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setIsNewOrReturningMember(e.target.value === NEW_OR_EXISTING_MEMBER_OPTION.yes);
+  };
+
+  const options: InputRadiosProps['options'] = [
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="application-spokes:new-or-returning-member.yes" components={{ bold: <strong /> }} />,
+      value: NEW_OR_EXISTING_MEMBER_OPTION.yes,
+      defaultChecked: defaultState?.isNewOrReturningMember === true,
+      onChange: handleNewOrReturningMemberSelection,
+    },
+    {
+      children: <Trans ns={handle.i18nNamespaces} i18nKey="application-spokes:new-or-returning-member.no" components={{ bold: <strong /> }} />,
+      value: NEW_OR_EXISTING_MEMBER_OPTION.no,
+      defaultChecked: defaultState?.isNewOrReturningMember === false,
+      onChange: handleNewOrReturningMemberSelection,
+    },
+  ];
+
+  return (
+    <div className="max-w-prose">
+      <p className="mb-4 italic">{t('application:required-label')}</p>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ErrorSummary />
+        <fetcher.Form method="post" noValidate>
+          <CsrfTokenInput />
+          <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t('application-spokes:new-or-returning-member.previously-enrolled')} options={options} errorMessage={errors?.newOrExistingMember} required />
+          {isNewOrReturningMember && (
+            <div className="my-8">
+              <InputPatternField
+                id="member-id"
+                name="memberId"
+                format={renewalCodeInputPatternFormat}
+                label={t('application-spokes:new-or-returning-member.member-id')}
+                inputMode="numeric"
+                defaultValue={defaultState?.memberId ?? ''}
+                errorMessage={errors?.memberId}
+                helpMessagePrimary={t('application-spokes:new-or-returning-member.member-id-description')}
+                required={isNewOrReturningMember}
+              />
+            </div>
+          )}
+          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
+              {t('application-spokes:new-or-returning-member.save-btn')}
+            </LoadingButton>
+            <ButtonLink
+              id="back-button"
+              variant="secondary"
+              routeId={userAgeCategory === 'youth' ? 'public/application/$id/living-independently' : 'public/application/$id/your-application'}
+              params={params}
+              disabled={isSubmitting}
+              startIcon={faChevronLeft}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
+            >
+              {t('application-spokes:new-or-returning-member.back-btn')}
+            </ButtonLink>
+          </div>
+        </fetcher.Form>
+      </ErrorSummaryProvider>
+    </div>
+  );
+}

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -200,6 +200,11 @@ export const routes = [
           { id: 'public/application/$id/marital-status', file: 'routes/public/application/spokes/marital-status.tsx', paths: { en: '/:lang/application/:id/marital-status', fr: '/:lang/demande/:id/etat-civil' } },
           { id: 'public/application/$id/dental-insurance', file: 'routes/public/application/spokes/dental-insurance.tsx', paths: { en: '/:lang/application/:id/dental-insurance', fr: '/:lang/demande/:id/assurance-dentaire' } },
           {
+            id: 'public/application/$id/new-or-returning-member',
+            file: 'routes/public/application/spokes/new-or-returning-member.tsx',
+            paths: { en: '/:lang/public/application/:id/new-or-returning-member', fr: '/:lang/public/demande/:id/membre-nouveau-ou-actuel' },
+          },
+          {
             id: 'public/application/$id/dental-insurance-exit-application',
             file: 'routes/public/application/spokes/dental-insurance-exit-application.tsx',
             paths: { en: '/:lang/application/:id/dental-insurance-exit-application', fr: '/:lang/demande/:id/quitter-demande-assurance-dentaire' },

--- a/frontend/app/routes/public/routes.ts
+++ b/frontend/app/routes/public/routes.ts
@@ -202,7 +202,7 @@ export const routes = [
           {
             id: 'public/application/$id/new-or-returning-member',
             file: 'routes/public/application/spokes/new-or-returning-member.tsx',
-            paths: { en: '/:lang/public/application/:id/new-or-returning-member', fr: '/:lang/public/demande/:id/membre-nouveau-ou-actuel' },
+            paths: { en: '/:lang/application/:id/new-or-returning-member', fr: '/:lang/demande/:id/membre-nouveau-ou-actuel' },
           },
           {
             id: 'public/application/$id/dental-insurance-exit-application',


### PR DESCRIPTION
### Description
Add new or returning member route to online application

- add i18n
- add new or returning member hub to your-application page
- add spoke page 
- update confirmation page for the intake flow 

### Related Azure Boards Work Items
[AB#8661](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8661)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->