### PR TITLE
fix(frontend): Text discrepency on child application page

### DIFF
--- a/frontend/app/.server/locales/en/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.json
@@ -159,7 +159,7 @@
     "edit-child-dental-benefits": "Edit access to government dental benefits",
     "add-child-information": "Add applicant information",
     "add-answer": "Add answer",
-    "child-information-indicate-status": "Enter your child's name, date of birth, and Social Insurance Number (SIN).",
+    "child-information-indicate-status": "Enter your child's name, date of birth and Social Insurance Number (SIN).",
     "child-dental-insurance-indicate-status": "Indicate if your child has access to private dental insurance.",
     "child-dental-benefits-indicate-status": "Indicate if your child has access to government dental benefits.",
     "member-id-title": "Member ID",

--- a/frontend/app/.server/locales/en/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/en/protected-application-intake-family.json
@@ -178,7 +178,7 @@
     "add-child-information": "Add applicant information",
     "add-child-dental-insurance": "Add answer",
     "add-child-dental-benefits": "Add answer",
-    "child-information-indicate-status": "Enter your child's name, date of birth and Member ID.",
+    "child-information-indicate-status": "Enter your child's name, date of birth and Social Insurance Number (SIN).",
     "child-dental-insurance-indicate-status": "Indicate if your child has access to private dental insurance.",
     "child-dental-benefits-indicate-status": "Indicate if your child has access to government dental benefits.",
     "member-id-title": "Member ID",

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.json
@@ -159,7 +159,7 @@
     "edit-child-dental-benefits": "Modifier la réponse sur l'accès aux prestations dentaires gouvernementales",
     "add-child-information": "Ajouter les renseignements du demandeur",
     "add-answer": "Ajouter une réponse",
-    "child-information-indicate-status": "Entrez le nom, la date de naissance et le numéro d'identification du membre de votre enfant.",
+    "child-information-indicate-status": "Entrez le nom, la date de naissance et le numéro d'assurance sociale (NAS) de votre enfant.",
     "child-dental-insurance-indicate-status": "Veuillez indiquer si votre enfant a accès à une assurance dentaire privée.",
     "child-dental-benefits-indicate-status": "Indiquez si votre enfant a accès à des prestations dentaires gouvernementales.",
     "member-id-title": "Numéro d'identification du membre",

--- a/frontend/app/.server/locales/fr/protected-application-intake-family.json
+++ b/frontend/app/.server/locales/fr/protected-application-intake-family.json
@@ -178,7 +178,7 @@
     "add-child-information": "Ajouter les renseignements du demandeur",
     "add-child-dental-insurance": "Ajouter une réponse",
     "add-child-dental-benefits": "Ajouter une réponse",
-    "child-information-indicate-status": "Entrez le nom, la date de naissance et le numéro d'identification du membre de votre enfant.",
+    "child-information-indicate-status": "Entrez le nom, la date de naissance et le numéro d'assurance sociale (NAS) de votre enfant.",
     "child-dental-insurance-indicate-status": "Veuillez indiquer si votre enfant a accès à une assurance dentaire privée.",
     "child-dental-benefits-indicate-status": "Indiquez si votre enfant a accès à des prestations dentaires gouvernementales.",
     "member-id-title": "Numéro d'identification du membre",


### PR DESCRIPTION
### Description
MSCA intake child information description text should be `social insurance member` instead of member id.

### Related Azure Boards Work Items
AB#40997

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->