### PR TITLE
feat(frontend): add email hub to intake flow

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
@@ -36,6 +36,13 @@ export function isCommunicationPreferencesSectionCompleted(state: Pick<Protected
 }
 
 /**
+ * Checks if the email section is completed for intake application.
+ */
+export function isEmailSectionCompleted(state: Pick<ProtectedApplicationState, 'email' | 'emailVerified'>): boolean {
+  return state.email !== undefined && state.emailVerified === true;
+}
+
+/**
  * Checks if the dental insurance section is completed for intake application.
  */
 export function isDentalInsuranceSectionCompleted(state: Pick<ProtectedApplicationState, 'dentalInsurance'>): boolean {

--- a/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-section-checks.ts
@@ -1,3 +1,5 @@
+import validator from 'validator';
+
 import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ProtectedApplicationChildState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getEnv } from '~/.server/utils/env.utils';
@@ -39,7 +41,7 @@ export function isCommunicationPreferencesSectionCompleted(state: Pick<Protected
  * Checks if the email section is completed for intake application.
  */
 export function isEmailSectionCompleted(state: Pick<ProtectedApplicationState, 'email' | 'emailVerified'>): boolean {
-  return state.email !== undefined && state.emailVerified === true;
+  return state.email !== undefined && validator.isEmail(state.email) && state.emailVerified === true;
 }
 
 /**

--- a/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/contact-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpers/protected-application-intake-adult-route-helpers';
-import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
+import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isEmailSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
@@ -76,6 +76,7 @@ export async function loader({ context: { appContainer, session }, request, para
       phoneNumber: { completed: isPhoneNumberSectionCompleted(state) },
       address: { completed: isAddressSectionCompleted(state) },
       communicationPreferences: { completed: isCommunicationPreferencesSectionCompleted(state) },
+      email: { completed: isEmailSectionCompleted(state) },
     },
     meta,
   };
@@ -211,6 +212,30 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit comms click"
             >
               {sections.communicationPreferences.completed ? t('protected-application-intake-adult:contact-information.edit-communication-preferences') : t('protected-application-intake-adult:contact-information.add-communication-preferences')}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t('protected-application-intake-adult:contact-information.email')}</h2>
+            </CardTitle>
+            <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>{state.email === undefined ? <p>{t('protected-application-intake-adult:contact-information.email-help')}</p> : <p>{state.email}</p>}</CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink
+              id="edit-email-button"
+              variant="link"
+              className="p-0"
+              routeId="protected/application/$id/email"
+              params={params}
+              startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
+              size="lg"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit email click"
+            >
+              {sections.email.completed ? t('protected-application-intake-adult:contact-information.edit-email') : t('protected-application-intake-adult:contact-information.add-email')}
             </ButtonLink>
           </CardFooter>
         </Card>

--- a/frontend/app/routes/protected/application/intake-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-family/contact-information.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/contact-information';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/helpers/protected-application-intake-family-route-helpers';
-import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
+import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isEmailSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
@@ -76,6 +76,7 @@ export async function loader({ context: { appContainer, session }, request, para
       phoneNumber: { completed: isPhoneNumberSectionCompleted(state) },
       address: { completed: isAddressSectionCompleted(state) },
       communicationPreferences: { completed: isCommunicationPreferencesSectionCompleted(state) },
+      email: { completed: isEmailSectionCompleted(state) },
     },
     meta,
   };
@@ -211,6 +212,30 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit comms click"
             >
               {sections.communicationPreferences.completed ? t('protected-application-intake-family:contact-information.edit-communication-preferences') : t('protected-application-intake-family:contact-information.add-communication-preferences')}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t('protected-application-intake-family:contact-information.email')}</h2>
+            </CardTitle>
+            <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>{state.email === undefined ? <p>{t('protected-application-intake-family:contact-information.email-help')}</p> : <p>{state.email}</p>}</CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink
+              id="edit-email-button"
+              variant="link"
+              className="p-0"
+              routeId="protected/application/$id/email"
+              params={params}
+              startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
+              size="lg"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit email click"
+            >
+              {sections.email.completed ? t('protected-application-intake-family:contact-information.edit-email') : t('protected-application-intake-family:contact-information.add-email')}
             </ButtonLink>
           </CardFooter>
         </Card>

--- a/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { data, useFetcher, useNavigate } from 'react-router';
 
@@ -134,7 +134,6 @@ export async function action({ context: { appContainer, session }, params, reque
 export default function ApplicationSpokeCommunicationPreferences({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
   const { defaultState, applicationFlow, sunLifeCommunicationMethods, COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID } = loaderData;
-  const [preferredMethod, setPreferredMethod] = useState(defaultState?.preferredMethod ?? COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID);
 
   const navigate = useNavigate();
   const fetcher = useFetcher<typeof action>();
@@ -168,7 +167,6 @@ export default function ApplicationSpokeCommunicationPreferences({ loaderData, p
 
         getCheckedValue('preferredLanguage', 'preferred-language');
         getCheckedValue('preferredMethod', 'preferred-method-sunlife');
-        getCheckedValue('preferredNotificationMethod', 'preferred-method-government-of-canada');
 
         adobeAnalytics.pushFormSubmitEvent(formName, formValues);
       }
@@ -195,7 +193,6 @@ export default function ApplicationSpokeCommunicationPreferences({ loaderData, p
       value: method.id,
       children,
       defaultChecked: defaultState ? defaultState.preferredMethod === method.id : method.id === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID,
-      onChange: (e) => setPreferredMethod(e.target.value),
       'data-gc-analytics-value': method.code,
     };
   });
@@ -221,8 +218,8 @@ export default function ApplicationSpokeCommunicationPreferences({ loaderData, p
             />
           </div>
           <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Communication preferences click">
-              {preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID ? t('protected-application-spokes:communication-preferences.continue') : t('protected-application-spokes:communication-preferences.save')}
+            <LoadingButton variant="primary" id="save-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Communication preferences click">
+              {t('protected-application-spokes:communication-preferences.save')}
             </LoadingButton>
             <ButtonLink
               id="back-button"

--- a/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
@@ -95,7 +95,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
   const applicationFlow: ApplicationFlow = `${state.context}-${state.typeOfApplication}`;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = appContainer.get(TYPES.ServerConfig);
+  const { COMMUNICATION_METHOD_GC_DIGITAL_ID } = appContainer.get(TYPES.ServerConfig);
 
   // state validation schema
   const communicationPreferencesSchema = z.object({
@@ -126,11 +126,6 @@ export async function action({ context: { appContainer, session }, params, reque
       },
     },
   });
-
-  if (parsedDataResult.data.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID) {
-    const redirectUrl = getPathById('protected/application/$id/email', params);
-    return { success: true, redirectUrl, revalidate: false };
-  }
 
   const redirectUrl = getPathById(getRouteFromApplicationFlow(applicationFlow), params);
   return { success: true, redirectUrl, revalidate: false };

--- a/frontend/app/routes/protected/application/spokes/email.tsx
+++ b/frontend/app/routes/protected/application/spokes/email.tsx
@@ -59,6 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const meta = { title: t('gcweb:meta.title.template', { title: t('protected-application-spokes:email.page-title') }) };
   return {
     defaultState: state.email,
+    applicationFlow: `${state.context}-${state.typeOfApplication}` as const,
     meta,
   };
 }
@@ -132,7 +133,7 @@ export async function action({ context: { appContainer, session }, params, reque
 
 export default function ApplicationEmail({ loaderData, params }: Route.ComponentProps) {
   const { t } = useTranslation(handle.i18nNamespaces);
-  const { defaultState } = loaderData;
+  const { defaultState, applicationFlow } = loaderData;
 
   const fetcher = useFetcher<typeof action>();
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
@@ -170,7 +171,7 @@ export default function ApplicationEmail({ loaderData, params }: Route.Component
             <ButtonLink
               id="back-button"
               variant="secondary"
-              routeId="protected/application/$id/communication-preferences"
+              routeId={getRouteFromApplicationFlow(applicationFlow)}
               params={params}
               disabled={isSubmitting}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Email click"


### PR DESCRIPTION
### Description
Add email hub to the intake flow behind msca.
Email card is added to the contact information page. This card will complete when the email exist and verified. The communication no longer navigates to the email verification flow, the navigation is now on the email card.

Email hub for renewal will be added in another pr.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->