### PR TITLE
fix(frontend): update application process messages for renewal and intake contexts in English and French locales

### DIFF
--- a/frontend/app/.server/locales/en/application-full-adult.json
+++ b/frontend/app/.server/locales/en/application-full-adult.json
@@ -101,7 +101,10 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": {
+      "renewal": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+      "intake": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps."
+    },
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/en/application-full-child.json
+++ b/frontend/app/.server/locales/en/application-full-child.json
@@ -75,7 +75,10 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": {
+      "renewal": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+      "intake": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps."
+    },
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/en/application-full-family.json
+++ b/frontend/app/.server/locales/en/application-full-family.json
@@ -72,7 +72,10 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": {
+      "renewal": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+      "intake": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps."
+    },
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/en/protected-application-intake-adult.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-adult.json
@@ -119,7 +119,7 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps.",
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/en/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.json
@@ -80,7 +80,7 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps.",
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/en/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.json
@@ -76,7 +76,7 @@
     "print-copy-important": "It's important to keep a copy of your application.",
     "print-btn": "Print or save",
     "whats-next": "You will receive a letter confirming eligibility",
-    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days to let you know if you are eligible for the plan.",
+    "begin-process": "We have received your application. You will be sent a letter within 30 calendar days with more information and any next steps.",
     "proof-of-coverage": "If any of your T4 or T4A documents show you have access to employer or pension sponsored dental insurance or coverage, you may be asked to provide proof that you're not covered.",
     "check-status": "Check the status of your application",
     "cdcp-checker": "You can use the <cdcpLink>Canadian Dental Care Plan Status Checker</cdcpLink> or call <noWrap>1-833-537-4342</noWrap> to track the progress of your application.",

--- a/frontend/app/.server/locales/fr/application-full-adult.json
+++ b/frontend/app/.server/locales/fr/application-full-adult.json
@@ -101,7 +101,10 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": {
+      "renewal": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+      "intake": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin."
+    },
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/.server/locales/fr/application-full-child.json
+++ b/frontend/app/.server/locales/fr/application-full-child.json
@@ -75,7 +75,10 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": {
+      "renewal": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+      "intake": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin."
+    },
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/.server/locales/fr/application-full-family.json
+++ b/frontend/app/.server/locales/fr/application-full-family.json
@@ -72,7 +72,10 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": {
+      "renewal": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+      "intake": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin."
+    },
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/.server/locales/fr/protected-application-intake-adult.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-adult.json
@@ -119,7 +119,7 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin.",
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.json
@@ -81,7 +81,7 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin.",
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.json
@@ -76,7 +76,7 @@
     "print-copy-important": "Il est important de conserver une copie de votre demande.",
     "print-btn": "Imprimer ou sauvegarder",
     "whats-next": "Vous recevrez une lettre confirmant votre admissibilité",
-    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans les 30 jours civils pour vous informer de votre admissibilité au régime.",
+    "begin-process": "Nous avons reçu votre demande. Une lettre vous sera envoyée dans un délai de 30 jours civils avec plus d'informations et les prochaines étapes, au besoin.",
     "proof-of-coverage": "Si l'un de vos feuillets T4 ou T4A indique que vous avez accès à une assurance ou une couverture dentaire offerte par un employeur ou un régime de pension, vous pourriez devoir fournir une preuve que vous n'êtes pas couvert(e).",
     "check-status": "Consulter l'état de votre demande",
     "cdcp-checker": "Vous pouvez consulter le <cdcpLink>Vérificateur de l'état d'une demande du Régime canadien de soins dentaires</cdcpLink> ou composer le <noWrap>1-833-537-4342</noWrap> pour suivre l'état de votre demande.",

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -203,7 +203,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
-        <p className="mt-4">{t('confirm.begin-process')}</p>
+        <p className="mt-4">{t(`confirm.begin-process.${loaderData.context}`)}</p>
         {loaderData.context === 'intake' && <p className="mt-4">{t('confirm.proof-of-coverage')}</p>}
       </section>
 

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -230,7 +230,7 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
-        <p className="mt-4">{t('confirm.begin-process')}</p>
+        <p className="mt-4">{t(`confirm.begin-process.${loaderData.context}`)}</p>
         {loaderData.context === 'intake' && <p className="mt-4">{t('confirm.proof-of-coverage')}</p>}
       </section>
 

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -245,7 +245,7 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
 
       <section>
         <h2 className="font-lato text-3xl font-bold">{t('confirm.whats-next')}</h2>
-        <p className="mt-4">{t('confirm.begin-process')}</p>
+        <p className="mt-4">{t(`confirm.begin-process.${loaderData.context}`)}</p>
         {loaderData.context === 'intake' && <p className="mt-4">{t('confirm.proof-of-coverage')}</p>}
       </section>
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the confirmation messaging logic for application flows to provide more context-specific information to users, depending on whether their application is an "intake" or a "renewal." The changes include updates to translation files in both English and French, as well as adjustments to the React components to select the appropriate message based on application context.

**Localization updates:**

* Updated the `begin-process` translation key in both English and French JSON files for full adult, child, and family applications to use separate messages for "renewal" and "intake" contexts, providing more specific information to users. [[1]](diffhunk://#diff-8a76b70e230037f210612835ca1702a63afa97e256f422f5ab70563ab29883cdL104-R107) [[2]](diffhunk://#diff-92ad598dccd330073b251089ba74efdcea45476666ca5758f9745ad48c0a82e5L78-R81) [[3]](diffhunk://#diff-6c15aab7ee8a7241fc144f06128186ba4c30e006e24507fe7feda2fe89f6ee52L75-R78) [[4]](diffhunk://#diff-5c75e850147c428c588d2120ba11ee9044a209c7c00f66bfe40442d339b0f061L104-R107) [[5]](diffhunk://#diff-cca42e7d149918aee8cf90e43154a3daaf532b095a73599415251bd2d554e56fL78-R81) [[6]](diffhunk://#diff-600ad4b50b78e23c8165adaf042b252ee7afa0ca21caffddcec0a5b39bbb856fL75-R78)
* Updated the `begin-process` message in protected intake application JSON files (adult, child, family) in both English and French to give more detailed next steps for the "intake" context. [[1]](diffhunk://#diff-aa6b945349bbb1af16a0037cfc6bda06a823a8065366d2f893e8d0cc5fe5ad45L122-R122) [[2]](diffhunk://#diff-513a30444af4fa3d9760f1ffc6ae2adc590bf2911b0bf9943bacf3c86f9773c1L83-R83) [[3]](diffhunk://#diff-ba3b7a5f349ae4626c4e44efeb25aa2bf9d649477571dfeee9ed12a64ecb6405L79-R79) [[4]](diffhunk://#diff-4444f1a44ee09ece065500086cd8b21ded7b39e6879f0b17933aaaf54bfe78d3L122-R122) [[5]](diffhunk://#diff-c026727dddef96e0c733f6fba2ccb8d496d674c3034392080484a6af2ea685c2L84-R84) [[6]](diffhunk://#diff-bef58868883ef98ec977f85979091dd1cbaa6c9dba7a21d4c625d259536e168cL79-R79)

**Frontend logic updates:**

* Modified the confirmation components for full adult, child, and family application flows (`confirmation.tsx` files) to select the `begin-process` message dynamically based on `loaderData.context`, ensuring the correct context-specific message is shown to users. [[1]](diffhunk://#diff-acd3bfa529a1bd78497c7dc58cd38883359533157c989649a7df561033f78a9fL206-R206) [[2]](diffhunk://#diff-b790cd7d00aa2cd5e557138cd2b173fc516b52ec21615fc485b31a1a7338bb52L233-R233) [[3]](diffhunk://#diff-cf232cc8ed7123364f58de2188b3b7579490b247c3d3c1992646f3a53212bca5L248-R248)

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

ESDCCM/CDCP -> BUG 40926