### PR TITLE
fix(frontend): update application review links to point to the correct route

### DIFF
--- a/frontend/app/routes/protected/application/intake-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/submit.tsx
@@ -128,7 +128,7 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-intake-adult:submit.review-your-application')}</h2>
             <p>{t('protected-application-intake-adult:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/intake-adult/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Action click">
+            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Action click">
               {t('protected-application-intake-adult:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/protected/application/intake-children/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-children/submit.tsx
@@ -138,7 +138,7 @@ export default function ProtectedNewChildrenSubmit({ loaderData, params }: Route
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-intake-child:submit.review-your-application')}</h2>
             <p>{t('protected-application-intake-child:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/intake-children/parent-or-guardian" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Action click">
+            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Action click">
               {t('protected-application-intake-child:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/protected/application/intake-family/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-family/submit.tsx
@@ -140,7 +140,7 @@ export default function ProtectedNewFamilySubmit({ loaderData, params }: Route.C
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-intake-family:submit.review-your-application')}</h2>
             <p>{t('protected-application-intake-family:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/intake-family/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Action click">
+            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Action click">
               {t('protected-application-intake-family:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/protected/application/renewal-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/submit.tsx
@@ -132,15 +132,9 @@ export default function ProtectedNewAdultSubmit({ loaderData, params }: Route.Co
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-renewal-adult:submit.review-your-application')}</h2>
             <p>{t('protected-application-renewal-adult:submit.please-review')}</p>
-            {shouldSkipMaritalStatusStep ? (
-              <ButtonLink variant="primary" routeId="protected/application/$id/renewal-adult/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Action click">
-                {t('protected-application-renewal-adult:submit.review-application')}
-              </ButtonLink>
-            ) : (
-              <ButtonLink variant="primary" routeId="protected/application/$id/renewal-adult/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Action click">
-                {t('protected-application-renewal-adult:submit.review-application')}
-              </ButtonLink>
-            )}
+            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Action click">
+              {t('protected-application-renewal-adult:submit.review-application')}
+            </ButtonLink>
           </section>
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-renewal-adult:submit.submit-your-application')}</h2>

--- a/frontend/app/routes/protected/application/renewal-children/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/submit.tsx
@@ -140,7 +140,7 @@ export default function ProtectedRenewChildrenSubmit({ loaderData, params }: Rou
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-renewal-child:submit.review-your-application')}</h2>
             <p>{t('protected-application-renewal-child:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/renewal-children/parent-or-guardian" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Action click">
+            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Action click">
               {t('protected-application-renewal-child:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/protected/application/renewal-family/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/submit.tsx
@@ -143,15 +143,9 @@ export default function ProtectedRenewalFamilySubmit({ loaderData, params }: Rou
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-renewal-family:submit.review-your-application')}</h2>
             <p>{t('protected-application-renewal-family:submit.please-review')}</p>
-            {shouldSkipMaritalStatusStep ? (
-              <ButtonLink variant="primary" routeId="protected/application/$id/renewal-family/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Action click">
-                {t('protected-application-renewal-family:submit.review-application')}
-              </ButtonLink>
-            ) : (
-              <ButtonLink variant="primary" routeId="protected/application/$id/renewal-family/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Action click">
-                {t('protected-application-renewal-family:submit.review-application')}
-              </ButtonLink>
-            )}
+            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Action click">
+              {t('protected-application-renewal-family:submit.review-application')}
+            </ButtonLink>
           </section>
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('protected-application-renewal-family:submit.submit-your-application')}</h2>

--- a/frontend/app/routes/public/application/full-adult/submit.tsx
+++ b/frontend/app/routes/public/application/full-adult/submit.tsx
@@ -139,7 +139,7 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-full-adult:submit.review-your-application')}</h2>
             <p>{t('application-full-adult:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/full-adult/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Action click">
               {t('application-full-adult:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/public/application/full-children/submit.tsx
+++ b/frontend/app/routes/public/application/full-children/submit.tsx
@@ -148,7 +148,7 @@ export default function NewChildrenSubmit({ loaderData, params }: Route.Componen
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-full-child:submit.review-your-application')}</h2>
             <p>{t('application-full-child:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/full-children/parent-or-guardian" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Action click">
               {t('application-full-child:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/public/application/full-family/submit.tsx
+++ b/frontend/app/routes/public/application/full-family/submit.tsx
@@ -150,7 +150,7 @@ export default function NewFamilySubmit({ loaderData, params }: Route.ComponentP
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-full-family:submit.review-your-application')}</h2>
             <p>{t('application-full-family:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/full-family/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Action click">
               {t('application-full-family:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/public/application/simplified-adult/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/submit.tsx
@@ -126,7 +126,7 @@ export default function RenewAdultSubmit({ loaderData, params }: Route.Component
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-simplified-adult:submit.review-your-application')}</h2>
             <p>{t('application-simplified-adult:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/simplified-adult/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Action click">
               {t('application-simplified-adult:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/public/application/simplified-children/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-children/submit.tsx
@@ -133,7 +133,7 @@ export default function RenewChildrenSubmit({ loaderData, params }: Route.Compon
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-simplified-child:submit.review-your-application')}</h2>
             <p>{t('application-simplified-child:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/simplified-children/parent-or-guardian" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Action click">
               {t('application-simplified-child:submit.review-application')}
             </ButtonLink>
           </section>

--- a/frontend/app/routes/public/application/simplified-family/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-family/submit.tsx
@@ -135,7 +135,7 @@ export default function SimplifiedFamilySubmit({ loaderData, params }: Route.Com
           <section className="space-y-4">
             <h2 className="font-lato text-3xl leading-none font-bold">{t('application-simplified-family:submit.review-your-application')}</h2>
             <p>{t('application-simplified-family:submit.please-review')}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/simplified-family/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Action click">
+            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Action click">
               {t('application-simplified-family:submit.review-application')}
             </ButtonLink>
           </section>


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the "Review your application" button on all submit pages for both public and protected application flows. The button now consistently routes users to the relevant "your-application" or "renew" summary page, instead of various previous steps (like marital status or contact information). This change improves the user experience by streamlining navigation and ensuring users review their entire application before submission.

**Navigation updates for submit pages:**

* All "Review your application" buttons in public application submit pages now route to the `your-application` summary page, replacing previous routes to specific steps like marital status or contact information. (`frontend/app/routes/public/application/full-adult/submit.tsx` [[1]](diffhunk://#diff-9d2d08f597beb102bcabe09d0c49aeadbf3c639716ba6578de6618e9e74c00fbL142-R142) `full-children/submit.tsx` [[2]](diffhunk://#diff-390c99040b03c99e74f471f8a508c30b14f9c4f4482d9638c142f4594f1769c9L151-R151) `full-family/submit.tsx` [[3]](diffhunk://#diff-e1194fe282b728c12ec0927b3c39548af6a8fff3b8a5ecea31b78da9cb0931ceL153-R153) `simplified-adult/submit.tsx` [[4]](diffhunk://#diff-19263f33af7fc421fd5c5bb48f34880a8536cacd6ff1372380bc1ebbc7cc9225L129-R129) `simplified-children/submit.tsx` [[5]](diffhunk://#diff-4d3d47c5111281e444964f07191296cddf0d4e96b0d6def967ccba6f32222b1bL136-R136) `simplified-family/submit.tsx` [[6]](diffhunk://#diff-a92e3fb8f1e9acc71447ecdffb5d53b5accb743dc50873c93eeb356df3e32aa8L138-R138)
* All "Review your application" buttons in protected application intake submit pages now route to the `your-application` summary page, instead of specific steps like marital status or parent/guardian. (`frontend/app/routes/protected/application/intake-adult/submit.tsx` [[1]](diffhunk://#diff-e16fe02d7dc847eb26ce26ca3bba2974d6c8b93dafb1e5440bb082e024e9c15cL131-R131) `intake-children/submit.tsx` [[2]](diffhunk://#diff-91d54f25e390fac8236c525ec1094ef829b7e936d228654740485c1944f7faffL141-R141) `intake-family/submit.tsx` [[3]](diffhunk://#diff-56c1e84f66a9c06aeba31e6c87bcc90045430c70400caba2068dfa4fee6c8fe7L143-R143)
* All "Review your application" buttons in protected renewal submit pages now route to the `renew` summary page, replacing conditional logic and previous routes to marital status or contact information. (`frontend/app/routes/protected/application/renewal-adult/submit.tsx` [[1]](diffhunk://#diff-11de01e4b33aca5ec3d6a80e49d2155413435a90d658c04a61ef4fcf10884535L135-L143) `renewal-children/submit.tsx` [[2]](diffhunk://#diff-f3f51c345a40c7384e0905f26a232d1211f27e00ea5939fdbf219361c91f74ebL143-R143) `renewal-family/submit.tsx` [[3]](diffhunk://#diff-c6d0b9b63bc730d17e076e43767ff3f204e818e1ba7ab0e05eace4c61aec0e12L146-L154)

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

ESDCCM/CDCP => BUG 40969