### PR TITLE
fix(frontend): clean up communication preference

### DIFF
--- a/frontend/app/.server/locales/en/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-intake-child.ts
@@ -29,7 +29,6 @@ const ns = {
     communicationPreferencesHelp: "Select your communication preferences.",
     preferredLanguage: "Language preference",
     preferredMethod: "Sun Life communication preference",
-    preferredNotificationMethod: "Government of Canada communication preference",
     addCommunicationPreferences: "Add communication preferences",
     editCommunicationPreferences: "Edit communication preferences",
     email: "Email address",

--- a/frontend/app/.server/locales/en/protected-application-renewal-child.ts
+++ b/frontend/app/.server/locales/en/protected-application-renewal-child.ts
@@ -29,7 +29,6 @@ const ns = {
     updateCommunicationPreferences: "Update my communication preferences",
     preferredLanguage: "Language preference",
     preferredMethod: "Sun Life communication preference",
-    preferredNotificationMethod: "Government of Canada communication preference",
     email: "Email address",
     emailHelp: "Enter your email address.",
     addEmail: "Add email address",

--- a/frontend/app/.server/locales/fr/protected-application-intake-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-intake-child.ts
@@ -29,7 +29,6 @@ const ns = {
     communicationPreferencesHelp: "Veuillez choisir vos préférences de communication.",
     preferredLanguage: "Langue de préférence",
     preferredMethod: "Préférence de communication de Sun Life",
-    preferredNotificationMethod: "Préférence de communication du gouvernement du Canada",
     email: "Adresse courriel",
     emailHelp: "Veuillez entrer votre adresse courriel.",
     updateEmailHelp: "Souhaitez-vous mettre à jour votre adresse courriel?",

--- a/frontend/app/.server/locales/fr/protected-application-renewal-child.ts
+++ b/frontend/app/.server/locales/fr/protected-application-renewal-child.ts
@@ -21,7 +21,6 @@ const ns = {
     communicationPreferencesHelp: "Veuillez choisir vos préférences de communication.",
     preferredLanguage: "Langue de préférence",
     preferredMethod: "Préférence de communication de Sun Life",
-    preferredNotificationMethod: "Préférence de communication du gouvernement du Canada",
     email: "Adresse courriel",
     emailHelp: "Veuillez entrer votre adresse courriel.",
     addEmail: "Ajouter une adresse courriel",

--- a/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
@@ -196,7 +196,6 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               <DefinitionList layout="single-column">
                 <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationIntakeAdult' })}>{preferredLanguage?.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationIntakeAdult' })}>{preferredMethod?.name}</DefinitionListItem>
-                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'protectedApplicationIntakeAdult' })}>{state.email}</DefinitionListItem>}
               </DefinitionList>
             ) : (
               <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeAdult' })}</p>

--- a/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
@@ -76,7 +76,6 @@ export async function loader({ context: { appContainer, session }, request, para
     homeAddressInfo,
     preferredLanguage: state.communicationPreferences?.hasChanged ? appContainer.get(TYPES.LanguageService).getLocalizedLanguageById(state.communicationPreferences.value.preferredLanguage, locale) : undefined,
     preferredMethod: state.communicationPreferences?.hasChanged ? appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale) : undefined,
-    preferredNotificationMethod: state.communicationPreferences?.hasChanged ? appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale) : undefined,
     sections: {
       maritalStatus: { completed: isMaritalStatusSectionCompleted(state) },
       phoneNumber: { completed: isPhoneNumberSectionCompleted(state) },
@@ -89,7 +88,7 @@ export async function loader({ context: { appContainer, session }, request, para
 }
 
 export default function ProtectedNewChildParentOrGuardian({ loaderData, params }: Route.ComponentProps) {
-  const { state, mailingAddressInfo, homeAddressInfo, preferredLanguage, preferredMethod, preferredNotificationMethod, sections } = loaderData;
+  const { state, mailingAddressInfo, homeAddressInfo, preferredLanguage, preferredMethod, sections } = loaderData;
   const { t } = useTranslation(handle.i18nNamespaces);
 
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
@@ -239,7 +238,6 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               <DefinitionList layout="single-column">
                 <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationIntakeChild' })}>{preferredLanguage?.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationIntakeChild' })}>{preferredMethod?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod, { ns: 'protectedApplicationIntakeChild' })}>{preferredNotificationMethod?.name}</DefinitionListItem>
               </DefinitionList>
             ) : (
               <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeChild' })}</p>

--- a/frontend/app/routes/protected/application/intake-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-family/contact-information.tsx
@@ -196,7 +196,6 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               <DefinitionList layout="single-column">
                 <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationIntakeFamily' })}>{preferredLanguage?.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationIntakeFamily' })}>{preferredMethod?.name}</DefinitionListItem>
-                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'protectedApplicationIntakeFamily' })}>{state.email}</DefinitionListItem>}
               </DefinitionList>
             ) : (
               <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeFamily' })}</p>

--- a/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
@@ -81,7 +81,6 @@ export async function loader({ context: { appContainer, session }, request, para
         ? {
             preferredLanguage: languageService.getLocalizedLanguageById(state.communicationPreferences.value.preferredLanguage, locale).name,
             preferredMethod: sunLifeCommunicationMethodService.getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale).name,
-            preferredNotificationMethod: gcCommunicationMethodService.getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale).name,
           }
         : undefined,
       mailingAddress: state.mailingAddress?.hasChanged
@@ -712,7 +711,6 @@ function CommunicationPreferencesCardContent(): JSX.Element {
         <DefinitionList layout="single-column">
           <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationRenewalChild' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
           <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationRenewalChild' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod, { ns: 'protectedApplicationRenewalChild' })}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -723,8 +721,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
       <CardContent>
         <DefinitionList layout="single-column">
           <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>{' '}
         </DefinitionList>
       </CardContent>
     );


### PR DESCRIPTION
### Description
Remove email address field from the communication preference hub in msca
Remove GOC communication preference field from the communication preference hub in protected children.

### Related Azure Boards Work Items
AB#41103

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->