### PR TITLE
fix(frontend): French phrasing for living independently instructions

### DIFF
--- a/frontend/app/.server/locales/fr/application-spokes.json
+++ b/frontend/app/.server/locales/fr/application-spokes.json
@@ -264,13 +264,13 @@
   "living-independently": {
     "page-title": "Personne vivant de manière indépendante",
     "description": "Vivre de manière indépendante de vos parents signifie que vous avez 16 ou 17 ans, que vous ne recevez pas d'aide financière de vos parents et que votre résidence principale est différente de la leur.",
-    "form-instructions": "Vivez-vous de manière indépendante de vos parents?",
+    "form-instructions": "Vivez-vous indépendamment de vos parents?",
     "radio-options": {
       "yes": "Oui",
       "no": "Non"
     },
     "error-message": {
-      "living-independently-required": "Sélectionnez si vous vivez de manière indépendante de vos parents"
+      "living-independently-required": "Sélectionnez si vous vivez indépendamment de vos parents"
     },
     "back-btn": "Retour",
     "save-btn": "Sauvegarder"

--- a/frontend/app/.server/locales/fr/protected-application-spokes.json
+++ b/frontend/app/.server/locales/fr/protected-application-spokes.json
@@ -264,13 +264,13 @@
   "living-independently": {
     "page-title": "Personne vivant de manière indépendante",
     "description": "Vivre de manière indépendante de vos parents signifie que vous avez 16 ou 17 ans, que vous ne recevez pas d'aide financière de vos parents et que votre résidence principale est différente de la leur.",
-    "form-instructions": "Vivez-vous de manière indépendante de vos parents?",
+    "form-instructions": "Vivez-vous indépendamment de vos parents?",
     "radio-options": {
       "yes": "Oui",
       "no": "Non"
     },
     "error-message": {
-      "living-independently-required": "Sélectionnez si vous vivez de manière indépendante de vos parents"
+      "living-independently-required": "Sélectionnez si vous vivez indépendamment de vos parents"
     },
     "back-btn": "Retour",
     "save-btn": "Sauvegarder"


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates French translations in two locale files to use more natural phrasing for questions about living independently from parents. The changes focus on improving the clarity and accuracy of the language.

Localization improvements:

* Updated the `form-instructions` and `living-independently-required` strings in `frontend/app/.server/locales/fr/application-spokes.json` to use "indépendamment de vos parents" instead of "de manière indépendante de vos parents" for more natural French phrasing.
* Made the same updates to the `form-instructions` and `living-independently-required` strings in `frontend/app/.server/locales/fr/protected-application-spokes.json` for consistency across protected application spokes.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

ESDCCM/CDCP -> BUG 40921