### PR TITLE
feat(frontend): enforce email format and verification state on intake and renewal review

### DIFF
--- a/frontend/app/.server/routes/helpers/protected-application-intake-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-adult-route-helpers.ts
@@ -1,10 +1,11 @@
 import { redirect } from 'react-router';
 
+import validator from 'validator';
+
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -96,8 +97,6 @@ export function validateProtectedApplicationIntakeAdultStateForReview({ params, 
     newOrReturningMember,
   } = state;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
-
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
   }
@@ -156,7 +155,7 @@ export function validateProtectedApplicationIntakeAdultStateForReview({ params, 
     throw redirect(getPathById('protected/application/$id/intake-adult/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/intake-adult/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-child-route-helpers.ts
@@ -1,10 +1,11 @@
 import { redirect } from 'react-router';
 
+import validator from 'validator';
+
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -92,8 +93,6 @@ export function validateProtectedApplicationIntakeChildStateForReview({ params, 
     newOrReturningMember,
   } = state;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
-
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
   }
@@ -154,7 +153,7 @@ export function validateProtectedApplicationIntakeChildStateForReview({ params, 
     throw redirect(getPathById('protected/application/$id/intake-children/parent-or-guardian', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/intake-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-intake-family-route-helpers.ts
@@ -1,10 +1,11 @@
 import { redirect } from 'react-router';
 
+import validator from 'validator';
+
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -94,8 +95,6 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     newOrReturningMember,
   } = state;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
-
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
   }
@@ -154,7 +153,7 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/intake-family/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/intake-family/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-adult-route-helpers.ts
@@ -1,12 +1,12 @@
 import { redirect } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
+import validator from 'validator';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -68,15 +68,15 @@ interface LoadProtectedApplicationRenewalAdultStateForReviewArgs {
  */
 export function loadProtectedApplicationRenewalAdultStateForReview({ params, request, session }: LoadProtectedApplicationRenewalAdultStateForReviewArgs) {
   const state = loadProtectedApplicationRenewalAdultState({ params, request, session });
-  return validateProtectedRenewAdultStateForReview({ params, state });
+  return validateProtectedApplicationRenewalAdultStateForReview({ params, state });
 }
 
-interface ValidateProtectedRenewAdultStateForReviewArgs {
+interface ValidateProtectedApplicationRenewalAdultStateForReviewArgs {
   params: ApplicationStateParams;
   state: ProtectedApplicationRenewalAdultState;
 }
 
-export function validateProtectedRenewAdultStateForReview({ params, state }: ValidateProtectedRenewAdultStateForReviewArgs) {
+export function validateProtectedApplicationRenewalAdultStateForReview({ params, state }: ValidateProtectedApplicationRenewalAdultStateForReviewArgs) {
   const {
     applicantInformation,
     applicationYear,
@@ -102,8 +102,6 @@ export function validateProtectedRenewAdultStateForReview({ params, state }: Val
     typeOfApplication,
     children,
   } = state;
-
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
 
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
@@ -155,15 +153,7 @@ export function validateProtectedRenewAdultStateForReview({ params, state }: Val
     throw redirect(getPathById('protected/application/$id/renewal-adult/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
-    throw redirect(getPathById('protected/application/$id/renewal-adult/contact-information', params));
-  }
-
-  if (
-    communicationPreferences.hasChanged === false &&
-    (clientApplication.communicationPreferences.preferredMethodSunLife === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada === COMMUNICATION_METHOD_GC_DIGITAL_ID) &&
-    !(clientApplication.contactInformation.email && clientApplication.contactInformation.emailVerified)
-  ) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/renewal-adult/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-child-route-helpers.ts
@@ -1,12 +1,12 @@
 import { redirect } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
+import validator from 'validator';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -100,8 +100,6 @@ export function validateProtectedApplicationRenewalChildStateForReview({ params,
     typeOfApplication,
   } = state;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
-
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
   }
@@ -162,15 +160,7 @@ export function validateProtectedApplicationRenewalChildStateForReview({ params,
     throw redirect(getPathById('protected/application/$id/renewal-children/parent-or-guardian', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
-    throw redirect(getPathById('protected/application/$id/renewal-children/parent-or-guardian', params));
-  }
-
-  if (
-    communicationPreferences.hasChanged === false &&
-    (clientApplication.communicationPreferences.preferredMethodSunLife === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada === COMMUNICATION_METHOD_GC_DIGITAL_ID) &&
-    !(clientApplication.contactInformation.email && clientApplication.contactInformation.emailVerified)
-  ) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/renewal-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-renewal-family-route-helpers.ts
@@ -1,12 +1,12 @@
 import { redirect } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
+import validator from 'validator';
 
 import { createLogger } from '~/.server/logging';
 import { getAllowedTypeOfApplication, isChildClientNumberValid, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import { getChildrenState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ApplicationStateParams, ProtectedApplicationChildrenState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getEnv } from '~/.server/utils/env.utils';
 import type { Session } from '~/.server/web/session';
 import { getPathById } from '~/utils/route-utils';
 
@@ -102,8 +102,6 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     typeOfApplication,
   } = state;
 
-  const { COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID, COMMUNICATION_METHOD_GC_DIGITAL_ID } = getEnv();
-
   if (termsAndConditions === undefined) {
     throw redirect(getPathById('protected/application/$id/eligibility-requirements', params));
   }
@@ -162,15 +160,7 @@ export function validateProtectedApplicationFamilyStateForReview({ params, state
     throw redirect(getPathById('protected/application/$id/renewal-family/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
-    throw redirect(getPathById('protected/application/$id/renewal-family/contact-information', params));
-  }
-
-  if (
-    communicationPreferences.hasChanged === false &&
-    (clientApplication.communicationPreferences.preferredMethodSunLife === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada === COMMUNICATION_METHOD_GC_DIGITAL_ID) &&
-    !(clientApplication.contactInformation.email && clientApplication.contactInformation.emailVerified)
-  ) {
+  if (!email || !validator.isEmail(email) || !emailVerified) {
     throw redirect(getPathById('protected/application/$id/renewal-family/contact-information', params));
   }
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors and simplifies the email validation logic across all protected application intake and renewal route helpers. The main improvement is the consistent use of the `validator` library for email validation, replacing previous logic that checked communication preferences and relied on environment variables. This change ensures that users are redirected to the appropriate contact information page if their email is missing, invalid, or unverified, regardless of communication method.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

[AB#8662](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8662)