### PR TITLE
refactor(frontend): removed pageTitleI18nKey from route handle and add AppPageTitle component

### DIFF
--- a/frontend/__tests__/components/__snapshots__/app-page-title.test.tsx.snap
+++ b/frontend/__tests__/components/__snapshots__/app-page-title.test.tsx.snap
@@ -1,0 +1,23 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AppPageTitle > should render the AppPageTitle > expected html 1`] = `
+<div>
+  <div
+    class="my-8 max-w-prose after:mt-2 after:block after:h-1.5 after:w-18 after:bg-[#a62a1e] after:content-['']"
+  >
+    <h2
+      class="font-lato mb-2 font-semibold"
+    >
+      header.applicationTitle
+    </h2>
+    <h1
+      class="font-lato text-3xl font-bold focus-visible:ring-3"
+      id="wb-cont"
+      property="name"
+      tabindex="-1"
+    >
+      My Page Title
+    </h1>
+  </div>
+</div>
+`;

--- a/frontend/__tests__/components/app-page-title.test.tsx
+++ b/frontend/__tests__/components/app-page-title.test.tsx
@@ -1,0 +1,16 @@
+import { render } from '@testing-library/react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { AppPageTitle } from '~/components/app-page-title';
+
+vi.mock('~/hooks', () => ({
+  useAccessibleFocusManagement: vi.fn(),
+}));
+
+describe('AppPageTitle', () => {
+  it('should render the AppPageTitle', () => {
+    const { container } = render(<AppPageTitle>My Page Title</AppPageTitle>);
+    expect(container).toMatchSnapshot('expected html');
+  });
+});

--- a/frontend/__tests__/utils/route-utils.test.tsx
+++ b/frontend/__tests__/utils/route-utils.test.tsx
@@ -5,7 +5,7 @@ import { Outlet, createRoutesStub } from 'react-router';
 import { describe, expect, it } from 'vitest';
 
 import type { Breadcrumbs, BuildInfo, RouteHandleData } from '~/utils/route-utils';
-import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, usePageTitleI18nKey, useTransformAdobeAnalyticsUrl } from '~/utils/route-utils';
+import { coalesce, useBreadcrumbs, useBuildInfo, useI18nNamespaces, usePageIdentifier, useTransformAdobeAnalyticsUrl } from '~/utils/route-utils';
 
 /*
  * @vitest-environment jsdom
@@ -264,47 +264,5 @@ describe('usePageIdentifier()', () => {
 
     const element = await waitFor(async () => await screen.findByTestId('data'));
     expect(element.textContent).toEqual('"CDCP-0001"');
-  });
-});
-
-describe('usePageTitle()', () => {
-  it('expect no page title from usePageTitle() if the loaders do not provide data', async () => {
-    const RoutesStub = createRoutesStub([
-      {
-        Component: () => <Outlet />,
-        children: [
-          {
-            Component: () => <div data-testid="data">{JSON.stringify(usePageTitleI18nKey())}</div>,
-            path: '/',
-          },
-        ],
-      },
-    ]);
-
-    render(<RoutesStub />);
-
-    const element = await waitFor(async () => await screen.findByTestId('data'));
-    expect(element.textContent).toEqual('');
-  });
-
-  it('expect correctly coalesced page title from usePageTitle() if the loaders provide data', async () => {
-    const RoutesStub = createRoutesStub([
-      {
-        Component: () => <Outlet />,
-        handle: { pageTitleI18nKey: 'protectedApplication:index.pageTitle' } satisfies RouteHandleData,
-        children: [
-          {
-            Component: () => <div data-testid="data">{JSON.stringify(usePageTitleI18nKey())}</div>,
-            handle: { pageTitleI18nKey: 'protectedApplication:index.pageTitle' } satisfies RouteHandleData,
-            path: '/',
-          },
-        ],
-      },
-    ]);
-
-    render(<RoutesStub />);
-
-    const element = await waitFor(async () => await screen.findByTestId('data'));
-    expect(element.textContent).toEqual('"protectedApplication:index.pageTitle"');
   });
 });

--- a/frontend/app/.server/locales/en/protected-application-spokes.ts
+++ b/frontend/app/.server/locales/en/protected-application-spokes.ts
@@ -515,7 +515,7 @@ const ns = {
     },
     parentGuardian: {
       pageTitle: "Parent or legal guardian",
-      parentLegend: "Are you the parent or legal guardian of {{ childName }}?",
+      parentLegend: "Are you the parent or legal guardian of {{childName}}?",
       radioOptions: {
         yes: "Yes",
         no: "No",

--- a/frontend/app/.server/locales/fr/protected-application-spokes.ts
+++ b/frontend/app/.server/locales/fr/protected-application-spokes.ts
@@ -515,7 +515,7 @@ const ns = {
     },
     parentGuardian: {
       pageTitle: "Parent ou tuteur légal",
-      parentLegend: "Êtes-vous le parent ou le tuteur légal de {{ childName }}?",
+      parentLegend: "Êtes-vous le parent ou le tuteur légal de {{childName}}?",
       radioOptions: {
         yes: "Oui",
         no: "Non",

--- a/frontend/app/components/app-page-title.tsx
+++ b/frontend/app/components/app-page-title.tsx
@@ -1,0 +1,21 @@
+import type { PropsWithChildren } from 'react';
+import { useRef } from 'react';
+
+import { useTranslation } from 'react-i18next';
+
+import { PageTitle } from '~/components/page-title';
+import { useAccessibleFocusManagement } from '~/hooks';
+
+export function AppPageTitle({ children }: PropsWithChildren) {
+  const { t } = useTranslation('gcweb');
+
+  const focusableElementRef = useRef<HTMLHeadingElement | null>(null);
+  useAccessibleFocusManagement(focusableElementRef);
+
+  return (
+    <div className="my-8 max-w-prose after:mt-2 after:block after:h-1.5 after:w-18 after:bg-[#a62a1e] after:content-['']">
+      <h2 className="font-lato mb-2 font-semibold">{t(($) => $.header.applicationTitle)}</h2>
+      <PageTitle ref={focusableElementRef}>{children}</PageTitle>
+    </div>
+  );
+}

--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import type { PropsWithChildren } from 'react';
 
 import { Link } from 'react-router';
@@ -18,12 +18,12 @@ import { PageDetails } from '~/components/page-details';
 import { PageHeaderBrand } from '~/components/page-header-brand';
 import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
-import { useAccessibleFocusManagement, useBrowserCompatiblityBanner } from '~/hooks';
+import { useBrowserCompatiblityBanner } from '~/hooks';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
 import { getTypedI18nNamespaces, translateFromKey } from '~/utils/locale-utils';
-import { useBreadcrumbs, usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
+import { useBreadcrumbs } from '~/utils/route-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -32,35 +32,16 @@ export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
  * see: https://wet-boew.github.io/GCWeb/templates/application/application-docs-en.html
  */
 export function ProtectedLayout({ children }: PropsWithChildren) {
-  const { i18n } = useTranslation();
-  const pageTitleI18nKey = usePageTitleI18nKey();
-  const i18nOptions = usePageTitleI18nOptions();
-  const pageTitle = pageTitleI18nKey ? translateFromKey(i18n, pageTitleI18nKey, i18nOptions) : undefined;
-
   return (
     <>
       <PageHeader />
       <PageBreadcrumbs />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        {pageTitle && <AppPageTitle>{pageTitle}</AppPageTitle>}
         {children}
         <PageDetails />
       </main>
       <PageFooter />
     </>
-  );
-}
-
-export function AppPageTitle({ children }: PropsWithChildren) {
-  const { t } = useTranslation(i18nNamespaces);
-  const focusableElementRef = useRef<HTMLHeadingElement | null>(null);
-  useAccessibleFocusManagement(focusableElementRef);
-
-  return (
-    <div className="my-8 max-w-prose after:mt-2 after:block after:h-1.5 after:w-18 after:bg-[#a62a1e] after:content-['']">
-      <h2 className="font-lato mb-2 font-semibold">{t(($) => $.header.applicationTitle)}</h2>
-      <PageTitle ref={focusableElementRef}>{children}</PageTitle>
-    </div>
   );
 }
 

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren } from 'react';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 
 import { Link } from 'react-router';
 
@@ -13,12 +13,11 @@ import { PageDetails } from '~/components/page-details';
 import { PageHeaderBrand } from '~/components/page-header-brand';
 import { PageTitle } from '~/components/page-title';
 import { SkipNavigationLinks } from '~/components/skip-navigation-links';
-import { useAccessibleFocusManagement, useBrowserCompatiblityBanner, useCurrentLanguage } from '~/hooks';
+import { useBrowserCompatiblityBanner, useCurrentLanguage } from '~/hooks';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
-import { getTypedI18nNamespaces, translateFromKey } from '~/utils/locale-utils';
-import { usePageTitleI18nKey, usePageTitleI18nOptions } from '~/utils/route-utils';
+import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 
 export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
 
@@ -27,35 +26,16 @@ export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
  * see: https://wet-boew.github.io/GCWeb/templates/application/application-docs-en.html
  */
 export function PublicLayout({ children }: PropsWithChildren) {
-  const { i18n } = useTranslation();
-  const pageTitleI18nKey = usePageTitleI18nKey();
-  const i18nOptions = usePageTitleI18nOptions();
-  const pageTitle = pageTitleI18nKey ? translateFromKey(i18n, pageTitleI18nKey, i18nOptions) : undefined;
-
   return (
     <>
       <PageHeader />
       <PageBreadcrumbs />
       <main className="container" property="mainContentOfPage" resource="#wb-main" typeof="WebPageElement">
-        {pageTitle && <AppPageTitle>{pageTitle}</AppPageTitle>}
         {children}
         <PageDetails />
       </main>
       <PageFooter />
     </>
-  );
-}
-
-export function AppPageTitle({ children }: PropsWithChildren) {
-  const { t } = useTranslation(i18nNamespaces);
-  const focusableElementRef = useRef<HTMLHeadingElement | null>(null);
-  useAccessibleFocusManagement(focusableElementRef);
-
-  return (
-    <div className="my-8 max-w-prose after:mt-2 after:block after:h-1.5 after:w-18 after:bg-[#a62a1e] after:content-['']">
-      <h2 className="font-lato mb-2 font-semibold">{t(($) => $.header.applicationTitle)}</h2>
-      <PageTitle ref={focusableElementRef}>{children}</PageTitle>
-    </div>
   );
 }
 

--- a/frontend/app/routes/protected/application/entry/eligibility-requirements.tsx
+++ b/frontend/app/routes/protected/application/entry/eligibility-requirements.tsx
@@ -9,6 +9,7 @@ import { isTaxFilingSectionCompleted, isTermsAndConditionsSectionCompleted } fro
 import { getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
@@ -23,7 +24,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.eligibilityRequirements,
-  pageTitleI18nKey: 'protectedApplication:eligibilityRequirements.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -64,107 +64,110 @@ export default function ProtectedApplicationEligibilityRequirements({ loaderData
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <div className="max-w-prose space-y-8">
-      <div className="space-y-4">
-        <p>{t(($) => $.completeAllSections)}</p>
-        <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.eligibilityRequirements.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <div className="space-y-4">
+          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{completedSectionsLabel}</p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t(($) => $.eligibilityRequirements.termsConditionsSection.title)}</CardTitle>
+            <CardAction>{sections.termsAndConditions.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {state.termsAndConditions === undefined ? (
+              <p>{t(($) => $.eligibilityRequirements.termsConditionsSection.instructions)}</p>
+            ) : (
+              <ul className="list-disc space-y-1 pl-7">
+                {state.termsAndConditions.acknowledgeTerms && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgeTerms)}</li>}
+                {state.termsAndConditions.acknowledgePrivacy && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgePrivacy)}</li>}
+                {state.termsAndConditions.shareData && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.shareData)}</li>}
+              </ul>
+            )}
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            {sections.termsAndConditions.completed ? (
+              <ButtonLink
+                id="edit-terms-conditions-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/terms-conditions"
+                params={params}
+                startIcon={faPenToSquare}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit terms conditions click"
+                aria-label={t(($) => $.eligibilityRequirements.termsConditionsSection.editButtonAria)}
+              >
+                {t(($) => $.eligibilityRequirements.termsConditionsSection.editButton)}
+              </ButtonLink>
+            ) : (
+              <ButtonLink
+                id="add-terms-conditions-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/terms-conditions"
+                params={params}
+                startIcon={faCircleCheck}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Add terms conditions click"
+              >
+                {t(($) => $.eligibilityRequirements.termsConditionsSection.addButton)}
+              </ButtonLink>
+            )}
+          </CardFooter>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t(($) => $.eligibilityRequirements.taxFilingSection.title)}</CardTitle>
+            <CardAction>{sections.taxFiling.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            <p>{state.hasFiledTaxes === true ? t(($) => $.eligibilityRequirements.taxFilingSection.haveFiledTaxes) : t(($) => $.eligibilityRequirements.taxFilingSection.instructions)}</p>
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            {sections.taxFiling.completed ? (
+              <ButtonLink
+                id="edit-tax-filing-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/tax-filing"
+                params={params}
+                startIcon={faPenToSquare}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit tax filing click"
+                aria-label={t(($) => $.eligibilityRequirements.taxFilingSection.editButtonAria)}
+              >
+                {t(($) => $.eligibilityRequirements.taxFilingSection.editButton)}
+              </ButtonLink>
+            ) : (
+              <ButtonLink
+                id="add-tax-filing-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/tax-filing"
+                params={params}
+                startIcon={faCircleCheck}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Add tax filing click"
+              >
+                {t(($) => $.eligibilityRequirements.taxFilingSection.addButton)}
+              </ButtonLink>
+            )}
+          </CardFooter>
+        </Card>
+        <NavigationButtonLink
+          disabled={!allSectionsCompleted}
+          variant="primary"
+          direction="next"
+          routeId={`protected/application/$id/${isIntake ? 'your-application' : 'renew'}`}
+          params={params}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click"
+        >
+          {t(($) => $.eligibilityRequirements.nextButton[isIntake ? 'intake' : 'renewal'])}
+        </NavigationButtonLink>
       </div>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t(($) => $.eligibilityRequirements.termsConditionsSection.title)}</CardTitle>
-          <CardAction>{sections.termsAndConditions.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {state.termsAndConditions === undefined ? (
-            <p>{t(($) => $.eligibilityRequirements.termsConditionsSection.instructions)}</p>
-          ) : (
-            <ul className="list-disc space-y-1 pl-7">
-              {state.termsAndConditions.acknowledgeTerms && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgeTerms)}</li>}
-              {state.termsAndConditions.acknowledgePrivacy && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgePrivacy)}</li>}
-              {state.termsAndConditions.shareData && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.shareData)}</li>}
-            </ul>
-          )}
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          {sections.termsAndConditions.completed ? (
-            <ButtonLink
-              id="edit-terms-conditions-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/terms-conditions"
-              params={params}
-              startIcon={faPenToSquare}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit terms conditions click"
-              aria-label={t(($) => $.eligibilityRequirements.termsConditionsSection.editButtonAria)}
-            >
-              {t(($) => $.eligibilityRequirements.termsConditionsSection.editButton)}
-            </ButtonLink>
-          ) : (
-            <ButtonLink
-              id="add-terms-conditions-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/terms-conditions"
-              params={params}
-              startIcon={faCircleCheck}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Add terms conditions click"
-            >
-              {t(($) => $.eligibilityRequirements.termsConditionsSection.addButton)}
-            </ButtonLink>
-          )}
-        </CardFooter>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t(($) => $.eligibilityRequirements.taxFilingSection.title)}</CardTitle>
-          <CardAction>{sections.taxFiling.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          <p>{state.hasFiledTaxes === true ? t(($) => $.eligibilityRequirements.taxFilingSection.haveFiledTaxes) : t(($) => $.eligibilityRequirements.taxFilingSection.instructions)}</p>
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          {sections.taxFiling.completed ? (
-            <ButtonLink
-              id="edit-tax-filing-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/tax-filing"
-              params={params}
-              startIcon={faPenToSquare}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit tax filing click"
-              aria-label={t(($) => $.eligibilityRequirements.taxFilingSection.editButtonAria)}
-            >
-              {t(($) => $.eligibilityRequirements.taxFilingSection.editButton)}
-            </ButtonLink>
-          ) : (
-            <ButtonLink
-              id="add-tax-filing-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/tax-filing"
-              params={params}
-              startIcon={faCircleCheck}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Add tax filing click"
-            >
-              {t(($) => $.eligibilityRequirements.taxFilingSection.addButton)}
-            </ButtonLink>
-          )}
-        </CardFooter>
-      </Card>
-      <NavigationButtonLink
-        disabled={!allSectionsCompleted}
-        variant="primary"
-        direction="next"
-        routeId={`protected/application/$id/${isIntake ? 'your-application' : 'renew'}`}
-        params={params}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click"
-      >
-        {t(($) => $.eligibilityRequirements.nextButton[isIntake ? 'intake' : 'renewal'])}
-      </NavigationButtonLink>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/entry/renew.tsx
+++ b/frontend/app/routes/protected/application/entry/renew.tsx
@@ -10,6 +10,7 @@ import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getProt
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -25,7 +26,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.typeOfApplication,
-  pageTitleI18nKey: 'protectedApplication:renewalSelection.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -83,57 +83,60 @@ export default function ProtectedTypeOfApplication({ loaderData, params }: Route
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <div className="max-w-prose space-y-8">
-      <div className="space-y-4">
-        <p>{t(($) => $.completeAllSections)}</p>
-        <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.renewalSelection.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <div className="space-y-4">
+          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{completedSectionsLabel}</p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t(($) => $.renewalSelection.typeApplicationHeading)}</CardTitle>
+            <CardAction>{sections.applicantClientIdsToRenew.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {defaultState.applicantClientIdsToRenew === undefined ? (
+              <p>{t(($) => $.renewalSelection.typeApplicationDescription)}</p>
+            ) : (
+              <DefinitionList layout="single-column">
+                <DefinitionListItem term={t(($) => $.renewalSelection.typeApplicationLegend)}>
+                  <ul className="list-disc space-y-1 pl-7">
+                    {applicants.map(({ id, name }) => (
+                      <li key={id}>{name}</li>
+                    ))}
+                  </ul>
+                </DefinitionListItem>
+                {defaultState.livingIndependently !== undefined && (
+                  <DefinitionListItem term={t(($) => $.renewalSelection.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.renewalSelection.livingIndependentlyYes) : t(($) => $.renewalSelection.livingIndependentlyNo)}</DefinitionListItem>
+                )}
+              </DefinitionList>
+            )}
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink
+              id="type-of-application-edit-button"
+              variant="link"
+              className="p-0"
+              routeId="protected/application/$id/renewal-selection"
+              params={params}
+              startIcon={defaultState.applicantClientIdsToRenew ? faPenToSquare : faCirclePlus}
+              size="lg"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit type of application click"
+            >
+              {defaultState.applicantClientIdsToRenew === undefined ? t(($) => $.renewalSelection.addTypeApplication) : t(($) => $.renewalSelection.editTypeApplication)}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
+            {t(($) => $.renewalSelection.application)}
+          </NavigationButtonLink>
+          <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Back click">
+            {t(($) => $.renewalSelection.beforeYouStart)}
+          </NavigationButtonLink>
+        </div>
       </div>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t(($) => $.renewalSelection.typeApplicationHeading)}</CardTitle>
-          <CardAction>{sections.applicantClientIdsToRenew.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {defaultState.applicantClientIdsToRenew === undefined ? (
-            <p>{t(($) => $.renewalSelection.typeApplicationDescription)}</p>
-          ) : (
-            <DefinitionList layout="single-column">
-              <DefinitionListItem term={t(($) => $.renewalSelection.typeApplicationLegend)}>
-                <ul className="list-disc space-y-1 pl-7">
-                  {applicants.map(({ id, name }) => (
-                    <li key={id}>{name}</li>
-                  ))}
-                </ul>
-              </DefinitionListItem>
-              {defaultState.livingIndependently !== undefined && (
-                <DefinitionListItem term={t(($) => $.renewalSelection.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.renewalSelection.livingIndependentlyYes) : t(($) => $.renewalSelection.livingIndependentlyNo)}</DefinitionListItem>
-              )}
-            </DefinitionList>
-          )}
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          <ButtonLink
-            id="type-of-application-edit-button"
-            variant="link"
-            className="p-0"
-            routeId="protected/application/$id/renewal-selection"
-            params={params}
-            startIcon={defaultState.applicantClientIdsToRenew ? faPenToSquare : faCirclePlus}
-            size="lg"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit type of application click"
-          >
-            {defaultState.applicantClientIdsToRenew === undefined ? t(($) => $.renewalSelection.addTypeApplication) : t(($) => $.renewalSelection.editTypeApplication)}
-          </ButtonLink>
-        </CardFooter>
-      </Card>
-      <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-        <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
-          {t(($) => $.renewalSelection.application)}
-        </NavigationButtonLink>
-        <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Back click">
-          {t(($) => $.renewalSelection.beforeYouStart)}
-        </NavigationButtonLink>
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -8,6 +8,7 @@ import { isNewOrReturningMemberSectionCompleted, isPersonalInformationSectionCom
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getProtectedApplicationState, shouldSkipNewOrReturningMember, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -28,7 +29,6 @@ const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children' 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.typeOfApplication,
-  pageTitleI18nKey: 'protectedApplication:yourApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -99,106 +99,109 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <div className="max-w-prose space-y-8">
-      <div className="space-y-4">
-        <p>{t(($) => $.completeAllSections)}</p>
-        <p>{completedSectionsLabel}</p>
-      </div>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t(($) => $.yourApplication.typeApplicationHeading)}</CardTitle>
-          <CardAction>{sections.typeOfApplication.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {defaultState.typeOfApplication === undefined ? (
-            <p>{t(($) => $.yourApplication.typeApplicationDescription)}</p>
-          ) : (
-            <DefinitionList layout="single-column">
-              <DefinitionListItem term={t(($) => $.yourApplication.typeApplicationLegend)}>{getTypeOfApplication(defaultState.typeOfApplication)}</DefinitionListItem>
-            </DefinitionList>
-          )}
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          <ButtonLink
-            id="type-of-application-edit-button"
-            variant="link"
-            className="p-0"
-            routeId="protected/application/$id/type-application"
-            params={params}
-            startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
-            size="lg"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit type of application click"
-          >
-            {defaultState.typeOfApplication === undefined ? t(($) => $.yourApplication.addTypeApplication) : t(($) => $.yourApplication.editTypeApplication)}
-          </ButtonLink>
-        </CardFooter>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle>{t(($) => $.yourApplication.personalInfoHeading)}</CardTitle>
-          <CardAction>{sections.personalInformation.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {defaultState.personalInformation === undefined ? (
-            <p>{t(($) => $.yourApplication.personalInfoDescription[defaultState.context])}</p>
-          ) : (
-            <DefinitionList layout="single-column">
-              {defaultState.personalInformation.memberId && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{formatClientNumber(defaultState.personalInformation.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.yourApplication.fullName)}>{`${defaultState.personalInformation.firstName} ${defaultState.personalInformation.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.yourApplication.dateOfBirth)}>{formattedDateOfBirth}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.yourApplication.sin)}>{formatSin(defaultState.personalInformation.socialInsuranceNumber)}</DefinitionListItem>
-              {defaultState.livingIndependently !== undefined && (
-                <DefinitionListItem term={t(($) => $.yourApplication.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.yourApplication.livingIndependentlyYes) : t(($) => $.yourApplication.livingIndependentlyNo)}</DefinitionListItem>
-              )}
-            </DefinitionList>
-          )}
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          <ButtonLink
-            id="personal-information-edit-button"
-            variant="link"
-            className="p-0"
-            routeId="protected/application/$id/personal-information"
-            params={params}
-            startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
-            size="lg"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit personal information click"
-          >
-            {defaultState.personalInformation === undefined ? t(($) => $.yourApplication.addPersonalInformation) : t(($) => $.yourApplication.editPersonalInformation)}
-          </ButtonLink>
-        </CardFooter>
-      </Card>
-      {showNewOrReturningMemberSection && (
+    <>
+      <AppPageTitle>{t(($) => $.yourApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <div className="space-y-4">
+          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{completedSectionsLabel}</p>
+        </div>
         <Card>
           <CardHeader>
-            <CardTitle>{t(($) => $.yourApplication.newOrReturningHeading)}</CardTitle>
-            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+            <CardTitle>{t(($) => $.yourApplication.typeApplicationHeading)}</CardTitle>
+            <CardAction>{sections.typeOfApplication.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
-            {defaultState.newOrReturningMember === undefined ? (
-              <p>{t(($) => $.yourApplication.newOrReturningDescription)}</p>
+            {defaultState.typeOfApplication === undefined ? (
+              <p>{t(($) => $.yourApplication.typeApplicationDescription)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.yourApplication.previouslyEnrolled)}>{defaultState.newOrReturningMember.isNewOrReturningMember ? t(($) => $.yourApplication.yes) : t(($) => $.yourApplication.no)}</DefinitionListItem>
-                {defaultState.newOrReturningMember.isNewOrReturningMember === true && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{defaultState.newOrReturningMember.memberId}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.yourApplication.typeApplicationLegend)}>{getTypeOfApplication(defaultState.typeOfApplication)}</DefinitionListItem>
               </DefinitionList>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
-              {defaultState.newOrReturningMember === undefined ? t(($) => $.yourApplication.addAnswer) : t(($) => $.yourApplication.editAnswer)}
+            <ButtonLink
+              id="type-of-application-edit-button"
+              variant="link"
+              className="p-0"
+              routeId="protected/application/$id/type-application"
+              params={params}
+              startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
+              size="lg"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit type of application click"
+            >
+              {defaultState.typeOfApplication === undefined ? t(($) => $.yourApplication.addTypeApplication) : t(($) => $.yourApplication.editTypeApplication)}
             </ButtonLink>
           </CardFooter>
         </Card>
-      )}
-      <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-        <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
-          {t(($) => $.yourApplication.application)}
-        </NavigationButtonLink>
-        <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Back click">
-          {t(($) => $.yourApplication.beforeYouStart)}
-        </NavigationButtonLink>
+        <Card>
+          <CardHeader>
+            <CardTitle>{t(($) => $.yourApplication.personalInfoHeading)}</CardTitle>
+            <CardAction>{sections.personalInformation.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {defaultState.personalInformation === undefined ? (
+              <p>{t(($) => $.yourApplication.personalInfoDescription[defaultState.context])}</p>
+            ) : (
+              <DefinitionList layout="single-column">
+                {defaultState.personalInformation.memberId && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{formatClientNumber(defaultState.personalInformation.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.yourApplication.fullName)}>{`${defaultState.personalInformation.firstName} ${defaultState.personalInformation.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.yourApplication.dateOfBirth)}>{formattedDateOfBirth}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.yourApplication.sin)}>{formatSin(defaultState.personalInformation.socialInsuranceNumber)}</DefinitionListItem>
+                {defaultState.livingIndependently !== undefined && (
+                  <DefinitionListItem term={t(($) => $.yourApplication.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.yourApplication.livingIndependentlyYes) : t(($) => $.yourApplication.livingIndependentlyNo)}</DefinitionListItem>
+                )}
+              </DefinitionList>
+            )}
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            <ButtonLink
+              id="personal-information-edit-button"
+              variant="link"
+              className="p-0"
+              routeId="protected/application/$id/personal-information"
+              params={params}
+              startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
+              size="lg"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Edit personal information click"
+            >
+              {defaultState.personalInformation === undefined ? t(($) => $.yourApplication.addPersonalInformation) : t(($) => $.yourApplication.editPersonalInformation)}
+            </ButtonLink>
+          </CardFooter>
+        </Card>
+        {showNewOrReturningMemberSection && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(($) => $.yourApplication.newOrReturningHeading)}</CardTitle>
+              <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CardContent>
+              {defaultState.newOrReturningMember === undefined ? (
+                <p>{t(($) => $.yourApplication.newOrReturningDescription)}</p>
+              ) : (
+                <DefinitionList layout="single-column">
+                  <DefinitionListItem term={t(($) => $.yourApplication.previouslyEnrolled)}>{defaultState.newOrReturningMember.isNewOrReturningMember ? t(($) => $.yourApplication.yes) : t(($) => $.yourApplication.no)}</DefinitionListItem>
+                  {defaultState.newOrReturningMember.isNewOrReturningMember === true && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{defaultState.newOrReturningMember.memberId}</DefinitionListItem>}
+                </DefinitionList>
+              )}
+            </CardContent>
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink id="edit-button" variant="link" className="p-0" routeId="protected/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
+                {defaultState.newOrReturningMember === undefined ? t(($) => $.yourApplication.addAnswer) : t(($) => $.yourApplication.editAnswer)}
+              </ButtonLink>
+            </CardFooter>
+          </Card>
+        )}
+        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Continue click">
+            {t(($) => $.yourApplication.application)}
+          </NavigationButtonLink>
+          <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Entry:Back click">
+            {t(($) => $.yourApplication.beforeYouStart)}
+          </NavigationButtonLink>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/index.tsx
+++ b/frontend/app/routes/protected/application/index.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react';
 import { redirect, useNavigate, useNavigation } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
+import { useTranslation } from 'react-i18next';
 
 import type { Route } from './+types/index';
 
@@ -11,6 +12,7 @@ import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos'
 import { isWithinRenewalPeriod, startProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
@@ -24,7 +26,6 @@ import { secondsToMilliseconds } from '~/utils/units.utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.index,
-  pageTitleI18nKey: 'protectedApplication:eligibilityRequirements.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -78,6 +79,7 @@ const NAVIGATION_DELAY_MS = secondsToMilliseconds(1);
 export default function ProtectedApplicationIndex({ loaderData, params }: Route.ComponentProps) {
   const { id } = loaderData;
 
+  const { t } = useTranslation(handle.i18nNamespaces);
   const navigation = useNavigation();
   const navigate = useNavigate();
   const { set: setApplicationFlowStorageValue } = useApplicationFlowStorage();
@@ -108,57 +110,60 @@ export default function ProtectedApplicationIndex({ loaderData, params }: Route.
   }, [setApplicationFlowStorageValue, eligibilityRequirementsPath, isIdle, navigate]);
 
   return (
-    <div className="max-w-prose animate-pulse space-y-8">
-      {/* Intro text */}
-      <div className="space-y-4">
-        <div className="h-5 w-40 rounded bg-gray-200"></div>
-        <div className="h-5 w-56 rounded bg-gray-200"></div>
-      </div>
+    <>
+      <AppPageTitle>{t(($) => $.eligibilityRequirements.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose animate-pulse space-y-8">
+        {/* Intro text */}
+        <div className="space-y-4">
+          <div className="h-5 w-40 rounded bg-gray-200"></div>
+          <div className="h-5 w-56 rounded bg-gray-200"></div>
+        </div>
 
-      {/* Card 1 */}
-      <div className="rounded-lg border border-gray-300">
-        <div className="space-y-8 p-6">
-          <div className="h-6 w-3/4 rounded bg-gray-300"></div>
+        {/* Card 1 */}
+        <div className="rounded-lg border border-gray-300">
+          <div className="space-y-8 p-6">
+            <div className="h-6 w-3/4 rounded bg-gray-300"></div>
+            <div className="space-y-3">
+              <div className="h-5 w-full rounded bg-gray-200"></div>
+              <div className="h-5 w-5/6 rounded bg-gray-200"></div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+              <div className="h-5 w-2/3 rounded bg-gray-200"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Card 2 */}
+        <div className="rounded-lg border border-gray-300">
+          <div className="space-y-8 p-6">
+            <div className="h-6 w-40 rounded bg-gray-300"></div>
+            <div className="space-y-3">
+              <div className="h-5 w-full rounded bg-gray-200"></div>
+              <div className="h-5 w-5/6 rounded bg-gray-200"></div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+              <div className="h-5 w-32 rounded bg-gray-200"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Next button */}
+        <div className="flex w-64 items-center justify-between rounded bg-gray-300 px-6 py-4">
           <div className="space-y-3">
-            <div className="h-5 w-full rounded bg-gray-200"></div>
-            <div className="h-5 w-5/6 rounded bg-gray-200"></div>
-          </div>
-        </div>
-
-        <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="h-6 w-6 rounded-full bg-gray-300"></div>
-            <div className="h-5 w-2/3 rounded bg-gray-200"></div>
-          </div>
-        </div>
-      </div>
-
-      {/* Card 2 */}
-      <div className="rounded-lg border border-gray-300">
-        <div className="space-y-8 p-6">
-          <div className="h-6 w-40 rounded bg-gray-300"></div>
-          <div className="space-y-3">
-            <div className="h-5 w-full rounded bg-gray-200"></div>
-            <div className="h-5 w-5/6 rounded bg-gray-200"></div>
-          </div>
-        </div>
-
-        <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+            <div className="h-4 w-10 rounded bg-gray-200"></div>
             <div className="h-5 w-32 rounded bg-gray-200"></div>
           </div>
+          <div className="h-8 w-8 rounded-full bg-gray-200"></div>
         </div>
       </div>
-
-      {/* Next button */}
-      <div className="flex w-64 items-center justify-between rounded bg-gray-300 px-6 py-4">
-        <div className="space-y-3">
-          <div className="h-4 w-10 rounded bg-gray-200"></div>
-          <div className="h-5 w-32 rounded bg-gray-200"></div>
-        </div>
-        <div className="h-8 w-8 rounded-full bg-gray-200"></div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpe
 import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.confirmation,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -159,222 +159,225 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
   const cdcpLink = <InlineLink to={t(($) => $.confirm.statusCheckerLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
-        <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
+          <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
+              </section>
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                  </DefinitionListItem>
                 )}
-              </DefinitionListItem>
-            </DefinitionList>
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
           </section>
         </section>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </div>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Close confirm modal click">
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Close confirm modal click">
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
@@ -10,6 +10,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.contactInformation,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -40,7 +40,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'protectedApplicationIntakeAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -92,27 +92,28 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="contactInformation" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationIntakeAdult' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationIntakeAdult' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -126,7 +127,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'protectedApplicationIntakeAdult' })}
+              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -134,16 +135,16 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.contactInformation.addressHelp, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.contactInformation.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationIntakeAdult' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -154,7 +155,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationIntakeAdult' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -179,7 +180,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.contactInformation.addAddress, { ns: 'protectedApplicationIntakeAdult' })}
+              {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -187,18 +188,18 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationIntakeAdult' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationIntakeAdult' })}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -212,9 +213,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit comms click"
             >
-              {sections.communicationPreferences.completed
-                ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'protectedApplicationIntakeAdult' })
-                : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'protectedApplicationIntakeAdult' })}
+              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -222,11 +221,11 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.email, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.email)}</h2>
             </CardTitle>
             <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
-          <CardContent>{state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp, { ns: 'protectedApplicationIntakeAdult' })}</p> : <p>{state.email}</p>}</CardContent>
+          <CardContent>{state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp)}</p> : <p>{state.email}</p>}</CardContent>
           <CardFooter className="border-t bg-zinc-100">
             <ButtonLink
               id="edit-email-button"
@@ -238,7 +237,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit email click"
             >
-              {sections.email.completed ? t(($) => $.contactInformation.editEmail, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.contactInformation.addEmail, { ns: 'protectedApplicationIntakeAdult' })}
+              {sections.email.completed ? t(($) => $.contactInformation.editEmail) : t(($) => $.contactInformation.addEmail)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -252,7 +251,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Continue click"
           >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.contactInformation.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink
             variant="secondary"
@@ -261,7 +260,7 @@ export default function ProtectedNewAdultContactInformation({ loaderData, params
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back click"
           >
-            {t(($) => $.contactInformation.prevBtn, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.contactInformation.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/dental-insurance.tsx
@@ -8,6 +8,7 @@ import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpe
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -22,9 +23,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.dentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -39,7 +39,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'protectedApplicationIntakeAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram
@@ -83,28 +83,29 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalInsurance?.dentalInsuranceEligibilityConfirmation === true ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'protectedApplicationIntakeAdult' })}>
-                  {state.dentalInsurance.hasDentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'protectedApplicationIntakeAdult' })}
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>
+                  {state.dentalInsurance.hasDentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -116,14 +117,10 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
               params={params}
               startIcon={sections.dentalInsurance.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalInsurance === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeAdult' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationIntakeAdult' })}`
-                  : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationIntakeAdult' })
-              }
+              aria-label={state.dentalInsurance === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}` : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit insurance click"
             >
-              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationIntakeAdult' })}
+              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -131,29 +128,29 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalBenefits ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationIntakeAdult' })}>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
                   {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
                     <div className="space-y-3">
-                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationIntakeAdult' })}</p>
+                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                       <ul className="list-disc space-y-1 pl-7">
                         {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                         {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                       </ul>
                     </div>
                   ) : (
-                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationIntakeAdult' })}</p>
+                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
                   )}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -165,14 +162,10 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
               params={params}
               startIcon={sections.dentalBenefits.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalBenefits === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeAdult' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationIntakeAdult' })}`
-                  : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationIntakeAdult' })
-              }
+              aria-label={state.dentalBenefits === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}` : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit benefits click"
             >
-              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationIntakeAdult' })}
+              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -186,7 +179,7 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Continue click"
           >
-            {t(($) => $.dentalInsurance.submit, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.dentalInsurance.submit)}
           </NavigationButtonLink>
           <NavigationButtonLink
             variant="secondary"
@@ -195,7 +188,7 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back click"
           >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.dentalInsurance.contactInformation)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-adult/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpers/protected-application-intake-adult-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function NewAdultExitApplication({ loaderData, params }: Route.Co
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/intake-adult/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/intake-adult/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
@@ -8,6 +8,7 @@ import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpe
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -23,9 +24,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.maritalStatus,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -39,7 +39,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'protectedApplicationIntakeAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -62,30 +62,31 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationIntakeAdult' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'protectedApplicationIntakeAdult' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationIntakeAdult' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'protectedApplicationIntakeAdult' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'protectedApplicationIntakeAdult' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'protectedApplicationIntakeAdult' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'protectedApplicationIntakeAdult' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -102,7 +103,7 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'protectedApplicationIntakeAdult' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'protectedApplicationIntakeAdult' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -115,10 +116,10 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Continue click"
           >
-            {t(($) => $.maritalStatus.nextBtn, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.maritalStatus.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back click">
-            {t(($) => $.maritalStatus.prevBtn, { ns: 'protectedApplicationIntakeAdult' })}
+            {t(($) => $.maritalStatus.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationIntakeAdultStateForReview } from '~/.server/rou
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeAdult.submit,
-  pageTitleI18nKey: 'protectedApplicationIntakeAdult:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationIntakeAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const { ENABLED_FEATURES } = appContainer.get(TYPES.ClientConfig);
@@ -83,10 +83,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationIntakeAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationIntakeAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -114,75 +114,78 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationIntakeAdult' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationIntakeAdult' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationIntakeAdult' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationIntakeAdult' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationIntakeAdult' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationIntakeAdult' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationIntakeAdult' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationIntakeAdult' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationIntakeAdult' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationIntakeAdult' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationIntakeAdult' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/intake-adult/dental-insurance"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back click"
-                >
-                  {t(($) => $.submit.dentalInsurance, { ns: 'protectedApplicationIntakeAdult' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/intake-adult/dental-insurance"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Adult:Back click"
+                  >
+                    {t(($) => $.submit.dentalInsurance)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/intake-adult/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/intake-adult/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationIntakeAdult' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -12,6 +12,7 @@ import { loadProtectedApplicationIntakeChildState } from '~/.server/routes/helpe
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -35,7 +36,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb', 'common'),
   pageIdentifier: pageIds.protected.application.intakeChild.childApplication,
-  pageTitleI18nKey: 'protectedApplicationIntakeChild:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -154,6 +154,7 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -170,7 +171,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'protectedApplicationIntakeChild',
                 })}
               </h2>
               <div className="space-y-4">
@@ -189,7 +189,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'protectedApplicationIntakeChild',
                       })}
                     </h2>
                   </CardTitle>
@@ -223,7 +222,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'protectedApplicationIntakeChild',
                         })}
                   </ButtonLink>
                 </CardFooter>
@@ -261,7 +259,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                         ? `${t(($) => $.childrensApplication.addAnswer)} - ${t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}`
                         : t(($) => $.childrensApplication.editChildDentalInsurance, {
                             childNumber: index + 1,
-                            ns: 'protectedApplicationIntakeChild',
                           })
                     }
                   >
@@ -269,7 +266,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                       ? t(($) => $.childrensApplication.addAnswer)
                       : t(($) => $.childrensApplication.editChildDentalInsurance, {
                           childNumber: index + 1,
-                          ns: 'protectedApplicationIntakeChild',
                         })}
                   </ButtonLink>
                 </CardFooter>
@@ -317,7 +313,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                         ? `${t(($) => $.childrensApplication.addAnswer)} - ${t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}`
                         : t(($) => $.childrensApplication.editChildDentalBenefits, {
                             childNumber: index + 1,
-                            ns: 'protectedApplicationIntakeChild',
                           })
                     }
                   >
@@ -325,7 +320,6 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
                       ? t(($) => $.childrensApplication.addAnswer)
                       : t(($) => $.childrensApplication.editChildDentalBenefits, {
                           childNumber: index + 1,
-                          ns: 'protectedApplicationIntakeChild',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/protected/application/intake-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-children/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadProtectedApplicationIntakeChildState } from '~/.server/routes/helpe
 import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeChild.confirmation,
-  pageTitleI18nKey: 'protectedApplicationIntakeChild:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -185,252 +185,253 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
-        <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
+          <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
         <section className="space-y-8">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
               </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
             </DefinitionList>
-          </section>
+          </div>
 
-          {spouseInfo && (
+          <section className="space-y-8">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationIntakeChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationIntakeChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Close confirm modal click">
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Close confirm modal click">
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-children/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeChildState } from '~/.server/routes/helpers/protected-application-intake-child-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeChild.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationIntakeChild:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function ProtectedNewChildrenExitApplication({ loaderData, params
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/intake-children/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/intake-children/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
@@ -9,6 +9,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeChild.parentOrGuardian,
-  pageTitleI18nKey: 'protectedApplicationIntakeChild:parentOrGuardian.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -40,7 +40,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle, { ns: 'protectedApplicationIntakeChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -95,30 +95,31 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.maritalStatus, { ns: 'protectedApplicationIntakeChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.parentOrGuardian.selectYourStatus, { ns: 'protectedApplicationIntakeChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus, { ns: 'protectedApplicationIntakeChild' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin, { ns: 'protectedApplicationIntakeChild' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob, { ns: 'protectedApplicationIntakeChild' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.consent, { ns: 'protectedApplicationIntakeChild' })}>{t(($) => $.parentOrGuardian.consentYes, { ns: 'protectedApplicationIntakeChild' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.consent)}>{t(($) => $.parentOrGuardian.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -135,7 +136,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus, { ns: 'protectedApplicationIntakeChild' }) : t(($) => $.parentOrGuardian.editMaritalStatus, { ns: 'protectedApplicationIntakeChild' })}
+              {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus) : t(($) => $.parentOrGuardian.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -143,18 +144,18 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.phoneNumber, { ns: 'protectedApplicationIntakeChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber, { ns: 'protectedApplicationIntakeChild' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber, { ns: 'protectedApplicationIntakeChild' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.parentOrGuardian.phoneNumberHelp, { ns: 'protectedApplicationIntakeChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -168,7 +169,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber, { ns: 'protectedApplicationIntakeChild' }) : t(($) => $.parentOrGuardian.addPhoneNumber, { ns: 'protectedApplicationIntakeChild' })}
+              {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber) : t(($) => $.parentOrGuardian.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -176,16 +177,16 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress, { ns: 'protectedApplicationIntakeChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.parentOrGuardian.addressHelp, { ns: 'protectedApplicationIntakeChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress, { ns: 'protectedApplicationIntakeChild' })}>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -196,7 +197,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress, { ns: 'protectedApplicationIntakeChild' })}>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -221,7 +222,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress, { ns: 'protectedApplicationIntakeChild' }) : t(($) => $.parentOrGuardian.addAddress, { ns: 'protectedApplicationIntakeChild' })}
+              {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress) : t(($) => $.parentOrGuardian.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -229,18 +230,18 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.communicationPreferences, { ns: 'protectedApplicationIntakeChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationIntakeChild' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationIntakeChild' })}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -254,9 +255,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Edit comms click"
             >
-              {sections.communicationPreferences.completed
-                ? t(($) => $.parentOrGuardian.editCommunicationPreferences, { ns: 'protectedApplicationIntakeChild' })
-                : t(($) => $.parentOrGuardian.addCommunicationPreferences, { ns: 'protectedApplicationIntakeChild' })}
+              {sections.communicationPreferences.completed ? t(($) => $.parentOrGuardian.editCommunicationPreferences) : t(($) => $.parentOrGuardian.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -264,11 +263,11 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.email, { ns: 'protectedApplicationIntakeChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.email)}</h2>
             </CardTitle>
             <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
-          <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.parentOrGuardian.emailHelp, { ns: 'protectedApplicationIntakeChild' })}</p> : <p>{loaderData.state.email}</p>}</CardContent>
+          <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.parentOrGuardian.emailHelp)}</p> : <p>{loaderData.state.email}</p>}</CardContent>
           <CardFooter className="border-t bg-zinc-100">
             <ButtonLink
               id="edit-email-button"
@@ -280,7 +279,7 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Edit email click"
             >
-              {sections.email.completed ? t(($) => $.parentOrGuardian.editEmail, { ns: 'protectedApplicationIntakeChild' }) : t(($) => $.parentOrGuardian.addEmail, { ns: 'protectedApplicationIntakeChild' })}
+              {sections.email.completed ? t(($) => $.parentOrGuardian.editEmail) : t(($) => $.parentOrGuardian.addEmail)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -294,10 +293,10 @@ export default function ProtectedNewChildParentOrGuardian({ loaderData, params }
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Continue click"
           >
-            {t(($) => $.parentOrGuardian.childrensApplication, { ns: 'protectedApplicationIntakeChild' })}
+            {t(($) => $.parentOrGuardian.childrensApplication)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back click">
-            {t(($) => $.parentOrGuardian.yourApplication, { ns: 'protectedApplicationIntakeChild' })}
+            {t(($) => $.parentOrGuardian.yourApplication)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-children/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-children/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationIntakeChildStateForReview } from '~/.server/rou
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeChild.submit,
-  pageTitleI18nKey: 'protectedApplicationIntakeChild:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationIntakeChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -89,10 +89,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationIntakeChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationIntakeChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -122,77 +122,80 @@ export default function ProtectedNewChildrenSubmit({ loaderData, params }: Route
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationIntakeChild' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationIntakeChild' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationIntakeChild' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationIntakeChild' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationIntakeChild' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationIntakeChild' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationIntakeChild' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationIntakeChild' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationIntakeChild' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationIntakeChild' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationIntakeChild' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/intake-children/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'protectedApplicationIntakeChild' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/intake-children/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Child:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/intake-children/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/intake-children/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationIntakeChild' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -12,6 +12,7 @@ import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/help
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -35,7 +36,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb', 'common'),
   pageIdentifier: pageIds.protected.application.intakeFamily.childApplication,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -154,6 +154,7 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -170,7 +171,6 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'protectedApplicationIntakeFamily',
                 })}
               </h2>
               <div className="space-y-4">
@@ -189,7 +189,6 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'protectedApplicationIntakeFamily',
                       })}
                     </h2>
                   </CardTitle>
@@ -223,7 +222,6 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'protectedApplicationIntakeFamily',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/protected/application/intake-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-family/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/help
 import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.confirmation,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -201,273 +201,274 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
-        <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess)}</p>
+          <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationIntakeFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationIntakeFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Close confirm modal click">
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Close confirm modal click">
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-family/contact-information.tsx
@@ -10,6 +10,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.contactInformation,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -40,7 +40,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'protectedApplicationIntakeFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -92,27 +92,28 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="contactInformation" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationIntakeFamily' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationIntakeFamily' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -126,7 +127,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'protectedApplicationIntakeFamily' })}
+              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -134,16 +135,16 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.contactInformation.addressHelp, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.contactInformation.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationIntakeFamily' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -154,7 +155,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationIntakeFamily' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -179,7 +180,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.contactInformation.addAddress, { ns: 'protectedApplicationIntakeFamily' })}
+              {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -187,18 +188,18 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationIntakeFamily' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationIntakeFamily' })}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -212,9 +213,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit comms click"
             >
-              {sections.communicationPreferences.completed
-                ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'protectedApplicationIntakeFamily' })
-                : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'protectedApplicationIntakeFamily' })}
+              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -222,11 +221,11 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.email, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.email)}</h2>
             </CardTitle>
             <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
-          <CardContent>{state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp, { ns: 'protectedApplicationIntakeFamily' })}</p> : <p>{state.email}</p>}</CardContent>
+          <CardContent>{state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp)}</p> : <p>{state.email}</p>}</CardContent>
           <CardFooter className="border-t bg-zinc-100">
             <ButtonLink
               id="edit-email-button"
@@ -238,7 +237,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit email click"
             >
-              {sections.email.completed ? t(($) => $.contactInformation.editEmail, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.contactInformation.addEmail, { ns: 'protectedApplicationIntakeFamily' })}
+              {sections.email.completed ? t(($) => $.contactInformation.editEmail) : t(($) => $.contactInformation.addEmail)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -252,7 +251,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Continue click"
           >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.contactInformation.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink
             variant="secondary"
@@ -261,7 +260,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back click"
           >
-            {t(($) => $.contactInformation.prevBtn, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.contactInformation.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-family/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/intake-family/dental-insurance.tsx
@@ -8,6 +8,7 @@ import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/help
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -22,9 +23,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.dentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -39,7 +39,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'protectedApplicationIntakeFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram
@@ -83,27 +83,26 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalInsurance === undefined ? (
-              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'protectedApplicationIntakeFamily' })}>
-                  {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'protectedApplicationIntakeFamily' })}
-                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
               </DefinitionList>
             )}
           </CardContent>
@@ -116,14 +115,10 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
               params={params}
               startIcon={sections.dentalInsurance.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalInsurance === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeFamily' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationIntakeFamily' })}`
-                  : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationIntakeFamily' })
-              }
+              aria-label={state.dentalInsurance === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}` : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit insurance click"
             >
-              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationIntakeFamily' })}
+              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -131,29 +126,29 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalBenefits ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationIntakeFamily' })}>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
                   {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
                     <div className="space-y-3">
-                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationIntakeFamily' })}</p>
+                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                       <ul className="list-disc space-y-1 pl-7">
                         {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                         {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                       </ul>
                     </div>
                   ) : (
-                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationIntakeFamily' })}</p>
+                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
                   )}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -165,14 +160,10 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
               params={params}
               startIcon={sections.dentalBenefits.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalBenefits === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeFamily' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationIntakeFamily' })}`
-                  : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationIntakeFamily' })
-              }
+              aria-label={state.dentalBenefits === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}` : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit benefits click"
             >
-              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationIntakeFamily' })}
+              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -186,7 +177,7 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Continue click"
           >
-            {t(($) => $.dentalInsurance.childrensApplication, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.dentalInsurance.childrensApplication)}
           </NavigationButtonLink>
           <NavigationButtonLink
             variant="secondary"
@@ -195,7 +186,7 @@ export default function ProtectedNewFamilyDentalInsurance({ loaderData, params }
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back click"
           >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.dentalInsurance.contactInformation)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-family/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/helpers/protected-application-intake-family-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function ProtectedNewFamilyExitApplication({ loaderData, params }
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/intake-family/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/intake-family/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/intake-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-family/marital-status.tsx
@@ -8,6 +8,7 @@ import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/help
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/protected-application-intake-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -23,9 +24,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.maritalStatus,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -39,7 +39,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'protectedApplicationIntakeFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -62,30 +62,31 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationIntakeFamily' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'protectedApplicationIntakeFamily' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationIntakeFamily' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'protectedApplicationIntakeFamily' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'protectedApplicationIntakeFamily' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'protectedApplicationIntakeFamily' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'protectedApplicationIntakeFamily' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -102,7 +103,7 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'protectedApplicationIntakeFamily' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'protectedApplicationIntakeFamily' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -115,10 +116,10 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Continue click"
           >
-            {t(($) => $.maritalStatus.contactInformation, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.maritalStatus.contactInformation)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back click">
-            {t(($) => $.maritalStatus.yourApplication, { ns: 'protectedApplicationIntakeFamily' })}
+            {t(($) => $.maritalStatus.yourApplication)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/intake-family/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-family/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationIntakeFamilyStateForReview } from '~/.server/ro
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationIntakeFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.intakeFamily.submit,
-  pageTitleI18nKey: 'protectedApplicationIntakeFamily:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationIntakeFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -90,10 +90,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationIntakeFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationIntakeFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -123,78 +123,81 @@ export default function ProtectedNewFamilySubmit({ loaderData, params }: Route.C
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationIntakeFamily' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationIntakeFamily' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationIntakeFamily' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationIntakeFamily' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationIntakeFamily' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationIntakeFamily' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationIntakeFamily' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationIntakeFamily' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationIntakeFamily' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationIntakeFamily' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationIntakeFamily' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/intake-family/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back click"
-                >
-                  {t(($) => $.submit.childrenApplication, { ns: 'protectedApplicationIntakeFamily' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/intake-family/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Intake_Family:Back click"
+                  >
+                    {t(($) => $.submit.childrenApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/intake-family/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/intake-family/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationIntakeFamily' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -19,6 +19,7 @@ import {
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -39,7 +40,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.confirmation,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -184,236 +184,239 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
   const cdcpLink = <InlineLink to={t(($) => $.confirm.statusCheckerLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose space-y-10">
-      {isSimplifiedRenewal && (
-        <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-          <DefinitionList border>
-            <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
-              <Eligibility type={eligibility} />
-            </DefinitionListItem>
-          </DefinitionList>
-        </section>
-      )}
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
-        <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
-          </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      {!isSimplifiedRenewal && (
-        <>
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
-            <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
-          </section>
-
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-            <p className="mt-4">
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-            </p>
-            <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-          </section>
-        </>
-      )}
-      {isSimplifiedRenewal && (
-        <section>
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
-          <p className="mt-4">
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-          </p>
-        </section>
-      )}
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
-
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        {isSimplifiedRenewal && (
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
+            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
             <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+              <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
+                <Eligibility type={eligibility} />
               </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
             </DefinitionList>
           </section>
+        )}
+        <div className="space-y-4">
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+          </h2>
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        {!isSimplifiedRenewal && (
+          <>
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
+              <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
+            </section>
 
-          {spouseInfo && (
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+              <p className="mt-4">
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+              </p>
+              <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+            </section>
+          </>
+        )}
+        {isSimplifiedRenewal && (
+          <section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
+            <p className="mt-4">
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+            </p>
+          </section>
+        )}
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
+
+          <section className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.phoneNumber && (
-                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
-                </DefinitionListItem>
-              )}
-              {userInfo.altPhoneNumber && (
-                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
-                </DefinitionListItem>
-              )}
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
+              </section>
+            )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                {userInfo.phoneNumber && (
+                  <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                    <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                  </DefinitionListItem>
                 )}
-              </DefinitionListItem>
-            </DefinitionList>
+                {userInfo.altPhoneNumber && (
+                  <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                    <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
+                  </DefinitionListItem>
+                )}
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
           </section>
         </section>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </div>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Close confirm modal click">
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Close confirm modal click">
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/contact-information.tsx
@@ -15,6 +15,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -36,9 +37,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.contactInformation,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -52,7 +52,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'protectedApplicationRenewalAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -214,101 +214,104 @@ export default function ProtectedRenewAdultContactInformation({ loaderData, para
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="contactInformation" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
-          <p>{t(($) => $.confirmInformation)}</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
+    <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="contactInformation" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
+            <p>{completedSectionsLabel}</p>
+            <p>{t(($) => $.confirmInformation, { ns: 'protectedApplication' })}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
+              </CardTitle>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.email, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp, { ns: 'protectedApplicationRenewalAdult' })}</p> : <p>{loaderData.state.email}</p>}</CardContent>
-          <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink
-              id="edit-email-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/email"
-              params={params}
-              startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit email click"
-            >
-              {sections.email.completed ? t(($) => $.contactInformation.editEmail, { ns: 'protectedApplicationRenewalAdult' }) : t(($) => $.contactInformation.addEmail, { ns: 'protectedApplicationRenewalAdult' })}
-            </ButtonLink>
-          </CardFooter>
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.email)}</h2>
+              </CardTitle>
+              <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp)}</p> : <p>{loaderData.state.email}</p>}</CardContent>
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink
+                id="edit-email-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/email"
+                params={params}
+                startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit email click"
+              >
+                {sections.email.completed ? t(($) => $.contactInformation.editEmail) : t(($) => $.contactInformation.addEmail)}
+              </ButtonLink>
+            </CardFooter>
+          </Card>
 
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="protected/application/$id/renewal-adult/dental-insurance"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Continue click"
-          >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'protectedApplicationRenewalAdult' })}
-          </NavigationButtonLink>
-          {shouldSkipMaritalStatusStep ? (
-            <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click">
-              {t(($) => $.contactInformation.prevBtn.renew, { ns: 'protectedApplicationRenewalAdult' })}
-            </NavigationButtonLink>
-          ) : (
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <NavigationButtonLink
-              variant="secondary"
-              direction="previous"
-              routeId="protected/application/$id/renewal-adult/marital-status"
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="protected/application/$id/renewal-adult/dental-insurance"
               params={params}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Continue click"
             >
-              {t(($) => $.contactInformation.prevBtn.maritalStatus, { ns: 'protectedApplicationRenewalAdult' })}
+              {t(($) => $.contactInformation.nextBtn)}
             </NavigationButtonLink>
-          )}
+            {shouldSkipMaritalStatusStep ? (
+              <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click">
+                {t(($) => $.contactInformation.prevBtn.renew)}
+              </NavigationButtonLink>
+            ) : (
+              <NavigationButtonLink
+                variant="secondary"
+                direction="previous"
+                routeId="protected/application/$id/renewal-adult/marital-status"
+                params={params}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
+              >
+                {t(($) => $.contactInformation.prevBtn.maritalStatus)}
+              </NavigationButtonLink>
+            )}
+          </div>
         </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -336,8 +339,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalAdult' })}>{state.phoneNumber.primary}</DefinitionListItem>
-          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationRenewalAdult' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -347,8 +350,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalAdult' })}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
-          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationRenewalAdult' })}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
+          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -356,7 +359,7 @@ function PhoneNumberCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'protectedApplicationRenewalAdult' })}</p>
+      <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -398,7 +401,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit phone click"
         >
-          {t(($) => $.contactInformation.editPhoneNumber, { ns: 'protectedApplicationRenewalAdult' })}
+          {t(($) => $.contactInformation.editPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -418,7 +421,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Update phone click"
           >
-            {t(($) => $.contactInformation.updatePhoneNumber, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.contactInformation.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -432,7 +435,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged, { ns: 'protectedApplicationRenewalAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -451,7 +454,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Add phone click"
       >
-        {t(($) => $.contactInformation.addPhoneNumber, { ns: 'protectedApplicationRenewalAdult' })}
+        {t(($) => $.contactInformation.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -483,7 +486,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
             <Address
               address={{
                 address: state.mailingAddress.address,
@@ -494,7 +497,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
             <Address
               address={{
                 address: state.homeAddress.address,
@@ -514,7 +517,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
             <Address
               address={{
                 address: clientApplication.mailingAddress.address,
@@ -525,7 +528,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
             <Address
               address={{
                 address: clientApplication.homeAddress.address,
@@ -543,7 +546,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.addressHelp, { ns: 'protectedApplicationRenewalAdult' })}</p>
+      <p>{t(($) => $.contactInformation.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -587,7 +590,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit address click"
         >
-          {t(($) => $.contactInformation.editAddress, { ns: 'protectedApplicationRenewalAdult' })}
+          {t(($) => $.contactInformation.editAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -607,7 +610,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Update address click"
           >
-            {t(($) => $.contactInformation.updateAddress, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.contactInformation.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -621,7 +624,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Complete address click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged, { ns: 'protectedApplicationRenewalAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -640,7 +643,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Add address click"
       >
-        {t(($) => $.contactInformation.addAddress, { ns: 'protectedApplicationRenewalAdult' })}
+        {t(($) => $.contactInformation.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -672,8 +675,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationRenewalAdult' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationRenewalAdult' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -683,8 +686,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationRenewalAdult' })}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationRenewalAdult' })}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -692,7 +695,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationRenewalAdult' })}</p>
+      <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -735,7 +738,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit comms click"
         >
-          {t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'protectedApplicationRenewalAdult' })}
+          {t(($) => $.contactInformation.editCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -755,7 +758,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Update comms click"
           >
-            {t(($) => $.contactInformation.updateCommunicationPreferences, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.contactInformation.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -769,7 +772,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged, { ns: 'protectedApplicationRenewalAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -788,7 +791,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Add comms click"
       >
-        {t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'protectedApplicationRenewalAdult' })}
+        {t(($) => $.contactInformation.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
@@ -15,6 +15,7 @@ import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } f
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -34,9 +35,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.dentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'protectedApplicationRenewalAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
@@ -160,60 +160,63 @@ export default function ProtectedRenewAdultDentalInsurance({ loaderData, params 
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="dentalInsurance" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="dentalInsurance" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalInsuranceCardContent />
+            <DentalInsuranceCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalBenefitsCardContent />
+            <DentalBenefitsCardFooter />
+          </Card>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="protected/application/$id/renewal-adult/submit"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Continue click"
+            >
+              {t(($) => $.dentalInsurance.submit)}
+            </NavigationButtonLink>
+            <NavigationButtonLink
+              variant="secondary"
+              direction="previous"
+              routeId="protected/application/$id/renewal-adult/contact-information"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
+            >
+              {t(($) => $.dentalInsurance.contactInformation)}
+            </NavigationButtonLink>
+          </div>
         </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalInsuranceCardContent />
-          <DentalInsuranceCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalBenefitsCardContent />
-          <DentalBenefitsCardFooter />
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="protected/application/$id/renewal-adult/submit"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Continue click"
-          >
-            {t(($) => $.dentalInsurance.submit, { ns: 'protectedApplicationRenewalAdult' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink
-            variant="secondary"
-            direction="previous"
-            routeId="protected/application/$id/renewal-adult/contact-information"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
-          >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'protectedApplicationRenewalAdult' })}
-          </NavigationButtonLink>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -237,9 +240,7 @@ function DentalInsuranceCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'protectedApplicationRenewalAdult' })}>
-            {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'protectedApplicationRenewalAdult' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'protectedApplicationRenewalAdult' })}
-          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -247,7 +248,7 @@ function DentalInsuranceCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'protectedApplicationRenewalAdult' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -280,7 +281,7 @@ function DentalInsuranceCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit button dental insurance click"
         >
-          {t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationRenewalAdult' })}
+          {t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
         </ButtonLink>
       </CardFooter>
     );
@@ -297,9 +298,9 @@ function DentalInsuranceCardFooter(): JSX.Element {
         startIcon={faCirclePlus}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Add button dental insurance click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalAdult' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationRenewalAdult' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalAdult' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );
@@ -326,17 +327,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationRenewalAdult' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                   {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationRenewalAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -348,17 +349,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationRenewalAdult' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {clientApplication.dentalBenefits.hasFederalBenefits || clientApplication.dentalBenefits.hasProvincialTerritorialBenefits ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationRenewalAdult' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {clientApplication.dentalBenefits.hasFederalBenefits && <li>{clientApplication.dentalBenefits.federalSocialProgram}</li>}
                   {clientApplication.dentalBenefits.hasProvincialTerritorialBenefits && <li>{clientApplication.dentalBenefits.provincialTerritorialSocialProgram}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationRenewalAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -368,7 +369,7 @@ function DentalBenefitsCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'protectedApplicationRenewalAdult' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -403,7 +404,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit button government benefits click"
         >
-          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationRenewalAdult' })}
+          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
         </ButtonLink>
       </CardFooter>
     );
@@ -423,7 +424,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Update button government benefits click"
           >
-            {t(($) => $.dentalInsurance.updateMyAccess, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.dentalInsurance.updateMyAccess)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -437,7 +438,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Complete benefits click"
           >
-            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged, { ns: 'protectedApplicationRenewalAdult' })}</span>
+            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -455,9 +456,9 @@ function DentalBenefitsCardFooter(): JSX.Element {
         startIcon={faPenToSquare}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Add button dental benefits click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalAdult' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationRenewalAdult' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalAdult' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/protected/application/renewal-adult/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalAdultState } from '~/.server/routes/helpers/protected-application-renewal-adult-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function ProtectedNewAdultExitApplication({ loaderData, params }:
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/renewal-adult/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/renewal-adult/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
@@ -10,6 +10,7 @@ import { loadProtectedApplicationRenewalAdultState } from '~/.server/routes/help
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -26,9 +27,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.maritalStatus,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'protectedApplicationRenewalAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -69,30 +69,31 @@ export default function ProtectedNewAdultMaritalStatus({ loaderData, params }: R
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationRenewalAdult' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'protectedApplicationRenewalAdult' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationRenewalAdult' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'protectedApplicationRenewalAdult' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'protectedApplicationRenewalAdult' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'protectedApplicationRenewalAdult' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'protectedApplicationRenewalAdult' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -109,7 +110,7 @@ export default function ProtectedNewAdultMaritalStatus({ loaderData, params }: R
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'protectedApplicationRenewalAdult' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'protectedApplicationRenewalAdult' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -122,10 +123,10 @@ export default function ProtectedNewAdultMaritalStatus({ loaderData, params }: R
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Continue click"
           >
-            {t(($) => $.maritalStatus.nextBtn, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.maritalStatus.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click">
-            {t(($) => $.maritalStatus.prevBtn, { ns: 'protectedApplicationRenewalAdult' })}
+            {t(($) => $.maritalStatus.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/renewal-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationRenewalAdultStateForReview } from '~/.server/ro
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalAdult.submit,
-  pageTitleI18nKey: 'protectedApplicationRenewalAdult:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationRenewalAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const { ENABLED_FEATURES } = appContainer.get(TYPES.ClientConfig);
@@ -86,10 +86,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationRenewalAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationRenewalAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -118,75 +118,78 @@ export default function ProtectedNewAdultSubmit({ loaderData, params }: Route.Co
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationRenewalAdult' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationRenewalAdult' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationRenewalAdult' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationRenewalAdult' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationRenewalAdult' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationRenewalAdult' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationRenewalAdult' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationRenewalAdult' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationRenewalAdult' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/renewal-adult/dental-insurance"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
-                >
-                  {t(($) => $.submit.dentalInsurance, { ns: 'protectedApplicationRenewalAdult' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/renewal-adult/dental-insurance"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Adult:Back click"
+                  >
+                    {t(($) => $.submit.dentalInsurance)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/renewal-adult/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/renewal-adult/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationRenewalAdult' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
@@ -15,6 +15,7 @@ import { loadProtectedApplicationRenewalChildState } from '~/.server/routes/help
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildParentGuardianSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -47,7 +48,6 @@ const FORM_ACTION = { DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed'
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb', 'common'),
   pageIdentifier: pageIds.protected.application.renewalChild.childApplication,
-  pageTitleI18nKey: 'protectedApplicationRenewalChild:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -196,6 +196,7 @@ export default function ProtectedRenewChildChildrensApplication({ loaderData, pa
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child) => {

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -20,6 +20,7 @@ import {
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -40,7 +41,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalChild.confirmation,
-  pageTitleI18nKey: 'protectedApplicationRenewalChild:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -217,269 +217,270 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      {isSimplifiedRenewal && (
-        <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-          {children.map((child) => (
-            <DefinitionList border key={child.id}>
-              <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
-                <Eligibility type={child.eligibility} />
-              </DefinitionListItem>
-            </DefinitionList>
-          ))}
-        </section>
-      )}
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
-        <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
-          </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      {!isSimplifiedRenewal && (
-        <>
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
-            <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
-          </section>
-
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-            <p className="mt-4">
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-            </p>
-            <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-          </section>
-        </>
-      )}
-      {isSimplifiedRenewal && (
-        <section>
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
-          <p className="mt-4">
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-          </p>
-        </section>
-      )}
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-8">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
-
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        {isSimplifiedRenewal && (
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
+            {children.map((child) => (
+              <DefinitionList border key={child.id}>
+                <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
+                  <Eligibility type={child.eligibility} />
+                </DefinitionListItem>
+              </DefinitionList>
+            ))}
+          </section>
+        )}
+        <div className="space-y-4">
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+          </h2>
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        {!isSimplifiedRenewal && (
+          <>
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
+              <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
+            </section>
+
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+              <p className="mt-4">
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+              </p>
+              <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+            </section>
+          </>
+        )}
+        {isSimplifiedRenewal && (
+          <section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
+            <p className="mt-4">
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+            </p>
+          </section>
+        )}
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
               </DefinitionListItem>
             </DefinitionList>
-          </section>
+          </div>
 
-          {spouseInfo && (
+          <section className="space-y-8">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationRenewalChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationRenewalChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-children/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalChildState } from '~/.server/routes/helpers/protected-application-renewal-child-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalChild.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationRenewalChild:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function ProtectedRenewChildrenExitApplication({ loaderData, para
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/renewal-children/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/renewal-children/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
@@ -15,6 +15,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -37,9 +38,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalChild.parentOrGuardian,
-  pageTitleI18nKey: 'protectedApplicationRenewalChild:parentOrGuardian.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -53,7 +53,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle, { ns: 'protectedApplicationRenewalChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -221,131 +221,134 @@ export default function ProtectedRenewChildParentOrGuardian({ loaderData, params
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
-          <p>{t(($) => $.confirmInformation)}</p>
-        </div>
+    <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
+            <p>{completedSectionsLabel}</p>
+            <p>{t(($) => $.confirmInformation, { ns: 'protectedApplication' })}</p>
+          </div>
 
-        {!shouldSkipMaritalStatusStep && (
+          {!shouldSkipMaritalStatusStep && (
+            <Card>
+              <CardHeader>
+                <CardTitle asChild>
+                  <h2>{t(($) => $.parentOrGuardian.maritalStatus)}</h2>
+                </CardTitle>
+                <CardAction>{sections.maritalStatus?.completed && <StatusTag status="complete" />}</CardAction>
+              </CardHeader>
+              <CardContent>
+                {state.maritalStatus === undefined ? (
+                  <p>{t(($) => $.parentOrGuardian.selectYourStatus)}</p>
+                ) : (
+                  <DefinitionList layout="single-column">
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
+                    {state.partnerInformation && (
+                      <>
+                        <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                        <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                        <DefinitionListItem term={t(($) => $.parentOrGuardian.consent)}>{t(($) => $.parentOrGuardian.consentYes)}</DefinitionListItem>
+                      </>
+                    )}
+                  </DefinitionList>
+                )}
+              </CardContent>
+              <CardFooter className="border-t bg-zinc-100">
+                <ButtonLink
+                  id="edit-marital-button"
+                  variant="link"
+                  className="p-0"
+                  routeId="protected/application/$id/marital-status"
+                  params={params}
+                  startIcon={sections.maritalStatus?.completed ? faPenToSquare : faCirclePlus}
+                  size="lg"
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit marital click"
+                >
+                  {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus) : t(($) => $.parentOrGuardian.editMaritalStatus)}
+                </ButtonLink>
+              </CardFooter>
+            </Card>
+          )}
+
           <Card>
             <CardHeader>
               <CardTitle asChild>
-                <h2>{t(($) => $.parentOrGuardian.maritalStatus, { ns: 'protectedApplicationRenewalChild' })}</h2>
+                <h2>{t(($) => $.parentOrGuardian.phoneNumber)}</h2>
               </CardTitle>
-              <CardAction>{sections.maritalStatus?.completed && <StatusTag status="complete" />}</CardAction>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
             </CardHeader>
-            <CardContent>
-              {state.maritalStatus === undefined ? (
-                <p>{t(($) => $.parentOrGuardian.selectYourStatus, { ns: 'protectedApplicationRenewalChild' })}</p>
-              ) : (
-                <DefinitionList layout="single-column">
-                  <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus, { ns: 'protectedApplicationRenewalChild' })}>{state.maritalStatus.name}</DefinitionListItem>
-                  {state.partnerInformation && (
-                    <>
-                      <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin, { ns: 'protectedApplicationRenewalChild' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                      <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob, { ns: 'protectedApplicationRenewalChild' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                      <DefinitionListItem term={t(($) => $.parentOrGuardian.consent, { ns: 'protectedApplicationRenewalChild' })}>{t(($) => $.parentOrGuardian.consentYes, { ns: 'protectedApplicationRenewalChild' })}</DefinitionListItem>
-                    </>
-                  )}
-                </DefinitionList>
-              )}
-            </CardContent>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.email)}</h2>
+              </CardTitle>
+              <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.parentOrGuardian.emailHelp)}</p> : <p>{loaderData.state.email}</p>}</CardContent>
             <CardFooter className="border-t bg-zinc-100">
               <ButtonLink
-                id="edit-marital-button"
+                id="edit-email-button"
                 variant="link"
                 className="p-0"
-                routeId="protected/application/$id/marital-status"
+                routeId="protected/application/$id/email"
                 params={params}
-                startIcon={sections.maritalStatus?.completed ? faPenToSquare : faCirclePlus}
+                startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
                 size="lg"
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit marital click"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit email click"
               >
-                {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus, { ns: 'protectedApplicationRenewalChild' }) : t(($) => $.parentOrGuardian.editMaritalStatus, { ns: 'protectedApplicationRenewalChild' })}
+                {sections.email.completed ? t(($) => $.parentOrGuardian.editEmail) : t(($) => $.parentOrGuardian.addEmail)}
               </ButtonLink>
             </CardFooter>
           </Card>
-        )}
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.phoneNumber, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.communicationPreferences, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.email, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.parentOrGuardian.emailHelp, { ns: 'protectedApplicationRenewalChild' })}</p> : <p>{loaderData.state.email}</p>}</CardContent>
-          <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink
-              id="edit-email-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/email"
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="protected/application/$id/renewal-children/childrens-application"
               params={params}
-              startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit email click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Continue click"
             >
-              {sections.email.completed ? t(($) => $.parentOrGuardian.editEmail, { ns: 'protectedApplicationRenewalChild' }) : t(($) => $.parentOrGuardian.addEmail, { ns: 'protectedApplicationRenewalChild' })}
-            </ButtonLink>
-          </CardFooter>
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="protected/application/$id/renewal-children/childrens-application"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Continue click"
-          >
-            {t(($) => $.parentOrGuardian.nextBtn, { ns: 'protectedApplicationRenewalChild' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back click">
-            {t(($) => $.parentOrGuardian.prevBtn, { ns: 'protectedApplicationRenewalChild' })}
-          </NavigationButtonLink>
+              {t(($) => $.parentOrGuardian.nextBtn)}
+            </NavigationButtonLink>
+            <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back click">
+              {t(($) => $.parentOrGuardian.prevBtn)}
+            </NavigationButtonLink>
+          </div>
         </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -373,8 +376,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber, { ns: 'protectedApplicationRenewalChild' })}>{state.phoneNumber.primary}</DefinitionListItem>
-          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber, { ns: 'protectedApplicationRenewalChild' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -384,8 +387,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
-          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber)}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
+          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber)}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -393,7 +396,7 @@ function PhoneNumberCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.phoneNumberHelp, { ns: 'protectedApplicationRenewalChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -435,7 +438,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit phone click"
         >
-          {t(($) => $.parentOrGuardian.editPhoneNumber, { ns: 'protectedApplicationRenewalChild' })}
+          {t(($) => $.parentOrGuardian.editPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -455,7 +458,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Update phone click"
           >
-            {t(($) => $.parentOrGuardian.updatePhoneNumber, { ns: 'protectedApplicationRenewalChild' })}
+            {t(($) => $.parentOrGuardian.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -469,7 +472,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.phoneNumberUnchanged, { ns: 'protectedApplicationRenewalChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -488,7 +491,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Add phone click"
       >
-        {t(($) => $.parentOrGuardian.addPhoneNumber, { ns: 'protectedApplicationRenewalChild' })}
+        {t(($) => $.parentOrGuardian.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -520,7 +523,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress, { ns: 'protectedApplicationRenewalChild' })}>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress)}>
             <Address
               address={{
                 address: state.mailingAddress.address,
@@ -531,7 +534,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress, { ns: 'protectedApplicationRenewalChild' })}>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress)}>
             <Address
               address={{
                 address: state.homeAddress.address,
@@ -551,7 +554,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress, { ns: 'protectedApplicationRenewalChild' })}>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress)}>
             <Address
               address={{
                 address: clientApplication.mailingAddress.address,
@@ -562,7 +565,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress, { ns: 'protectedApplicationRenewalChild' })}>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress)}>
             <Address
               address={{
                 address: clientApplication.homeAddress.address,
@@ -580,7 +583,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.addressHelp, { ns: 'protectedApplicationRenewalChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -624,7 +627,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit address click"
         >
-          {t(($) => $.parentOrGuardian.editAddress, { ns: 'protectedApplicationRenewalChild' })}
+          {t(($) => $.parentOrGuardian.editAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -644,7 +647,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Update address click"
           >
-            {t(($) => $.parentOrGuardian.updateAddress, { ns: 'protectedApplicationRenewalChild' })}
+            {t(($) => $.parentOrGuardian.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -658,7 +661,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Complete address click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.addressUnchanged, { ns: 'protectedApplicationRenewalChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -677,7 +680,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Add address click"
       >
-        {t(($) => $.parentOrGuardian.addAddress, { ns: 'protectedApplicationRenewalChild' })}
+        {t(($) => $.parentOrGuardian.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -709,8 +712,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationRenewalChild' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationRenewalChild' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -720,8 +723,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'protectedApplicationRenewalChild' })}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>{' '}
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage)}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod)}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>{' '}
         </DefinitionList>
       </CardContent>
     );
@@ -729,7 +732,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp, { ns: 'protectedApplicationRenewalChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -772,7 +775,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Edit comms click"
         >
-          {t(($) => $.parentOrGuardian.editCommunicationPreferences, { ns: 'protectedApplicationRenewalChild' })}
+          {t(($) => $.parentOrGuardian.editCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -792,7 +795,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Update comms click"
           >
-            {t(($) => $.parentOrGuardian.updateCommunicationPreferences, { ns: 'protectedApplicationRenewalChild' })}
+            {t(($) => $.parentOrGuardian.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -806,7 +809,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.communicationPreferencesUnchanged, { ns: 'protectedApplicationRenewalChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.communicationPreferencesUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -825,7 +828,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Add comms click"
       >
-        {t(($) => $.parentOrGuardian.addCommunicationPreferences, { ns: 'protectedApplicationRenewalChild' })}
+        {t(($) => $.parentOrGuardian.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/protected/application/renewal-children/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationRenewalChildStateForReview } from '~/.server/ro
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalChild.submit,
-  pageTitleI18nKey: 'protectedApplicationRenewalChild:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationRenewalChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -90,10 +90,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationRenewalChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationRenewalChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -124,77 +124,80 @@ export default function ProtectedRenewChildrenSubmit({ loaderData, params }: Rou
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationRenewalChild' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationRenewalChild' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationRenewalChild' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationRenewalChild' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationRenewalChild' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationRenewalChild' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationRenewalChild' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationRenewalChild' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationRenewalChild' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/renewal-children/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'protectedApplicationRenewalChild' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/renewal-children/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Child:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/renewal-children/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/renewal-children/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationRenewalChild' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
@@ -15,6 +15,7 @@ import { loadProtectedApplicationRenewalFamilyState } from '~/.server/routes/hel
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildParentGuardianSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -47,7 +48,6 @@ const FORM_ACTION = { DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed'
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb', 'common'),
   pageIdentifier: pageIds.protected.application.renewalFamily.childApplication,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -196,6 +196,7 @@ export default function ProtectedRenewFamilyChildrensApplication({ loaderData, p
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child) => {

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -21,6 +21,7 @@ import {
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -41,7 +42,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.confirmation,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -234,290 +234,291 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      {isSimplifiedRenewal && (
-        <section className="space-y-6">
-          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-          <DefinitionList border>
-            <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
-              <Eligibility type={eligibility} />
-            </DefinitionListItem>
-          </DefinitionList>
-          {children.map((child) => (
-            <DefinitionList key={child.id}>
-              <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
-                <Eligibility type={child.eligibility} />
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        {isSimplifiedRenewal && (
+          <section className="space-y-6">
+            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
+            <DefinitionList border>
+              <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
+                <Eligibility type={eligibility} />
               </DefinitionListItem>
             </DefinitionList>
-          ))}
-        </section>
-      )}
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+            {children.map((child) => (
+              <DefinitionList key={child.id}>
+                <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
+                  <Eligibility type={child.eligibility} />
+                </DefinitionListItem>
+              </DefinitionList>
+            ))}
+          </section>
+        )}
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
+          <p>{t(($) => $.confirm.makeNote)}</p>
         </div>
-      </ContextualAlert>
-      {!isSimplifiedRenewal && (
-        <>
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
-            <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
-          </section>
-
-          <section>
-            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-            <p className="mt-4">
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-            </p>
-            <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-          </section>
-        </>
-      )}
-      {isSimplifiedRenewal && (
         <section>
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
-          <p className="mt-4">
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-          </p>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </section>
-      )}
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        {!isSimplifiedRenewal && (
+          <>
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.fullWhatsNext)}</h2>
+              <p className="mt-4">{t(($) => $.confirm.fullBeginProcess)}</p>
+            </section>
 
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+            <section>
+              <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+              <p className="mt-4">
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+              </p>
+              <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+            </section>
+          </>
+        )}
+        {isSimplifiedRenewal && (
+          <section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.simplifiedWhatsNext)}</h2>
+            <p className="mt-4">
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.simplifiedBeginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+            </p>
+          </section>
+        )}
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationRenewalFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'protectedApplicationRenewalFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Close confirm modal click">
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button id="confirm-modal-close" variant="primary" size="sm" onClick={() => removeApplicationFlowStorageValue()} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Close confirm modal click">
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/contact-information.tsx
@@ -15,6 +15,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -36,9 +37,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.contactInformation,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -52,7 +52,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'protectedApplicationRenewalFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -214,101 +214,104 @@ export default function ProtectedRenewFamilyContactInformation({ loaderData, par
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="contactInformation" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
-          <p>{t(($) => $.confirmInformation)}</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
+    <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="contactInformation" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
+            <p>{completedSectionsLabel}</p>
+            <p>{t(($) => $.confirmInformation, { ns: 'protectedApplication' })}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
+              </CardTitle>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.email, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp, { ns: 'protectedApplicationRenewalFamily' })}</p> : <p>{loaderData.state.email}</p>}</CardContent>
-          <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink
-              id="edit-email-button"
-              variant="link"
-              className="p-0"
-              routeId="protected/application/$id/email"
-              params={params}
-              startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit email click"
-            >
-              {sections.email.completed ? t(($) => $.contactInformation.editEmail, { ns: 'protectedApplicationRenewalFamily' }) : t(($) => $.contactInformation.addEmail, { ns: 'protectedApplicationRenewalFamily' })}
-            </ButtonLink>
-          </CardFooter>
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.email)}</h2>
+              </CardTitle>
+              <CardAction>{sections.email.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CardContent>{loaderData.state.email === undefined ? <p>{t(($) => $.contactInformation.emailHelp)}</p> : <p>{loaderData.state.email}</p>}</CardContent>
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink
+                id="edit-email-button"
+                variant="link"
+                className="p-0"
+                routeId="protected/application/$id/email"
+                params={params}
+                startIcon={sections.email.completed ? faPenToSquare : faCirclePlus}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit email click"
+              >
+                {sections.email.completed ? t(($) => $.contactInformation.editEmail) : t(($) => $.contactInformation.addEmail)}
+              </ButtonLink>
+            </CardFooter>
+          </Card>
 
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="protected/application/$id/renewal-family/dental-insurance"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Continue click"
-          >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'protectedApplicationRenewalFamily' })}
-          </NavigationButtonLink>
-          {shouldSkipMaritalStatusStep ? (
-            <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click">
-              {t(($) => $.contactInformation.prevBtn.renew, { ns: 'protectedApplicationRenewalFamily' })}
-            </NavigationButtonLink>
-          ) : (
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
             <NavigationButtonLink
-              variant="secondary"
-              direction="previous"
-              routeId="protected/application/$id/renewal-family/marital-status"
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="protected/application/$id/renewal-family/dental-insurance"
               params={params}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Continue click"
             >
-              {t(($) => $.contactInformation.prevBtn.maritalStatus, { ns: 'protectedApplicationRenewalFamily' })}
+              {t(($) => $.contactInformation.nextBtn)}
             </NavigationButtonLink>
-          )}
+            {shouldSkipMaritalStatusStep ? (
+              <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click">
+                {t(($) => $.contactInformation.prevBtn.renew)}
+              </NavigationButtonLink>
+            ) : (
+              <NavigationButtonLink
+                variant="secondary"
+                direction="previous"
+                routeId="protected/application/$id/renewal-family/marital-status"
+                params={params}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
+              >
+                {t(($) => $.contactInformation.prevBtn.maritalStatus)}
+              </NavigationButtonLink>
+            )}
+          </div>
         </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -336,8 +339,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalFamily' })}>{state.phoneNumber.primary}</DefinitionListItem>
-          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationRenewalFamily' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+          {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -347,8 +350,8 @@ function PhoneNumberCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'protectedApplicationRenewalFamily' })}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
-          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'protectedApplicationRenewalFamily' })}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
+          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{clientApplication.phoneNumber.primary}</DefinitionListItem>
+          {clientApplication.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{clientApplication.phoneNumber.alternate}</DefinitionListItem>}
         </DefinitionList>
       </CardContent>
     );
@@ -356,7 +359,7 @@ function PhoneNumberCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'protectedApplicationRenewalFamily' })}</p>
+      <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -398,7 +401,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit phone click"
         >
-          {t(($) => $.contactInformation.editPhoneNumber, { ns: 'protectedApplicationRenewalFamily' })}
+          {t(($) => $.contactInformation.editPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -418,7 +421,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Update phone click"
           >
-            {t(($) => $.contactInformation.updatePhoneNumber, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.contactInformation.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -432,7 +435,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged, { ns: 'protectedApplicationRenewalFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -451,7 +454,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Add phone click"
       >
-        {t(($) => $.contactInformation.addPhoneNumber, { ns: 'protectedApplicationRenewalFamily' })}
+        {t(($) => $.contactInformation.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -483,7 +486,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
             <Address
               address={{
                 address: state.mailingAddress.address,
@@ -494,7 +497,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
             <Address
               address={{
                 address: state.homeAddress.address,
@@ -514,7 +517,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
             <Address
               address={{
                 address: clientApplication.mailingAddress.address,
@@ -525,7 +528,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
               }}
             />
           </DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
             <Address
               address={{
                 address: clientApplication.homeAddress.address,
@@ -543,7 +546,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.addressHelp, { ns: 'protectedApplicationRenewalFamily' })}</p>
+      <p>{t(($) => $.contactInformation.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -587,7 +590,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit address click"
         >
-          {t(($) => $.contactInformation.editAddress, { ns: 'protectedApplicationRenewalFamily' })}
+          {t(($) => $.contactInformation.editAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -607,7 +610,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Update address click"
           >
-            {t(($) => $.contactInformation.updateAddress, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.contactInformation.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -621,7 +624,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Complete address click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged, { ns: 'protectedApplicationRenewalFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -640,7 +643,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Add address click"
       >
-        {t(($) => $.contactInformation.addAddress, { ns: 'protectedApplicationRenewalFamily' })}
+        {t(($) => $.contactInformation.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -672,8 +675,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationRenewalFamily' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationRenewalFamily' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -683,8 +686,8 @@ function CommunicationPreferencesCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'protectedApplicationRenewalFamily' })}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'protectedApplicationRenewalFamily' })}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{clientApplication.communicationPreferences.preferredLanguage}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{clientApplication.communicationPreferences.preferredMethod}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -692,7 +695,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'protectedApplicationRenewalFamily' })}</p>
+      <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -735,7 +738,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit comms click"
         >
-          {t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'protectedApplicationRenewalFamily' })}
+          {t(($) => $.contactInformation.editCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -755,7 +758,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Update comms click"
           >
-            {t(($) => $.contactInformation.updateCommunicationPreferences, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.contactInformation.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -769,7 +772,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged, { ns: 'protectedApplicationRenewalFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -788,7 +791,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Add comms click"
       >
-        {t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'protectedApplicationRenewalFamily' })}
+        {t(($) => $.contactInformation.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
@@ -15,6 +15,7 @@ import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } f
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -34,9 +35,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.dentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -51,7 +51,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'protectedApplicationRenewalFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
@@ -158,60 +158,63 @@ export default function ProtectedRenewFamilyDentalInsurance({ loaderData, params
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="dentalInsurance" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="dentalInsurance" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalInsuranceCardContent />
+            <DentalInsuranceCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalBenefitsCardContent />
+            <DentalBenefitsCardFooter />
+          </Card>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="protected/application/$id/renewal-family/childrens-application"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Continue click"
+            >
+              {t(($) => $.dentalInsurance.childrensApplication)}
+            </NavigationButtonLink>
+            <NavigationButtonLink
+              variant="secondary"
+              direction="previous"
+              routeId="protected/application/$id/renewal-family/contact-information"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
+            >
+              {t(($) => $.dentalInsurance.contactInformation)}
+            </NavigationButtonLink>
+          </div>
         </div>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalInsuranceCardContent />
-          <DentalInsuranceCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalBenefitsCardContent />
-          <DentalBenefitsCardFooter />
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="protected/application/$id/renewal-family/childrens-application"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Continue click"
-          >
-            {t(($) => $.dentalInsurance.childrensApplication, { ns: 'protectedApplicationRenewalFamily' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink
-            variant="secondary"
-            direction="previous"
-            routeId="protected/application/$id/renewal-family/contact-information"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
-          >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'protectedApplicationRenewalFamily' })}
-          </NavigationButtonLink>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -235,9 +238,7 @@ function DentalInsuranceCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'protectedApplicationRenewalFamily' })}>
-            {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'protectedApplicationRenewalFamily' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'protectedApplicationRenewalFamily' })}
-          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -245,7 +246,7 @@ function DentalInsuranceCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'protectedApplicationRenewalFamily' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -278,7 +279,7 @@ function DentalInsuranceCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit button dental insurance click"
         >
-          {t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'protectedApplicationRenewalFamily' })}
+          {t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
         </ButtonLink>
       </CardFooter>
     );
@@ -295,9 +296,9 @@ function DentalInsuranceCardFooter(): JSX.Element {
         startIcon={faCirclePlus}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Add button dental insurance click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalFamily' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'protectedApplicationRenewalFamily' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalFamily' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );
@@ -324,17 +325,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationRenewalFamily' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                   {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationRenewalFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -346,17 +347,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'protectedApplicationRenewalFamily' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {clientApplication.dentalBenefits.hasFederalBenefits || clientApplication.dentalBenefits.hasProvincialTerritorialBenefits ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'protectedApplicationRenewalFamily' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {clientApplication.dentalBenefits.hasFederalBenefits && <li>{clientApplication.dentalBenefits.federalSocialProgram}</li>}
                   {clientApplication.dentalBenefits.hasProvincialTerritorialBenefits && <li>{clientApplication.dentalBenefits.provincialTerritorialSocialProgram}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'protectedApplicationRenewalFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -366,7 +367,7 @@ function DentalBenefitsCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'protectedApplicationRenewalFamily' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -401,7 +402,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit button government benefits click"
         >
-          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'protectedApplicationRenewalFamily' })}
+          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
         </ButtonLink>
       </CardFooter>
     );
@@ -421,7 +422,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Update button government benefits click"
           >
-            {t(($) => $.dentalInsurance.updateMyAccess, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.dentalInsurance.updateMyAccess)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -435,7 +436,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Complete benefits click"
           >
-            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged, { ns: 'protectedApplicationRenewalFamily' })}</span>
+            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -453,9 +454,9 @@ function DentalBenefitsCardFooter(): JSX.Element {
         startIcon={faPenToSquare}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Add button dental benefits click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalFamily' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'protectedApplicationRenewalFamily' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'protectedApplicationRenewalFamily' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/protected/application/renewal-family/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalFamilyState } from '~/.server/routes/helpers/protected-application-renewal-family-route-helpers';
 import { clearProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.exitApplication,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,28 +66,31 @@ export default function ProtectedRenewalFamilyExitApplication({ loaderData, para
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/renewal-family/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/renewal-family/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
@@ -10,6 +10,7 @@ import { loadProtectedApplicationRenewalFamilyState } from '~/.server/routes/hel
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/protected-application-renewal-section-checks';
 import { shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -26,9 +27,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.maritalStatus,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -46,7 +46,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'protectedApplicationRenewalFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -69,30 +69,31 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'protectedApplication' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationRenewalFamily' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'protectedApplicationRenewalFamily' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationRenewalFamily' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'protectedApplicationRenewalFamily' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'protectedApplicationRenewalFamily' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'protectedApplicationRenewalFamily' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'protectedApplicationRenewalFamily' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -109,7 +110,7 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Edit marital status click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'protectedApplicationRenewalFamily' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'protectedApplicationRenewalFamily' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -122,10 +123,10 @@ export default function ProtectedNewFamilyMaritalStatus({ loaderData, params }: 
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Continue click"
           >
-            {t(($) => $.maritalStatus.nextBtn, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.maritalStatus.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click">
-            {t(($) => $.maritalStatus.prevBtn, { ns: 'protectedApplicationRenewalFamily' })}
+            {t(($) => $.maritalStatus.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/protected/application/renewal-family/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/submit.tsx
@@ -11,6 +11,7 @@ import { loadProtectedApplicationRenewalFamilyStateForReview } from '~/.server/r
 import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationRenewalFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalFamily.submit,
-  pageTitleI18nKey: 'protectedApplicationRenewalFamily:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'protectedApplicationRenewalFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -92,10 +92,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'protectedApplicationRenewalFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'protectedApplicationRenewalFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -126,78 +126,81 @@ export default function ProtectedRenewalFamilySubmit({ loaderData, params }: Rou
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'protectedApplicationRenewalFamily' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'protectedApplicationRenewalFamily' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'protectedApplicationRenewalFamily' })}</p>
-            <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'protectedApplicationRenewalFamily' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'protectedApplicationRenewalFamily' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'protectedApplicationRenewalFamily' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'protectedApplicationRenewalFamily' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'protectedApplicationRenewalFamily' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" excludeMaritalStatus={shouldSkipMaritalStatusStep} className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'protectedApplicationRenewalFamily' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="protected/application/$id/renewal-family/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'protectedApplicationRenewalFamily' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="protected/application/$id/renew" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="protected/application/$id/renewal-family/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Renewal_Family:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="protected/application/$id/renewal-family/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="protected/application/$id/renewal-family/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'protectedApplicationRenewalFamily' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/renewal-submitted.tsx
+++ b/frontend/app/routes/protected/application/renewal-submitted.tsx
@@ -6,6 +6,7 @@ import type { Route } from './+types/renewal-submitted';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
@@ -19,7 +20,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.renewalSubmitted,
-  pageTitleI18nKey: 'protectedApplication:renewalSubmitted.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -58,22 +58,25 @@ export default function RenewalApplicationSubmitted({ loaderData, params }: Rout
   const mscaLinkAccount = <InlineLink to={t(($) => $.renewalSubmitted.mscaLinkAccount)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-6 space-y-4">
-        <p>{t(($) => $.renewalSubmitted.recordsShowApplicationSubmitted)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.statusCheckerInfo} components={{ statusCheckerLink }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.updateProfileInfo} components={{ mscaLinkAccount, noWrap }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.renewalSubmitted.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-6 space-y-4">
+          <p>{t(($) => $.renewalSubmitted.recordsShowApplicationSubmitted)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.statusCheckerInfo} components={{ statusCheckerLink }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.updateProfileInfo} components={{ mscaLinkAccount, noWrap }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Renewal application submitted click">
+            {t(($) => $.renewalSubmitted.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Renewal application submitted click">
-          {t(($) => $.renewalSubmitted.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/application-delegate.tsx
+++ b/frontend/app/routes/protected/application/spokes/application-delegate.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/application-delegate';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -21,7 +22,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.applicationDelegate,
-  pageTitleI18nKey: 'protectedApplicationSpokes:applicationDelegate.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -71,31 +71,34 @@ export default function ApplicationDelegate({ loaderData, params }: Route.Compon
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.contactRepresentative} components={{ contactServiceCanada, noWrap }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.prepareToApply} components={{ preparingToApply }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.applicationDelegate.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.contactRepresentative} components={{ contactServiceCanada, noWrap }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.prepareToApply} components={{ preparingToApply }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            variant="secondary"
+            type="button"
+            routeId="protected/application/$id/type-application"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Applying on behalf of someone click"
+          >
+            {t(($) => $.applicationDelegate.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Applying on behalf of someone click">
+            {t(($) => $.applicationDelegate.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          variant="secondary"
-          type="button"
-          routeId="protected/application/$id/type-application"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Applying on behalf of someone click"
-        >
-          {t(($) => $.applicationDelegate.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Applying on behalf of someone click">
-          {t(($) => $.applicationDelegate.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/cannot-apply-child.tsx
+++ b/frontend/app/routes/protected/application/spokes/cannot-apply-child.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/cannot-apply-child';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState, getSingleChildState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.cannotApplyChild,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.cannotApplyChild.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -63,29 +63,32 @@ export default function CannotApplyChild({ loaderData, params }: Route.Component
   const noWrap = <span className="whitespace-nowrap" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-6 space-y-4">
-        <p>{t(($) => $.children.cannotApplyChild.ineligibleToApply)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.cannotApplyChild.eligibilityInfo} components={{ noWrap }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.children.cannotApplyChild.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-6 space-y-4">
+          <p>{t(($) => $.children.cannotApplyChild.ineligibleToApply)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.cannotApplyChild.eligibilityInfo} components={{ noWrap }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/children/$childId/information"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child apply for yourself click"
+          >
+            {t(($) => $.children.cannotApplyChild.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Child apply for yourself click">
+            {t(($) => $.children.cannotApplyChild.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/children/$childId/information"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child apply for yourself click"
-        >
-          {t(($) => $.children.cannotApplyChild.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Child apply for yourself click">
-          {t(($) => $.children.cannotApplyChild.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/child-dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-dental-insurance.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -38,7 +39,6 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.childDentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.dentalInsurance.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -57,7 +57,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'protectedApplicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -65,7 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalInsurance.title, {
         childName: childName,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -73,14 +71,13 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalInsurance.title, {
         childName: childNumber,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
     }),
   };
 
-  return { meta, defaultState: childState.dentalInsurance, childName, i18nOptions: { childName }, applicationFlow: `${state.context}-${state.typeOfApplication}` };
+  return { meta, defaultState: childState.dentalInsurance, childName, applicationFlow: `${state.context}-${state.typeOfApplication}` };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -171,81 +168,84 @@ export default function ChildDentalInsurance({ loaderData, params }: Route.Compo
   );
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="my-6">
-            <InputRadios
-              id="has-dental-insurance"
-              name="hasDentalInsurance"
-              legend={t(($) => $.children.dentalInsurance.legend, {
-                childName: childName,
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionYes} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.yes,
-                  defaultChecked: defaultState?.hasDentalInsurance === true,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionNo} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.no,
-                  defaultChecked: defaultState?.hasDentalInsurance === false,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-              ]}
-              helpMessagePrimary={helpMessage}
-              helpMessagePrimaryClassName="text-black"
-              errorMessage={errors?.hasDentalInsurance}
-              required
-            />
-          </div>
-          {hasDentalInsurance && (
-            <div className="space-y-4">
-              <ContextualAlert type="info" id="child-dental-insurance-confirmation">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.children.dentalInsurance.alert.title)}</h2>
-                <p>
-                  {t(($) => $.children.dentalInsurance.alert.body, {
-                    childName: childName,
-                  })}
-                </p>
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation"
-                name="dentalInsuranceEligibilityConfirmation"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmation}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmation}
-                required
-                aria-describedby="child-dental-insurance-confirmation"
-              >
-                {t(($) => $.children.dentalInsurance.dentalInsuranceEligibilityConfirmation, {
+    <>
+      <AppPageTitle>{t(($) => $.children.dentalInsurance.title, { childName })}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="my-6">
+              <InputRadios
+                id="has-dental-insurance"
+                name="hasDentalInsurance"
+                legend={t(($) => $.children.dentalInsurance.legend, {
                   childName: childName,
                 })}
-              </InputCheckbox>
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionYes} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.yes,
+                    defaultChecked: defaultState?.hasDentalInsurance === true,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionNo} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.no,
+                    defaultChecked: defaultState?.hasDentalInsurance === false,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                ]}
+                helpMessagePrimary={helpMessage}
+                helpMessagePrimaryClassName="text-black"
+                errorMessage={errors?.hasDentalInsurance}
+                required
+              />
             </div>
-          )}
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child access to other dental insurance click">
-              {t(($) => $.children.dentalInsurance.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child access to other dental insurance click"
-            >
-              {t(($) => $.children.dentalInsurance.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            {hasDentalInsurance && (
+              <div className="space-y-4">
+                <ContextualAlert type="info" id="child-dental-insurance-confirmation">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.children.dentalInsurance.alert.title)}</h2>
+                  <p>
+                    {t(($) => $.children.dentalInsurance.alert.body, {
+                      childName: childName,
+                    })}
+                  </p>
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation"
+                  name="dentalInsuranceEligibilityConfirmation"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmation}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmation}
+                  required
+                  aria-describedby="child-dental-insurance-confirmation"
+                >
+                  {t(($) => $.children.dentalInsurance.dentalInsuranceEligibilityConfirmation, {
+                    childName: childName,
+                  })}
+                </InputCheckbox>
+              </div>
+            )}
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child access to other dental insurance click">
+                {t(($) => $.children.dentalInsurance.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child access to other dental insurance click"
+              >
+                {t(($) => $.children.dentalInsurance.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -13,6 +13,7 @@ import { getProtectedApplicationState, getSingleChildState, saveProtectedApplica
 import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicationDentalProvincialTerritorialBenefitsState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -40,7 +41,6 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.childFederalProvincialTerritorialBenefits,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.dentalBenefits.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -66,7 +66,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'protectedApplicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -74,7 +73,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalBenefits.title, {
         childName: childName,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -82,7 +80,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalBenefits.title, {
         childName: childNumber,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -97,7 +94,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     regions,
     childName,
     applicationFlow: `${state.context}-${state.typeOfApplication}` as const,
-    i18nOptions: { childName },
   };
 }
 
@@ -255,151 +251,151 @@ export default function ChildFederalProvincialTerritorialBenefits({ loaderData, 
   }
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4">{t(($) => $.children.dentalBenefits.accessToDental)}</p>
-        <p className="mb-4">{t(($) => $.children.dentalBenefits.eligibilityCriteria)}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">
-              {t(($) => $.children.dentalBenefits.federalBenefits.title, {
-                childName: childName,
-                ns: 'protectedApplicationSpokes',
-              })}
-            </legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.children.dentalBenefits.federalBenefits.legend, {
-                childName: childName,
-                ns: 'protectedApplicationSpokes',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.children.dentalBenefits.federalBenefits.socialPrograms.legend)}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: defaultState?.federalSocialProgram === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.legend, {
-                childName: childName,
-                ns: 'protectedApplicationSpokes',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.children.dentalBenefits.selectOne),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.children.dentalBenefits.title, { childName })}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4">{t(($) => $.children.dentalBenefits.accessToDental)}</p>
+          <p className="mb-4">{t(($) => $.children.dentalBenefits.eligibilityCriteria)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">
+                {t(($) => $.children.dentalBenefits.federalBenefits.title, {
+                  childName: childName,
+                })}
+              </legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.children.dentalBenefits.federalBenefits.legend, {
+                  childName: childName,
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.children.dentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: defaultState?.federalSocialProgram === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.legend, {
+                  childName: childName,
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.children.dentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
 
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton
-              variant="primary"
-              id="save-button"
-              loading={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child access to other federal, provincial or territorial dental benefits click"
-            >
-              {t(($) => $.children.dentalBenefits.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child access to other federal, provincial or territorial dental benefits click"
-            >
-              {t(($) => $.children.dentalBenefits.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                variant="primary"
+                id="save-button"
+                loading={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child access to other federal, provincial or territorial dental benefits click"
+              >
+                {t(($) => $.children.dentalBenefits.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child access to other federal, provincial or territorial dental benefits click"
+              >
+                {t(($) => $.children.dentalBenefits.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/child-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-information.tsx
@@ -14,6 +14,7 @@ import type { ProtectedApplicationChildInformationState, ProtectedApplicationChi
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -25,7 +26,6 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { AppPageTitle } from '~/components/layouts/protected-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
@@ -64,7 +64,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'protectedApplicationSpokes',
   });
   const childName = childState.isNew ? childNumber : (childState.information?.firstName ?? childNumber);
 
@@ -72,7 +71,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.information.pageTitle, {
         childName: childName,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -80,7 +78,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.information.pageTitle, {
         childName: childNumber,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -333,7 +330,6 @@ export default function ChildInformation({ loaderData, params }: Route.Component
       <AppPageTitle>
         {t(($) => $.children.information.pageTitle, {
           childName: childName,
-          ns: 'protectedApplicationSpokes',
         })}
       </AppPageTitle>
       <div className="max-w-prose">

--- a/frontend/app/routes/protected/application/spokes/child-parent-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-parent-guardian.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/child-parent-guardian';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.childParentOrGuardian,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.parentOrGuardian.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -71,26 +71,29 @@ export default function ChildParentGuardian({ loaderData, params }: Route.Compon
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.children.parentOrGuardian.unableToApply)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.children.parentOrGuardian.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.children.parentOrGuardian.unableToApply)}</p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId={`protected/application/$id/children/$childId/${isRenewal ? 'parent-guardian' : 'information'}`}
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child parent or guardian needs to apply click"
+          >
+            {t(($) => $.children.parentOrGuardian.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Child parent or guardian needs to apply click">
+            {t(($) => $.children.parentOrGuardian.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId={`protected/application/$id/children/$childId/${isRenewal ? 'parent-guardian' : 'information'}`}
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child parent or guardian needs to apply click"
-        >
-          {t(($) => $.children.parentOrGuardian.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Child parent or guardian needs to apply click">
-          {t(($) => $.children.parentOrGuardian.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
@@ -10,6 +10,7 @@ import type { ProtectedApplicationChildInformationState } from '~/.server/routes
 import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -28,7 +29,6 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.childSocialInsuranceNumber,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.socialInsuranceNumber.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -45,7 +45,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'protectedApplicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -53,7 +52,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.socialInsuranceNumber.pageTitle, {
         childName: childName,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -61,7 +59,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.socialInsuranceNumber.pageTitle, {
         childName: childNumber,
-        ns: 'protectedApplicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -72,7 +69,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     meta,
     childSin: childState.information?.socialInsuranceNumber,
     childName,
-    i18nOptions: { childName },
     applicationFlow: `${state.context}-${state.typeOfApplication}`,
   };
 }
@@ -158,45 +154,47 @@ export default function ChildSocialInsuranceNumber({ loaderData, params }: Route
   const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <p className="mb-4 italic">{t(($) => $.allOptional, { ns: 'protectedApplication' })}</p>
-          <div className="mb-6">
-            <InputPatternField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              format={sinInputPatternFormat}
-              label={t(($) => $.children.socialInsuranceNumber.legend, {
-                childName: childName,
-                ns: 'protectedApplicationSpokes',
-              })}
-              inputMode="numeric"
-              helpMessagePrimary={t(($) => $.children.socialInsuranceNumber.helpMessage)}
-              helpMessagePrimaryClassName="text-black"
-              defaultValue={childSin ?? ''}
-              errorMessage={errors?.socialInsuranceNumber}
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Child social insurance number click">
-              {t(($) => $.children.socialInsuranceNumber.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child social insurance number click"
-            >
-              {t(($) => $.children.socialInsuranceNumber.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.children.socialInsuranceNumber.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <p className="mb-4 italic">{t(($) => $.allOptional, { ns: 'protectedApplication' })}</p>
+            <div className="mb-6">
+              <InputPatternField
+                id="social-insurance-number"
+                name="socialInsuranceNumber"
+                format={sinInputPatternFormat}
+                label={t(($) => $.children.socialInsuranceNumber.legend, {
+                  childName: childName,
+                })}
+                inputMode="numeric"
+                helpMessagePrimary={t(($) => $.children.socialInsuranceNumber.helpMessage)}
+                helpMessagePrimaryClassName="text-black"
+                defaultValue={childSin ?? ''}
+                errorMessage={errors?.socialInsuranceNumber}
+              />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Child social insurance number click">
+                {t(($) => $.children.socialInsuranceNumber.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child social insurance number click"
+              >
+                {t(($) => $.children.socialInsuranceNumber.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
@@ -13,6 +13,7 @@ import { getProtectedApplicationState, saveProtectedApplicationState, validateAp
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -45,7 +46,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.communicationPreferences,
-  pageTitleI18nKey: 'protectedApplicationSpokes:communicationPreferences.pageTitle',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -212,42 +212,45 @@ export default function ApplicationSpokeCommunicationPreferences({ loaderData, p
   });
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.communicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
-            <InputRadios
-              id="preferred-method-sunlife"
-              legend={t(($) => $.communicationPreferences.preferredMethod)}
-              name="preferredMethod"
-              helpMessagePrimary={t(($) => $.communicationPreferences.preferredMethodHelpMessage)}
-              helpMessagePrimaryClassName="text-black"
-              options={sunLifeCommunicationMethodOptions}
-              errorMessage={errors?.preferredMethod}
-              required
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Communication preferences click">
-              {t(($) => $.communicationPreferences.save)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmittingOrSuccess}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Communication preferences click"
-            >
-              {t(($) => $.communicationPreferences.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+    <>
+      <AppPageTitle>{t(($) => $.communicationPreferences.pageTitle)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.communicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
+              <InputRadios
+                id="preferred-method-sunlife"
+                legend={t(($) => $.communicationPreferences.preferredMethod)}
+                name="preferredMethod"
+                helpMessagePrimary={t(($) => $.communicationPreferences.preferredMethodHelpMessage)}
+                helpMessagePrimaryClassName="text-black"
+                options={sunLifeCommunicationMethodOptions}
+                errorMessage={errors?.preferredMethod}
+                required
+              />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Communication preferences click">
+                {t(($) => $.communicationPreferences.save)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmittingOrSuccess}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Communication preferences click"
+              >
+                {t(($) => $.communicationPreferences.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/dental-insurance-exit-application.tsx
+++ b/frontend/app/routes/protected/application/spokes/dental-insurance-exit-application.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/dental-insurance-exit-application';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState, getProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.dentalInsuranceExitApplication,
-  pageTitleI18nKey: 'protectedApplicationSpokes:dentalInsuranceExitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -63,27 +63,30 @@ export default function ApplicationSpokeDentalInsuranceExitApplication({ loaderD
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.dentalInsuranceExitApplication.areYouSure)}</p>
-        <p>{t(($) => $.dentalInsuranceExitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsuranceExitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.dentalInsuranceExitApplication.areYouSure)}</p>
+          <p>{t(($) => $.dentalInsuranceExitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/dental-insurance"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Exiting the application click"
+          >
+            {t(($) => $.dentalInsuranceExitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Exiting the application click">
+            {t(($) => $.dentalInsuranceExitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/dental-insurance"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Exiting the application click"
-        >
-          {t(($) => $.dentalInsuranceExitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Exiting the application click">
-          {t(($) => $.dentalInsuranceExitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/spokes/dental-insurance.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -39,7 +40,6 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.dentalInsurance,
-  pageTitleI18nKey: 'protectedApplicationSpokes:dentalInsurance.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -165,93 +165,96 @@ export default function ApplicationSpokeDentalInsurance({ loaderData, params }: 
   const t4aHref = <InlineLink to={t(($) => $.dentalInsurance.no.alertT4aHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="my-6">
-            <InputRadios
-              id="has-dental-insurance"
-              name="hasDentalInsurance"
-              legend={t(($) => $.dentalInsurance.legend)}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionYes} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.yes,
-                  defaultChecked: defaultState?.hasDentalInsurance === true,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionNo} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.no,
-                  defaultChecked: defaultState?.hasDentalInsurance === false,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-              ]}
-              helpMessagePrimary={helpMessage}
-              helpMessagePrimaryClassName="text-black"
-              errorMessage={errors?.hasDentalInsurance}
-              required
-            />
-          </div>
-          {hasDentalInsurance === true && (
-            <div className="mb-4 space-y-4">
-              <ContextualAlert type="info" id="dental-insurance-confirmation-yes">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.yes.alertTitle)}</h2>
-                <p>{t(($) => $.dentalInsurance.yes.alertBody)}</p>
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation-yes"
-                name="dentalInsuranceEligibilityConfirmationYes"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationYes}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmationYes}
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.title)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="my-6">
+              <InputRadios
+                id="has-dental-insurance"
+                name="hasDentalInsurance"
+                legend={t(($) => $.dentalInsurance.legend)}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionYes} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.yes,
+                    defaultChecked: defaultState?.hasDentalInsurance === true,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionNo} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.no,
+                    defaultChecked: defaultState?.hasDentalInsurance === false,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                ]}
+                helpMessagePrimary={helpMessage}
+                helpMessagePrimaryClassName="text-black"
+                errorMessage={errors?.hasDentalInsurance}
                 required
-                aria-describedby="dental-insurance-confirmation-yes"
-              >
-                {t(($) => $.dentalInsurance.yes.confirmation)}
-              </InputCheckbox>
+              />
             </div>
-          )}
-          {hasDentalInsurance === false && (
-            <div className="mb-4 space-y-4">
-              <ContextualAlert type="info" id="dental-insurance-confirmation-no">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.no.alertTitle)}</h2>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.no.alertBody} components={{ t4Href, t4aHref }} />
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation-no"
-                name="dentalInsuranceEligibilityConfirmationNo"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationNo}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmationNo}
-                required
-                aria-describedby="dental-insurance-confirmation-no"
-              >
-                {t(($) => $.dentalInsurance.no.confirmation)}
-              </InputCheckbox>
-            </div>
-          )}
+            {hasDentalInsurance === true && (
+              <div className="mb-4 space-y-4">
+                <ContextualAlert type="info" id="dental-insurance-confirmation-yes">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.yes.alertTitle)}</h2>
+                  <p>{t(($) => $.dentalInsurance.yes.alertBody)}</p>
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation-yes"
+                  name="dentalInsuranceEligibilityConfirmationYes"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationYes}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmationYes}
+                  required
+                  aria-describedby="dental-insurance-confirmation-yes"
+                >
+                  {t(($) => $.dentalInsurance.yes.confirmation)}
+                </InputCheckbox>
+              </div>
+            )}
+            {hasDentalInsurance === false && (
+              <div className="mb-4 space-y-4">
+                <ContextualAlert type="info" id="dental-insurance-confirmation-no">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.no.alertTitle)}</h2>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.no.alertBody} components={{ t4Href, t4aHref }} />
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation-no"
+                  name="dentalInsuranceEligibilityConfirmationNo"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationNo}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmationNo}
+                  required
+                  aria-describedby="dental-insurance-confirmation-no"
+                >
+                  {t(($) => $.dentalInsurance.no.confirmation)}
+                </InputCheckbox>
+              </div>
+            )}
 
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Access to other dental insurance click">
-              {t(($) => $.dentalInsurance.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/${applicationFlow}/dental-insurance`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Access to other dental insurance click"
-            >
-              {t(($) => $.dentalInsurance.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Access to other dental insurance click">
+                {t(($) => $.dentalInsurance.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/${applicationFlow}/dental-insurance`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Access to other dental insurance click"
+              >
+                {t(($) => $.dentalInsurance.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/email.tsx
+++ b/frontend/app/routes/protected/application/spokes/email.tsx
@@ -11,6 +11,7 @@ import { getProtectedApplicationState, saveProtectedApplicationState, validateAp
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -42,7 +43,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.email,
-  pageTitleI18nKey: 'protectedApplicationSpokes:email.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -148,34 +148,37 @@ export default function ApplicationEmail({ loaderData, params }: Route.Component
   const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
-          <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
-          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-          <div className="mb-6">
-            <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Email click">
-              {t(($) => $.email.continue)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Email click"
-            >
-              {t(($) => $.email.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.email.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
+            <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
+            <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+            <div className="mb-6">
+              <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Email click">
+                {t(($) => $.email.continue)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Email click"
+              >
+                {t(($) => $.email.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -13,6 +13,7 @@ import type { ProtectedApplicationDentalFederalBenefitsState, ProtectedApplicati
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -38,9 +39,8 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.federalProvincialTerritorialBenefits,
-  pageTitleI18nKey: 'protectedApplicationSpokes:dentalBenefits.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -62,7 +62,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialTerritorialSocialPrograms = await appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalBenefits.title, { ns: 'protectedApplicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalBenefits.title) }),
   };
 
   return {
@@ -92,7 +92,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const federalBenefitsSchema = z
     .object({
       hasFederalBenefits: z.boolean({
-        error: t(($) => $.dentalBenefits.errorMessage.federalBenefitRequired, { ns: 'protectedApplicationSpokes' }),
+        error: t(($) => $.dentalBenefits.errorMessage.federalBenefitRequired),
       }),
       federalSocialProgram: z.string().trim().optional(),
     })
@@ -101,7 +101,7 @@ export async function action({ context: { appContainer, session }, params, reque
       if (val.hasFederalBenefits && (!val.federalSocialProgram || validator.isEmpty(val.federalSocialProgram))) {
         ctx.addIssue({
           code: 'custom',
-          message: t(($) => $.dentalBenefits.errorMessage.federalBenefitProgramRequired, { ns: 'protectedApplicationSpokes' }),
+          message: t(($) => $.dentalBenefits.errorMessage.federalBenefitProgramRequired),
           path: ['federalSocialProgram'],
         });
       }
@@ -116,7 +116,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const provincialTerritorialBenefitsSchema = z
     .object({
       hasProvincialTerritorialBenefits: z.boolean({
-        error: t(($) => $.dentalBenefits.errorMessage.provincialBenefitRequired, { ns: 'protectedApplicationSpokes' }),
+        error: t(($) => $.dentalBenefits.errorMessage.provincialBenefitRequired),
       }),
       provincialTerritorialSocialProgram: z.string().trim().optional(),
       province: z.string().trim().optional(),
@@ -127,13 +127,13 @@ export async function action({ context: { appContainer, session }, params, reque
         if (!val.province || validator.isEmpty(val.province)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.dentalBenefits.errorMessage.provincialTerritorialRequired, { ns: 'protectedApplicationSpokes' }),
+            message: t(($) => $.dentalBenefits.errorMessage.provincialTerritorialRequired),
             path: ['province'],
           });
         } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.dentalBenefits.errorMessage.provincialBenefitProgramRequired, { ns: 'protectedApplicationSpokes' }),
+            message: t(($) => $.dentalBenefits.errorMessage.provincialBenefitProgramRequired),
             path: ['provincialTerritorialSocialProgram'],
           });
         }
@@ -222,134 +222,137 @@ export default function ApplicationSpokeFederalProvincialTerritorialBenefits({ l
   }
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental, { ns: 'protectedApplicationSpokes' })}</p>
-        <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria, { ns: 'protectedApplicationSpokes' })}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.federalBenefits.title, { ns: 'protectedApplicationSpokes' })}</legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.dentalBenefits.federalBenefits.legend, { ns: 'protectedApplicationSpokes' })}
-              options={[
-                {
-                  children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.dentalBenefits.federalBenefits.socialPrograms.legend, { ns: 'protectedApplicationSpokes' })}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: defaultState?.federalSocialProgram === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.provincialTerritorialBenefits.title, { ns: 'protectedApplicationSpokes' })}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.legend, { ns: 'protectedApplicationSpokes' })}
-              options={[
-                {
-                  children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend, { ns: 'protectedApplicationSpokes' })}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.dentalBenefits.selectOne, { ns: 'protectedApplicationSpokes' }),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.dentalBenefits.title)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental)}</p>
+          <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.federalBenefits.title)}</legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.dentalBenefits.federalBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.dentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: defaultState?.federalSocialProgram === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend, { ns: 'protectedApplicationSpokes' })}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.dentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Access to other dental benefits click">
-              {t(($) => $.dentalBenefits.saveBtn, { ns: 'protectedApplicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/${applicationFlow}/dental-insurance`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Access to other dental benefits click"
-            >
-              {t(($) => $.dentalBenefits.backBtn, { ns: 'protectedApplicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Access to other dental benefits click">
+                {t(($) => $.dentalBenefits.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/${applicationFlow}/dental-insurance`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Access to other dental benefits click"
+              >
+                {t(($) => $.dentalBenefits.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/file-taxes.tsx
+++ b/frontend/app/routes/protected/application/spokes/file-taxes.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/file-taxes';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -21,7 +22,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.fileYourTaxes,
-  pageTitleI18nKey: 'protectedApplication:fileYourTaxes.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -70,39 +70,37 @@ export default function ApplicationFileYourTaxes({ loaderData, params }: Route.C
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.fileYourTaxes.ineligibleToApply)}</p>
-        <p>
-          {t(($) => $.fileYourTaxes.taxNotFiled, {
-            taxYear: taxYear,
-            ns: 'protectedApplication',
-          })}
-        </p>
-        <p>{t(($) => $.fileYourTaxes.unableToAssess)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.taxInfo} components={{ taxInfo }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.applyAfter} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.fileYourTaxes.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.fileYourTaxes.ineligibleToApply)}</p>
+          <p>{t(($) => $.fileYourTaxes.taxNotFiled, { taxYear: taxYear })}</p>
+          <p>{t(($) => $.fileYourTaxes.unableToAssess)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.taxInfo} components={{ taxInfo }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.applyAfter} />
+          </p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="protected/application/$id/tax-filing"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - File your taxes click"
+          >
+            {t(($) => $.fileYourTaxes.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - File your taxes click">
+            {t(($) => $.fileYourTaxes.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="protected/application/$id/tax-filing"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - File your taxes click"
-        >
-          {t(($) => $.fileYourTaxes.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - File your taxes click">
-          {t(($) => $.fileYourTaxes.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/home-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/home-address.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/protected-applica
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -56,7 +57,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.homeAddress,
-  pageTitleI18nKey: 'protectedApplicationSpokes:address.homeAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -266,117 +266,120 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-8">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="homeAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.address.addressField.address)}
-                helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                maxLength={100}
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="home-apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.address.addressField.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue=""
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="home-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode ?? ''}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {homeRegions.length > 0 && (
-                <InputSelect
-                  id="home-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.address.addressField.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...homeRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.address.homeAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-8">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="homeAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.address)}
+                  helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  maxLength={100}
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country ?? ''}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
+                <InputSanitizeField
+                  id="home-apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue=""
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {homeRegions.length > 0 && (
+                  <InputSelect
+                    id="home-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.address.addressField.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...homeRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="home-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.address.addressField.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country ?? ''}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={homeCountryChangeHandler}
+                  required
+                />
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Home address click"
+                  >
+                    {t(($) => $.address.saveBtn)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/mailing-address`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Home address click"
+              >
+                {t(($) => $.address.back)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Home address click"
-                >
-                  {t(($) => $.address.saveBtn)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/mailing-address`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Home address click"
-            >
-              {t(($) => $.address.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/living-independently.tsx
+++ b/frontend/app/routes/protected/application/spokes/living-independently.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -31,7 +32,6 @@ const LIVING_INDEPENDENTLY_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.livingIndependently,
-  pageTitleI18nKey: 'protectedApplicationSpokes:livingIndependently.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -101,49 +101,52 @@ export default function ApplyFlowLivingIndependently({ loaderData, params }: Rou
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-6">{t(($) => $.livingIndependently.description)}</p>
-      <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="living-independently"
-            name="livingIndependently"
-            legend={t(($) => $.livingIndependently.formInstructions)}
-            options={[
-              {
-                value: LIVING_INDEPENDENTLY_OPTION.yes,
-                children: t(($) => $.livingIndependently.radioOptions.yes),
-                defaultChecked: defaultState === true,
-              },
-              {
-                value: LIVING_INDEPENDENTLY_OPTION.no,
-                children: t(($) => $.livingIndependently.radioOptions.no),
-                defaultChecked: defaultState === false,
-              },
-            ]}
-            required
-            errorMessage={errors?.livingIndependently}
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Living independently click">
-              {t(($) => $.livingIndependently.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={context === 'intake' ? 'protected/application/$id/personal-information' : 'protected/application/$id/renewal-selection'}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Living independently click"
-            >
-              {t(($) => $.livingIndependently.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.livingIndependently.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-6">{t(($) => $.livingIndependently.description)}</p>
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="living-independently"
+              name="livingIndependently"
+              legend={t(($) => $.livingIndependently.formInstructions)}
+              options={[
+                {
+                  value: LIVING_INDEPENDENTLY_OPTION.yes,
+                  children: t(($) => $.livingIndependently.radioOptions.yes),
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  value: LIVING_INDEPENDENTLY_OPTION.no,
+                  children: t(($) => $.livingIndependently.radioOptions.no),
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              required
+              errorMessage={errors?.livingIndependently}
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Living independently click">
+                {t(($) => $.livingIndependently.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={context === 'intake' ? 'protected/application/$id/personal-information' : 'protected/application/$id/renewal-selection'}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Living independently click"
+              >
+                {t(($) => $.livingIndependently.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/mailing-address.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/protected-applica
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -57,7 +58,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.mailingAddress,
-  pageTitleI18nKey: 'protectedApplicationSpokes:address.mailingAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -302,122 +302,125 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="mailingAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.address.addressField.address)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="mailing-apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.address.addressField.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue=""
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="mailing-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {mailingRegions.length > 0 && (
-                <InputSelect
-                  id="mailing-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.address.addressField.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...mailingRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.address.mailingAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="mailingAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.address)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
-              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
-                {t(($) => $.address.homeAddress.useMailingAddress)}
-              </InputCheckbox>
+                <InputSanitizeField
+                  id="mailing-apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue=""
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="mailing-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {mailingRegions.length > 0 && (
+                  <InputSelect
+                    id="mailing-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.address.addressField.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...mailingRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="mailing-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.address.addressField.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={mailingCountryChangeHandler}
+                  required
+                />
+                <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
+                  {t(($) => $.address.homeAddress.useMailingAddress)}
+                </InputCheckbox>
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Mailing address click"
+                  >
+                    {copyAddressChecked ? t(($) => $.address.saveBtn) : t(($) => $.address.continue)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && (
+                      <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
+                    )}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Mailing address click"
+              >
+                {t(($) => $.address.back)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Mailing address click"
-                >
-                  {copyAddressChecked ? t(($) => $.address.saveBtn) : t(($) => $.address.continue)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && (
-                    <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
-                  )}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Mailing address click"
-            >
-              {t(($) => $.address.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow, ProtectedApplicationPartnerInformationState } fro
 import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -48,9 +49,8 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.maritalStatus,
-  pageTitleI18nKey: 'protectedApplicationSpokes:maritalStatus.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -65,7 +65,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'protectedApplicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const maritalStatuses = appContainer.get(TYPES.MaritalStatusService).listLocalizedMaritalStatuses(locale);
   return {
@@ -94,12 +94,12 @@ export async function action({ context: { appContainer, session }, params, reque
   const maritalStatusSchema = z.object({
     maritalStatus: z
       .string({
-        error: t(($) => $.maritalStatus.errorMessage.maritalStatusRequired, { ns: 'protectedApplicationSpokes' }),
+        error: t(($) => $.maritalStatus.errorMessage.maritalStatusRequired),
       })
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.maritalStatusRequired, { ns: 'protectedApplicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.maritalStatusRequired),
       ),
   });
 
@@ -107,36 +107,36 @@ export async function action({ context: { appContainer, session }, params, reque
   const partnerInformationSchema = z.object({
     consentToSharePersonalInformation: z.literal(
       true,
-      t(($) => $.maritalStatus.errorMessage.confirmRequired, { ns: 'protectedApplicationSpokes' }),
+      t(($) => $.maritalStatus.errorMessage.confirmRequired),
     ),
     yearOfBirth: z
       .string()
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.dateOfBirthYearRequired, { ns: 'protectedApplicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.dateOfBirthYearRequired),
       )
       .refine(
         (year) => Number.parseInt(year) > currentYear - 150,
-        t(($) => $.maritalStatus.errorMessage.yobIsPast, { ns: 'protectedApplicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.yobIsPast),
       )
       .refine(
         (year) => Number.parseInt(year) < currentYear,
-        t(($) => $.maritalStatus.errorMessage.yobIsFuture, { ns: 'protectedApplicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.yobIsFuture),
       ),
     socialInsuranceNumber: z
       .string()
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.sinRequired, { ns: 'protectedApplicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.sinRequired),
       )
 
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinValid, { ns: 'protectedApplicationSpokes' }),
+            message: t(($) => $.maritalStatus.errorMessage.sinValid),
           });
         } else if (
           [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
@@ -146,7 +146,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinUnique, { ns: 'protectedApplicationSpokes' }),
+            message: t(($) => $.maritalStatus.errorMessage.sinUnique),
           });
         }
       }),
@@ -213,82 +213,85 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
   }, [defaultState, maritalStatuses]);
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <InputRadios
-              id="maritalStatus"
-              name="maritalStatus"
-              legend={t(($) => $.maritalStatus.maritalStatus, { ns: 'protectedApplicationSpokes' })}
-              helpMessagePrimary={t(($) => $.maritalStatus.primaryHelpMessage, { ns: 'protectedApplicationSpokes' })}
-              options={maritalStatusOptions}
-              errorMessage={errors?.maritalStatus}
-              required
-            />
+    <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <InputRadios
+                id="maritalStatus"
+                name="maritalStatus"
+                legend={t(($) => $.maritalStatus.maritalStatus)}
+                helpMessagePrimary={t(($) => $.maritalStatus.primaryHelpMessage)}
+                options={maritalStatusOptions}
+                errorMessage={errors?.maritalStatus}
+                required
+              />
 
-            {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-              <>
-                <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw, { ns: 'protectedApplicationSpokes' })}</h2>
-                <p className="mb-4">{t(($) => $.maritalStatus.provideSin, { ns: 'protectedApplicationSpokes' })}</p>
-                <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation, { ns: 'protectedApplicationSpokes' })}</p>
-                <InputPatternField
-                  id="social-insurance-number"
-                  name="socialInsuranceNumber"
-                  format={sinInputPatternFormat}
-                  label={t(($) => $.maritalStatus.sin, { ns: 'protectedApplicationSpokes' })}
-                  inputMode="numeric"
-                  helpMessagePrimary={t(($) => $.maritalStatus.sinHelp, { ns: 'protectedApplicationSpokes' })}
-                  helpMessagePrimaryClassName="text-black"
-                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
-                  errorMessage={errors?.socialInsuranceNumber}
-                  required
-                />
-                <InputPatternField
-                  id="year-of-birth"
-                  name="yearOfBirth"
-                  inputMode="numeric"
-                  format="####"
-                  defaultValue={defaultState.yearOfBirth ?? ''}
-                  label={t(($) => $.maritalStatus.yearOfBirth, { ns: 'protectedApplicationSpokes' })}
-                  helpMessagePrimary={t(($) => $.maritalStatus.yearOfBirthHelp, { ns: 'protectedApplicationSpokes' })}
-                  helpMessagePrimaryClassName="text-black"
-                  errorMessage={errors?.yearOfBirth}
-                  required
-                />
-                <InputCheckbox
-                  id="consentToSharePersonalInformation"
-                  name="consentToSharePersonalInformation"
-                  value="yes"
-                  errorMessage={errors?.consentToSharePersonalInformation}
-                  defaultChecked={defaultState.consentToSharePersonalInformation === true}
-                  required
-                >
-                  {t(($) => $.maritalStatus.confirmCheckbox, { ns: 'protectedApplicationSpokes' })}
-                </InputCheckbox>
-              </>
-            )}
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Marital status click">
-              {t(($) => $.maritalStatus.saveBtn, { ns: 'protectedApplicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Marital status click"
-            >
-              {t(($) => $.maritalStatus.backBtn, { ns: 'protectedApplicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+              {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
+                <>
+                  <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</h2>
+                  <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
+                  <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
+                  <InputPatternField
+                    id="social-insurance-number"
+                    name="socialInsuranceNumber"
+                    format={sinInputPatternFormat}
+                    label={t(($) => $.maritalStatus.sin)}
+                    inputMode="numeric"
+                    helpMessagePrimary={t(($) => $.maritalStatus.sinHelp)}
+                    helpMessagePrimaryClassName="text-black"
+                    defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                    errorMessage={errors?.socialInsuranceNumber}
+                    required
+                  />
+                  <InputPatternField
+                    id="year-of-birth"
+                    name="yearOfBirth"
+                    inputMode="numeric"
+                    format="####"
+                    defaultValue={defaultState.yearOfBirth ?? ''}
+                    label={t(($) => $.maritalStatus.yearOfBirth)}
+                    helpMessagePrimary={t(($) => $.maritalStatus.yearOfBirthHelp)}
+                    helpMessagePrimaryClassName="text-black"
+                    errorMessage={errors?.yearOfBirth}
+                    required
+                  />
+                  <InputCheckbox
+                    id="consentToSharePersonalInformation"
+                    name="consentToSharePersonalInformation"
+                    value="yes"
+                    errorMessage={errors?.consentToSharePersonalInformation}
+                    defaultChecked={defaultState.consentToSharePersonalInformation === true}
+                    required
+                  >
+                    {t(($) => $.maritalStatus.confirmCheckbox)}
+                  </InputCheckbox>
+                </>
+              )}
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Marital status click">
+                {t(($) => $.maritalStatus.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Marital status click"
+              >
+                {t(($) => $.maritalStatus.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
@@ -14,6 +14,7 @@ import { TYPES } from '~/.server/constants';
 import { getContextualAgeCategoryFromDate, getProtectedApplicationState, saveProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -36,7 +37,6 @@ const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.newOrReturningMember,
-  pageTitleI18nKey: 'protectedApplicationSpokes:newOrReturningMember.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -149,46 +149,49 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
   ];
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t(($) => $.newOrReturningMember.previouslyEnrolled)} options={options} errorMessage={errors?.newOrExistingMember} required />
-          {isNewOrReturningMember && (
-            <div className="my-8">
-              <InputPatternField
-                id="member-id"
-                name="memberId"
-                format={renewalCodeInputPatternFormat}
-                label={t(($) => $.newOrReturningMember.memberId)}
-                inputMode="numeric"
-                defaultValue={defaultState?.memberId ?? ''}
-                errorMessage={errors?.memberId}
-                helpMessagePrimary={t(($) => $.newOrReturningMember.memberIdDescription)}
-                required={isNewOrReturningMember}
-              />
+    <>
+      <AppPageTitle>{t(($) => $.newOrReturningMember.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t(($) => $.newOrReturningMember.previouslyEnrolled)} options={options} errorMessage={errors?.newOrExistingMember} required />
+            {isNewOrReturningMember && (
+              <div className="my-8">
+                <InputPatternField
+                  id="member-id"
+                  name="memberId"
+                  format={renewalCodeInputPatternFormat}
+                  label={t(($) => $.newOrReturningMember.memberId)}
+                  inputMode="numeric"
+                  defaultValue={defaultState?.memberId ?? ''}
+                  errorMessage={errors?.memberId}
+                  helpMessagePrimary={t(($) => $.newOrReturningMember.memberIdDescription)}
+                  required={isNewOrReturningMember}
+                />
+              </div>
+            )}
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
+                {t(($) => $.newOrReturningMember.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={userAgeCategory === 'youth' ? 'protected/application/$id/living-independently' : 'protected/application/$id/your-application'}
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
+              >
+                {t(($) => $.newOrReturningMember.backBtn)}
+              </ButtonLink>
             </div>
-          )}
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
-              {t(($) => $.newOrReturningMember.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={userAgeCategory === 'youth' ? 'protected/application/$id/living-independently' : 'protected/application/$id/your-application'}
-              params={params}
-              disabled={isSubmitting}
-              startIcon={faChevronLeft}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
-            >
-              {t(($) => $.newOrReturningMember.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
@@ -10,6 +10,7 @@ import { getProtectedApplicationState, getSingleChildState, saveProtectedApplica
 import type { ProtectedApplicationChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InputRadios } from '~/components/input-radios';
@@ -30,7 +31,6 @@ const YES_NO_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.parentGuardian,
-  pageTitleI18nKey: 'protectedApplicationSpokes:children.parentGuardian.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'protectedApplicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -119,50 +118,52 @@ export default function ParentGuardian({ loaderData, params }: Route.ComponentPr
   const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
 
   return (
-    <div className="max-w-prose">
-      <fetcher.Form method="post" noValidate>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <div className="mb-8 space-y-4">
-          <InputRadios
-            id="is-parent-radios"
-            name="isParent"
-            legend={t(($) => $.children.parentGuardian.parentLegend, {
-              childName: childName,
-              ns: 'protectedApplicationSpokes',
-            })}
-            options={[
-              {
-                value: YES_NO_OPTION.yes,
-                children: t(($) => $.children.parentGuardian.radioOptions.yes),
-                defaultChecked: defaultState?.isParent === true,
-              },
-              {
-                value: YES_NO_OPTION.no,
-                children: t(($) => $.children.parentGuardian.radioOptions.no),
-                defaultChecked: defaultState?.isParent === false,
-              },
-            ]}
-            errorMessage={errors?.isParent}
-            required
-          />
-        </div>
-        <div className="flex flex-wrap items-center gap-3">
-          <CsrfTokenInput />
-          <ButtonLink
-            id="back-button"
-            variant="secondary"
-            routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
-            params={params}
-            disabled={isSubmitting}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child parent or guardian needs to apply click"
-          >
-            {t(($) => $.children.parentGuardian.backBtn)}
-          </ButtonLink>
-          <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child Information click">
-            {t(($) => $.children.parentGuardian.saveBtn)}
-          </LoadingButton>
-        </div>
-      </fetcher.Form>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.children.parentGuardian.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <fetcher.Form method="post" noValidate>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <div className="mb-8 space-y-4">
+            <InputRadios
+              id="is-parent-radios"
+              name="isParent"
+              legend={t(($) => $.children.parentGuardian.parentLegend, {
+                childName: childName,
+              })}
+              options={[
+                {
+                  value: YES_NO_OPTION.yes,
+                  children: t(($) => $.children.parentGuardian.radioOptions.yes),
+                  defaultChecked: defaultState?.isParent === true,
+                },
+                {
+                  value: YES_NO_OPTION.no,
+                  children: t(($) => $.children.parentGuardian.radioOptions.no),
+                  defaultChecked: defaultState?.isParent === false,
+                },
+              ]}
+              errorMessage={errors?.isParent}
+              required
+            />
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <CsrfTokenInput />
+            <ButtonLink
+              id="back-button"
+              variant="secondary"
+              routeId={`protected/application/$id/${applicationFlow}/childrens-application`}
+              params={params}
+              disabled={isSubmitting}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Child parent or guardian needs to apply click"
+            >
+              {t(($) => $.children.parentGuardian.backBtn)}
+            </ButtonLink>
+            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Child Information click">
+              {t(($) => $.children.parentGuardian.saveBtn)}
+            </LoadingButton>
+          </div>
+        </fetcher.Form>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/parent-or-guardian.tsx
@@ -8,6 +8,7 @@ import type { Route } from './+types/parent-or-guardian';
 import { TYPES } from '~/.server/constants';
 import { clearProtectedApplicationState, getContextualAgeCategoryFromDate, getProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.parentOrGuardian,
-  pageTitleI18nKey: 'protectedApplicationSpokes:parentOrGuardian.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -93,29 +93,32 @@ export default function ApplyFlowParentOrGuardian({ loaderData, params }: Route.
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p className="mb-4">{t(($) => $.parentOrGuardian.unableToApply)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.parentOrGuardian.applyForYourself} components={{ noWrap }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p className="mb-4">{t(($) => $.parentOrGuardian.unableToApply)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.parentOrGuardian.applyForYourself} components={{ noWrap }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId={getBackButtonRouteId()}
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Parent or guardian needs to apply click"
+          >
+            {t(($) => $.parentOrGuardian.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Parent or guardian needs to apply click">
+            {t(($) => $.parentOrGuardian.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId={getBackButtonRouteId()}
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Parent or guardian needs to apply click"
-        >
-          {t(($) => $.parentOrGuardian.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Exit - Parent or guardian needs to apply click">
-          {t(($) => $.parentOrGuardian.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -10,6 +10,7 @@ import type { ProtectedApplicationApplicantInformationState } from '~/.server/ro
 import { getContextualAgeCategoryFromDate, getProtectedApplicationState, isNewOrReturningMember, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -34,7 +35,6 @@ import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.personalInformation,
-  pageTitleI18nKey: 'protectedApplicationSpokes:personalInformation.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -230,93 +230,96 @@ export default function ApplicationPersonalInformation({ loaderData, params }: R
   const { ErrorAlert } = useErrorAlert(fetcherStatus === 'client-not-found');
 
   return (
-    <div className="max-w-prose">
-      <ErrorAlert>
-        <h2 className="mb-2 font-bold">{t(($) => $.personalInformation.errorMessage.alert.heading)}</h2>
-        <p className="mb-2">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.detail} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mb-2">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.applyDate} values={{ startDate: fetcherEligibilityStartDate }} components={{ strong: <strong /> }} />
-        </p>
-      </ErrorAlert>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <p className="mb-4">{t(($) => $.personalInformation.formInstructionsSin)}</p>
-        <p className="mb-6">{t(($) => $.personalInformation.formInstructionsInfo)}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputSanitizeField
-                id="first-name"
-                name="firstName"
-                label={t(($) => $.personalInformation.firstName)}
-                className="w-full"
-                maxLength={100}
-                aria-description={t(($) => $.personalInformation.nameInstructions)}
-                autoComplete="given-name"
-                defaultValue={state?.firstName ?? ''}
-                errorMessage={errors?.firstName}
+    <>
+      <AppPageTitle>{t(($) => $.personalInformation.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t(($) => $.personalInformation.errorMessage.alert.heading)}</h2>
+          <p className="mb-2">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.detail} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mb-2">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.applyDate} values={{ startDate: fetcherEligibilityStartDate }} components={{ strong: <strong /> }} />
+          </p>
+        </ErrorAlert>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <p className="mb-4">{t(($) => $.personalInformation.formInstructionsSin)}</p>
+          <p className="mb-6">{t(($) => $.personalInformation.formInstructionsInfo)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputSanitizeField
+                  id="first-name"
+                  name="firstName"
+                  label={t(($) => $.personalInformation.firstName)}
+                  className="w-full"
+                  maxLength={100}
+                  aria-description={t(($) => $.personalInformation.nameInstructions)}
+                  autoComplete="given-name"
+                  defaultValue={state?.firstName ?? ''}
+                  errorMessage={errors?.firstName}
+                  required
+                />
+                <InputSanitizeField
+                  id="last-name"
+                  name="lastName"
+                  label={t(($) => $.personalInformation.lastName)}
+                  className="w-full"
+                  maxLength={100}
+                  aria-description={t(($) => $.personalInformation.nameInstructions)}
+                  autoComplete="family-name"
+                  defaultValue={state?.lastName ?? ''}
+                  errorMessage={errors?.lastName}
+                  required
+                />
+              </div>
+              <Collapsible id="name-instructions" summary={t(($) => $.personalInformation.singleLegalName)}>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.nameInstructions} />
+                </p>
+              </Collapsible>
+              <DatePickerField
+                id="date-of-birth"
+                names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
+                defaultValue={state?.dateOfBirth ?? ''}
+                legend={t(($) => $.personalInformation.dob)}
+                errorMessages={{ all: errors?.dateOfBirth, year: errors?.dateOfBirthYear, month: errors?.dateOfBirthMonth, day: errors?.dateOfBirthDay }}
                 required
               />
-              <InputSanitizeField
-                id="last-name"
-                name="lastName"
-                label={t(($) => $.personalInformation.lastName)}
-                className="w-full"
-                maxLength={100}
-                aria-description={t(($) => $.personalInformation.nameInstructions)}
-                autoComplete="family-name"
-                defaultValue={state?.lastName ?? ''}
-                errorMessage={errors?.lastName}
+              <InputPatternField
+                id="social-insurance-number"
+                name="socialInsuranceNumber"
+                format={sinInputPatternFormat}
+                label={t(($) => $.personalInformation.sin)}
+                inputMode="numeric"
+                helpMessagePrimary={t(($) => $.personalInformation.helpMessage.sin)}
+                helpMessagePrimaryClassName="text-black"
+                defaultValue={state?.socialInsuranceNumber ?? ''}
+                errorMessage={errors?.socialInsuranceNumber}
                 required
               />
             </div>
-            <Collapsible id="name-instructions" summary={t(($) => $.personalInformation.singleLegalName)}>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.nameInstructions} />
-              </p>
-            </Collapsible>
-            <DatePickerField
-              id="date-of-birth"
-              names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
-              defaultValue={state?.dateOfBirth ?? ''}
-              legend={t(($) => $.personalInformation.dob)}
-              errorMessages={{ all: errors?.dateOfBirth, year: errors?.dateOfBirthYear, month: errors?.dateOfBirthMonth, day: errors?.dateOfBirthDay }}
-              required
-            />
-            <InputPatternField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              format={sinInputPatternFormat}
-              label={t(($) => $.personalInformation.sin)}
-              inputMode="numeric"
-              helpMessagePrimary={t(($) => $.personalInformation.helpMessage.sin)}
-              helpMessagePrimaryClassName="text-black"
-              defaultValue={state?.socialInsuranceNumber ?? ''}
-              errorMessage={errors?.socialInsuranceNumber}
-              required
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Applicant information click">
-              {t(($) => $.personalInformation.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`protected/application/$id/your-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Applicant information click"
-            >
-              {t(($) => $.personalInformation.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Applicant information click">
+                {t(($) => $.personalInformation.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`protected/application/$id/your-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Applicant information click"
+              >
+                {t(($) => $.personalInformation.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/phone-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/phone-number.tsx
@@ -11,6 +11,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/protected-applica
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { phoneSchema } from '~/.server/validation/phone-schema';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -44,7 +45,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.phoneNumber,
-  pageTitleI18nKey: 'protectedApplicationSpokes:phoneNumber.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -135,76 +135,79 @@ export default function PhoneNumber({ loaderData, params }: Route.ComponentProps
   const findOffice = <InlineLink to={t(($) => $.phoneNumber.officeLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
-            <div className="grid items-end gap-6">
-              <InputPhoneField
-                id="phone-number"
-                name="phoneNumber"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumber ?? ''}
-                errorMessage={errors?.phoneNumber}
-                label={t(($) => $.phoneNumber.phoneNumber)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
-              <InputPhoneField
-                id="phone-number-alt"
-                name="phoneNumberAlt"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumberAlt ?? ''}
-                errorMessage={errors?.phoneNumberAlt}
-                label={t(($) => $.phoneNumber.phoneNumberAlt)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
+    <>
+      <AppPageTitle>{t(($) => $.phoneNumber.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-6">
+              <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'protectedApplication' })}</p>
+              <div className="grid items-end gap-6">
+                <InputPhoneField
+                  id="phone-number"
+                  name="phoneNumber"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumber ?? ''}
+                  errorMessage={errors?.phoneNumber}
+                  label={t(($) => $.phoneNumber.phoneNumber)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+                <InputPhoneField
+                  id="phone-number-alt"
+                  name="phoneNumberAlt"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumberAlt ?? ''}
+                  errorMessage={errors?.phoneNumberAlt}
+                  label={t(($) => $.phoneNumber.phoneNumberAlt)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+              </div>
             </div>
-          </div>
-          <Collapsible summary={t(($) => $.phoneNumber.dontHaveNumber)}>
-            <div className="space-y-6">
-              <section className="space-y-4">
-                <p>{t(($) => $.phoneNumber.needPhoneNumber)}</p>
-                <ul className="list-disc space-y-1 pl-7">
-                  <li>
-                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.serviceCanada} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
-                  </li>
-                  <li>
-                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.inPerson} components={{ findOffice }} />
-                  </li>
-                </ul>
-              </section>
+            <Collapsible summary={t(($) => $.phoneNumber.dontHaveNumber)}>
+              <div className="space-y-6">
+                <section className="space-y-4">
+                  <p>{t(($) => $.phoneNumber.needPhoneNumber)}</p>
+                  <ul className="list-disc space-y-1 pl-7">
+                    <li>
+                      <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.serviceCanada} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
+                    </li>
+                    <li>
+                      <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.inPerson} components={{ findOffice }} />
+                    </li>
+                  </ul>
+                </section>
+              </div>
+            </Collapsible>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Phone number click">
+                {t(($) => $.phoneNumber.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Phone number click"
+              >
+                {t(($) => $.phoneNumber.backBtn)}
+              </ButtonLink>
             </div>
-          </Collapsible>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Phone number click">
-              {t(($) => $.phoneNumber.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Phone number click"
-            >
-              {t(($) => $.phoneNumber.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
+++ b/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
@@ -17,6 +17,7 @@ import {
 import type { ProtectedApplicationChildInformationState, ProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -34,7 +35,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.renewalSelection,
-  pageTitleI18nKey: 'protectedApplicationSpokes:renewalSelection.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -186,41 +186,44 @@ export default function ProtectedSpokesRenewalSelection({ loaderData, params }: 
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputCheckboxes
-            id="applicants"
-            name="applicants"
-            legend={t(($) => $.renewalSelection.select)}
-            options={applicants.map((applicant) => ({
-              value: applicant.id,
-              children: applicant.name,
-              defaultChecked: state.includes(applicant.id),
-            }))}
-            errorMessage={errors?.applicants}
-            required
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Renewal selection click">
-              {t(($) => $.renewalSelection.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="protected/application/$id/renew"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Renewal selection click"
-            >
-              {t(($) => $.renewalSelection.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.renewalSelection.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputCheckboxes
+              id="applicants"
+              name="applicants"
+              legend={t(($) => $.renewalSelection.select)}
+              options={applicants.map((applicant) => ({
+                value: applicant.id,
+                children: applicant.name,
+                defaultChecked: state.includes(applicant.id),
+              }))}
+              errorMessage={errors?.applicants}
+              required
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Renewal selection click">
+                {t(($) => $.renewalSelection.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="protected/application/$id/renew"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Renewal selection click"
+              >
+                {t(($) => $.renewalSelection.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/tax-filing.tsx
+++ b/frontend/app/routes/protected/application/spokes/tax-filing.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -28,7 +29,6 @@ const TAX_FILING_OPTION = { no: 'no', yes: 'yes' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.taxFiling,
-  pageTitleI18nKey: 'protectedApplication:taxFiling.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -85,51 +85,51 @@ export default function ApplicationTaxFiling({ loaderData, params }: Route.Compo
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="tax-filing"
-            name="hasFiledTaxes"
-            legend={t(($) => $.taxFiling.formInstructions, {
-              taxYear: taxYear,
-              ns: 'protectedApplication',
-            })}
-            options={[
-              {
-                value: TAX_FILING_OPTION.yes,
-                children: t(($) => $.taxFiling.radioOptions.yes),
-                defaultChecked: defaultState === true,
-              },
-              {
-                value: TAX_FILING_OPTION.no,
-                children: t(($) => $.taxFiling.radioOptions.no),
-                defaultChecked: defaultState === false,
-              },
-            ]}
-            errorMessage={errors?.hasFiledTaxes}
-            required
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Tax filing click">
-              {t(($) => $.taxFiling.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="protected/application/$id/eligibility-requirements"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Tax filing click"
-            >
-              {t(($) => $.taxFiling.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.taxFiling.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="tax-filing"
+              name="hasFiledTaxes"
+              legend={t(($) => $.taxFiling.formInstructions, { taxYear: taxYear })}
+              options={[
+                {
+                  value: TAX_FILING_OPTION.yes,
+                  children: t(($) => $.taxFiling.radioOptions.yes),
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  value: TAX_FILING_OPTION.no,
+                  children: t(($) => $.taxFiling.radioOptions.no),
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              errorMessage={errors?.hasFiledTaxes}
+              required
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Tax filing click">
+                {t(($) => $.taxFiling.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="protected/application/$id/eligibility-requirements"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Tax filing click"
+              >
+                {t(($) => $.taxFiling.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/terms-conditions.tsx
+++ b/frontend/app/routes/protected/application/spokes/terms-conditions.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -45,7 +46,6 @@ const CONSENT_CHECKBOXES = [CHECKBOX_IDS.ACKNOWLEDGE_TERMS, CHECKBOX_IDS.ACKNOWL
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.termsConditions,
-  pageTitleI18nKey: 'protectedApplicationSpokes:termsConditions.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -193,182 +193,185 @@ export default function ApplyIndex({ loaderData, params }: Route.ComponentProps)
   const cite = <cite />;
 
   return (
-    <div className="max-w-prose">
-      <div className="space-y-6">
-        <h2 className="font-bold">{t(($) => $.termsConditions.beforeYouBegin)}</h2>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.reviewConfirm} components={{ eligibilityRequirements }} />
-          </li>
-          <li>{t(($) => $.termsConditions.resolveActions)}</li>
-          <li>{t(($) => $.termsConditions.reviewStatements)}</li>
-        </ul>
-        <Collapsible summary={t(($) => $.termsConditions.termsAndConditionsOfUse.summary)}>
-          <div className="space-y-6">
-            <div className="space-y-4">
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplicationLegalTerms} components={{ canadaTermsConditions }} />
-              </p>
-              <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.esdcDefinitionClarification)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.termsConditions.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="space-y-6">
+          <h2 className="font-bold">{t(($) => $.termsConditions.beforeYouBegin)}</h2>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.reviewConfirm} components={{ eligibilityRequirements }} />
+            </li>
+            <li>{t(($) => $.termsConditions.resolveActions)}</li>
+            <li>{t(($) => $.termsConditions.reviewStatements)}</li>
+          </ul>
+          <Collapsible summary={t(($) => $.termsConditions.termsAndConditionsOfUse.summary)}>
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplicationLegalTerms} components={{ canadaTermsConditions }} />
+                </p>
+                <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.esdcDefinitionClarification)}</p>
+              </div>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.heading)}</h2>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.selfAgreement)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.timeout)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.incorrectInformation)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.onBehalfOfSomeoneElse)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.atYourOwnRisk)}</li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.msdc} components={{ microsoftDataPrivacyPolicy }} />
+                  </li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.antibot} components={{ hcaptchaTermsOfService }} />
+                  </li>
+                </ul>
+              </section>
+              <section className="space-y-4">
+                <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
+              </section>
             </div>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.heading)}</h2>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.selfAgreement)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.timeout)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.incorrectInformation)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.onBehalfOfSomeoneElse)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.atYourOwnRisk)}</li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.msdc} components={{ microsoftDataPrivacyPolicy }} />
-                </li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.antibot} components={{ hcaptchaTermsOfService }} />
-                </li>
-              </ul>
-            </section>
-            <section className="space-y-4">
-              <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
-            </section>
-          </div>
-        </Collapsible>
+          </Collapsible>
 
-        <Collapsible summary={t(($) => $.termsConditions.privacyNoticeStatement.summary)}>
-          <div className="space-y-6">
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.heading)}</h2>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaApplicationAdministration)}</p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaInformationCollection)}</p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.participation} components={{ contactServiceCanada }} />
-              </p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.policyAnalysis)}</p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.digitalCommunications)}</p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.collectionUse} components={{ cite }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.microsoftPolicy} components={{ microsoftDataPrivacyPolicy, cite }} />
-              </p>
-            </section>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.heading)}</h2>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationRightsAndAccess)}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.hcPpu440} components={{ hcPib }} />
-                </li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.esdcPpu712} components={{ esdcPib }} />
-                </li>
-              </ul>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.infoSourceAccess} components={{ infosource }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyContact} components={{ contactServiceCanada }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationHandlingComplaintProcess} components={{ fileacomplaint }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyProtection} components={{ cdcpPrivacyPolicy }} />
-              </p>
-            </section>
-          </div>
-        </Collapsible>
-        <Collapsible summary={t(($) => $.termsConditions.sharingYourInformation.summary)}>
-          <div className="space-y-6">
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.heading)}</h2>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.shareInfo)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.policyAnalysis)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sendLetters)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.discloseInfo)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sunLifeAuthorization)}</p>
-            </section>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.heading)}</h2>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.enrolConsent)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.consideredMinor)}</p>
-            </section>
-          </div>
-        </Collapsible>
+          <Collapsible summary={t(($) => $.termsConditions.privacyNoticeStatement.summary)}>
+            <div className="space-y-6">
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.heading)}</h2>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaApplicationAdministration)}</p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaInformationCollection)}</p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.participation} components={{ contactServiceCanada }} />
+                </p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.policyAnalysis)}</p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.digitalCommunications)}</p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.collectionUse} components={{ cite }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.microsoftPolicy} components={{ microsoftDataPrivacyPolicy, cite }} />
+                </p>
+              </section>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.heading)}</h2>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationRightsAndAccess)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.hcPpu440} components={{ hcPib }} />
+                  </li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.esdcPpu712} components={{ esdcPib }} />
+                  </li>
+                </ul>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.infoSourceAccess} components={{ infosource }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyContact} components={{ contactServiceCanada }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationHandlingComplaintProcess} components={{ fileacomplaint }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyProtection} components={{ cdcpPrivacyPolicy }} />
+                </p>
+              </section>
+            </div>
+          </Collapsible>
+          <Collapsible summary={t(($) => $.termsConditions.sharingYourInformation.summary)}>
+            <div className="space-y-6">
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.heading)}</h2>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.shareInfo)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.policyAnalysis)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sendLetters)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.discloseInfo)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sunLifeAuthorization)}</p>
+              </section>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.heading)}</h2>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.enrolConsent)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.consideredMinor)}</p>
+              </section>
+            </div>
+          </Collapsible>
+        </div>
+        <p className="my-8" id="application-consent">
+          {t(($) => $.termsConditions.apply.applicationConsent)}
+        </p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <ErrorSummary />
+            <div className="space-y-2">
+              <InputCheckbox
+                id="acknowledge-terms"
+                name={CHECKBOX_IDS.ACKNOWLEDGE_TERMS}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_TERMS]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_TERMS, e.target.checked)}
+                errorMessage={errors?.acknowledgeTerms}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.acknowledgeTerms)}
+              </InputCheckbox>
+
+              <InputCheckbox
+                id="acknowledge-privacy"
+                name={CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, e.target.checked)}
+                errorMessage={errors?.acknowledgePrivacy}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.acknowledgePrivacy)}
+              </InputCheckbox>
+
+              <InputCheckbox
+                id="share-data"
+                name={CHECKBOX_IDS.SHARE_DATA}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.SHARE_DATA]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.SHARE_DATA, e.target.checked)}
+                errorMessage={errors?.shareData}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.shareData)}
+              </InputCheckbox>
+            </div>
+
+            <InputCheckbox
+              id="do-not-consent"
+              name={CHECKBOX_IDS.DO_NOT_CONSENT}
+              value={CHECKBOX_VALUE.yes}
+              className="my-8"
+              checked={checkboxState[CHECKBOX_IDS.DO_NOT_CONSENT]}
+              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.DO_NOT_CONSENT, e.target.checked)}
+              errorMessage={errors?.doNotConsent}
+            >
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.checkboxes.doNotConsent} />
+            </InputCheckbox>
+
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton aria-describedby="application-consent" variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Terms and Conditions click">
+                {t(($) => $.termsConditions.apply.continueButton)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="protected/application/$id/eligibility-requirements"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Terms and Conditions click"
+              >
+                {t(($) => $.termsConditions.apply.backButton)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
       </div>
-      <p className="my-8" id="application-consent">
-        {t(($) => $.termsConditions.apply.applicationConsent)}
-      </p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <ErrorSummary />
-          <div className="space-y-2">
-            <InputCheckbox
-              id="acknowledge-terms"
-              name={CHECKBOX_IDS.ACKNOWLEDGE_TERMS}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_TERMS]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_TERMS, e.target.checked)}
-              errorMessage={errors?.acknowledgeTerms}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.acknowledgeTerms)}
-            </InputCheckbox>
-
-            <InputCheckbox
-              id="acknowledge-privacy"
-              name={CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, e.target.checked)}
-              errorMessage={errors?.acknowledgePrivacy}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.acknowledgePrivacy)}
-            </InputCheckbox>
-
-            <InputCheckbox
-              id="share-data"
-              name={CHECKBOX_IDS.SHARE_DATA}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.SHARE_DATA]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.SHARE_DATA, e.target.checked)}
-              errorMessage={errors?.shareData}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.shareData)}
-            </InputCheckbox>
-          </div>
-
-          <InputCheckbox
-            id="do-not-consent"
-            name={CHECKBOX_IDS.DO_NOT_CONSENT}
-            value={CHECKBOX_VALUE.yes}
-            className="my-8"
-            checked={checkboxState[CHECKBOX_IDS.DO_NOT_CONSENT]}
-            onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.DO_NOT_CONSENT, e.target.checked)}
-            errorMessage={errors?.doNotConsent}
-          >
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.checkboxes.doNotConsent} />
-          </InputCheckbox>
-
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton aria-describedby="application-consent" variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Terms and Conditions click">
-              {t(($) => $.termsConditions.apply.continueButton)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="protected/application/$id/eligibility-requirements"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Terms and Conditions click"
-            >
-              {t(($) => $.termsConditions.apply.backButton)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/type-application.tsx
+++ b/frontend/app/routes/protected/application/spokes/type-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getProtectedApplicationState, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -26,9 +27,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children', delegate: 'delegate' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.typeOfApplication,
-  pageTitleI18nKey: 'protectedApplicationSpokes:typeOfApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -43,7 +43,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.typeOfApplication.pageTitle, { ns: 'protectedApplicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.typeOfApplication.pageTitle) }),
   };
 
   return { meta, defaultState: state.typeOfApplication };
@@ -66,7 +66,7 @@ export async function action({ context: { appContainer, session }, params, reque
    */
   const typeOfApplicationSchema = z.object({
     typeOfApplication: z.enum(APPLICANT_TYPE, {
-      error: t(($) => $.typeOfApplication.errorMessage.typeOfApplicationRequired, { ns: 'protectedApplicationSpokes' }),
+      error: t(($) => $.typeOfApplication.errorMessage.typeOfApplicationRequired),
     }),
   });
 
@@ -95,42 +95,45 @@ export default function ApplicationTypeOfApplication({ loaderData, params }: Rou
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <p className="mt-8 mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="type-of-application"
-            name="typeOfApplication"
-            legend={t(($) => $.typeOfApplication.formInstructions, { ns: 'protectedApplicationSpokes' })}
-            options={[
-              { value: APPLICANT_TYPE.adult, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personal} />, defaultChecked: defaultState === APPLICANT_TYPE.adult },
-              { value: APPLICANT_TYPE.children, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.child} />, defaultChecked: defaultState === APPLICANT_TYPE.children },
-              { value: APPLICANT_TYPE.family, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personalAndChild} />, defaultChecked: defaultState === APPLICANT_TYPE.family },
-              { value: APPLICANT_TYPE.delegate, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.delegate} />, defaultChecked: defaultState === APPLICANT_TYPE.delegate },
-            ]}
-            required
-            errorMessage={errors?.typeOfApplication}
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Type of application click">
-              {t(($) => $.typeOfApplication.saveBtn, { ns: 'protectedApplicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="protected/application/$id/your-application"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Type of application click"
-            >
-              {t(($) => $.typeOfApplication.backBtn, { ns: 'protectedApplicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.typeOfApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mt-8 mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="type-of-application"
+              name="typeOfApplication"
+              legend={t(($) => $.typeOfApplication.formInstructions)}
+              options={[
+                { value: APPLICANT_TYPE.adult, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personal} />, defaultChecked: defaultState === APPLICANT_TYPE.adult },
+                { value: APPLICANT_TYPE.children, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.child} />, defaultChecked: defaultState === APPLICANT_TYPE.children },
+                { value: APPLICANT_TYPE.family, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personalAndChild} />, defaultChecked: defaultState === APPLICANT_TYPE.family },
+                { value: APPLICANT_TYPE.delegate, children: <Trans ns="protectedApplicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.delegate} />, defaultChecked: defaultState === APPLICANT_TYPE.delegate },
+              ]}
+              required
+              errorMessage={errors?.typeOfApplication}
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Save - Type of application click">
+                {t(($) => $.typeOfApplication.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="protected/application/$id/your-application"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Type of application click"
+              >
+                {t(($) => $.typeOfApplication.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/application/spokes/verify-email.tsx
+++ b/frontend/app/routes/protected/application/spokes/verify-email.tsx
@@ -12,6 +12,7 @@ import { getProtectedApplicationState, saveProtectedApplicationState, validateAp
 import type { ApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
@@ -53,7 +54,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.verifyEmail,
-  pageTitleI18nKey: 'protectedApplicationSpokes:verifyEmail.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -232,92 +232,100 @@ export default function ApplicationVerifyEmail({ loaderData, params }: Route.Com
   );
 
   return (
-    <div className="max-w-prose">
-      <ErrorAlert>
-        <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
-        <p className="-mb-3">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.verificationCodeAlert.detail} components={{ requestLink }} />
-        </p>
-      </ErrorAlert>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <p className="mb-4">
-          {t(($) => $.verifyEmail.verificationCode, {
-            email: defaultState,
-            ns: 'protectedApplicationSpokes',
-          })}
-        </p>
-        <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
-        <p className="mb-8">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
-        </p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
-            </div>
-            <LoadingButton
-              id="request-button"
-              type="button"
-              name="_action"
-              variant="link"
-              className="no-underline hover:underline"
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.request}
-              value={FORM_ACTION.request}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Request new verification code - Verify email click"
-              onClick={async () => {
-                const formData = new FormData();
-                formData.append('_action', FORM_ACTION.request);
-                formData.append('_csrf', csrfToken);
-
-                await fetcher.submit(formData, { method: 'post' });
-              }}
-            >
-              {t(($) => $.verifyEmail.requestNewCode)}
-            </LoadingButton>
-          </div>
-
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton
-              variant="primary"
-              id="continue-button"
-              name="_action"
-              value={FORM_ACTION.submit}
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.submit}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Verify email click"
-            >
-              {t(($) => $.verifyEmail.continue)}
-            </LoadingButton>
-            <ButtonLink id="back-button" variant="secondary" routeId="protected/application/$id/email" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Verify email click">
-              {t(($) => $.verifyEmail.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-      <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
-          </DialogHeader>
-          <DialogDescription>
-            {t(($) => $.verifyEmail.codeSent.detail, {
+    <>
+      <AppPageTitle>{t(($) => $.verifyEmail.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
+          <p className="-mb-3">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.verificationCodeAlert.detail} components={{ requestLink }} />
+          </p>
+        </ErrorAlert>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <p className="mb-4">
+            {t(($) => $.verifyEmail.verificationCode, {
               email: defaultState,
-              ns: 'protectedApplicationSpokes',
             })}
-          </DialogDescription>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Modal Continue - Verify email click">
+          </p>
+          <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
+          <p className="mb-8">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
+          </p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'protectedApplication' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-6">
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
+              </div>
+              <LoadingButton
+                id="request-button"
+                type="button"
+                name="_action"
+                variant="link"
+                className="no-underline hover:underline"
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.request}
+                value={FORM_ACTION.request}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Request new verification code - Verify email click"
+                onClick={async () => {
+                  const formData = new FormData();
+                  formData.append('_action', FORM_ACTION.request);
+                  formData.append('_csrf', csrfToken);
+
+                  await fetcher.submit(formData, { method: 'post' });
+                }}
+              >
+                {t(($) => $.verifyEmail.requestNewCode)}
+              </LoadingButton>
+            </div>
+
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                variant="primary"
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.submit}
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.submit}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Continue - Verify email click"
+              >
                 {t(($) => $.verifyEmail.continue)}
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="protected/application/$id/email"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Back - Verify email click"
+              >
+                {t(($) => $.verifyEmail.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+        <Dialog open={showDialog} onOpenChange={setShowDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
+            </DialogHeader>
+            <DialogDescription>
+              {t(($) => $.verifyEmail.codeSent.detail, {
+                email: defaultState,
+              })}
+            </DialogDescription>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Protected-Spoke:Modal Continue - Verify email click">
+                  {t(($) => $.verifyEmail.continue)}
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -5,6 +5,7 @@ import type { Route } from './+types/data-unavailable';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
@@ -16,7 +17,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('dataUnavailable', 'gcweb'),
   pageIdentifier: pageIds.protected.dataUnavailable,
-  pageTitleI18nKey: 'dataUnavailable:pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,31 +47,34 @@ export default function DataUnavailable({ loaderData, params }: Route.ComponentP
   const contactLink = <InlineLink to={t(($) => $.contactUsHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="space-y-4">
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.serviceEligible} components={{ statusCheckerLink }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.otherEnquiry} components={{ cdcpLink }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.serviceDelay} components={{ contactLink }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="space-y-4">
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.serviceEligible} components={{ statusCheckerLink }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.otherEnquiry} components={{ cdcpLink }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.serviceDelay} components={{ contactLink }} />
+          </p>
+        </div>
+        <div className="mt-6 flex flex-wrap items-center gap-3">
+          <ButtonLink
+            id="back-button"
+            to={t(($) => $.header.menuDashboardHref, {
+              baseUri: SCCH_BASE_URI,
+              ns: 'gcweb',
+            })}
+            variant="primary"
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Applications:Return to dashboard - You have not applied for CDCP click"
+          >
+            {t(($) => $.backButton)}
+          </ButtonLink>
+        </div>
       </div>
-      <div className="mt-6 flex flex-wrap items-center gap-3">
-        <ButtonLink
-          id="back-button"
-          to={t(($) => $.header.menuDashboardHref, {
-            baseUri: SCCH_BASE_URI,
-            ns: 'gcweb',
-          })}
-          variant="primary"
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applications:Return to dashboard - You have not applied for CDCP click"
-        >
-          {t(($) => $.backButton)}
-        </ButtonLink>
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/documents/index.tsx
+++ b/frontend/app/routes/protected/documents/index.tsx
@@ -6,6 +6,7 @@ import type { Route } from './+types/index';
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/table';
 import { pageIds } from '~/page-ids';
@@ -18,7 +19,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
   pageIdentifier: pageIds.protected.documents.index,
-  pageTitleI18nKey: 'documents:index.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,50 +66,53 @@ export default function DocumentsIndex({ loaderData, params }: Route.ComponentPr
   const hasDocuments = documents.length > 0;
 
   return (
-    <div className="space-y-8">
-      <div className="space-y-4">
-        <p>{hasDocuments ? t(($) => $.index.hasDocuments) : t(($) => $.index.noDocuments)}</p>
-        {hasDocuments && (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>{t(($) => $.index.tableHeaders.fileName)}</TableHead>
-                <TableHead>{t(($) => $.index.tableHeaders.applicant)}</TableHead>
-                <TableHead>{t(($) => $.index.tableHeaders.typeOfDocument)}</TableHead>
-                <TableHead>{t(($) => $.index.tableHeaders.dateUploaded)}</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {documents.map((document) => (
-                <TableRow key={document.id} className="odd:bg-white even:bg-gray-50">
-                  <TableCell className="max-w-[200px] break-all">{document.fileName}</TableCell>
-                  <TableCell>{`${document.client.firstName} ${document.client.lastName}`}</TableCell>
-                  <TableCell>{document.documentType.name}</TableCell>
-                  <TableCell className="text-nowrap">{document.mscaUploadDateFormatted}</TableCell>
+    <>
+      <AppPageTitle>{t(($) => $.index.pageTitle)}</AppPageTitle>
+      <div className="space-y-8">
+        <div className="space-y-4">
+          <p>{hasDocuments ? t(($) => $.index.hasDocuments) : t(($) => $.index.noDocuments)}</p>
+          {hasDocuments && (
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>{t(($) => $.index.tableHeaders.fileName)}</TableHead>
+                  <TableHead>{t(($) => $.index.tableHeaders.applicant)}</TableHead>
+                  <TableHead>{t(($) => $.index.tableHeaders.typeOfDocument)}</TableHead>
+                  <TableHead>{t(($) => $.index.tableHeaders.dateUploaded)}</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
-        )}
+              </TableHeader>
+              <TableBody>
+                {documents.map((document) => (
+                  <TableRow key={document.id} className="odd:bg-white even:bg-gray-50">
+                    <TableCell className="max-w-[200px] break-all">{document.fileName}</TableCell>
+                    <TableCell>{`${document.client.firstName} ${document.client.lastName}`}</TableCell>
+                    <TableCell>{document.documentType.name}</TableCell>
+                    <TableCell className="text-nowrap">{document.mscaUploadDateFormatted}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          )}
+        </div>
+        <div>
+          <ButtonLink id="upload-button" routeId="protected/documents/upload" params={params} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Upload documents - Submitted documents click">
+            {t(($) => $.index.uploadDocuments)}
+          </ButtonLink>
+        </div>
+        <div>
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            to={t(($) => $.header.menuDashboardHref, {
+              baseUri: SCCH_BASE_URI,
+              ns: 'gcweb',
+            })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Return to dashboard - Submitted documents click"
+          >
+            {t(($) => $.index.returnDashboard)}
+          </ButtonLink>
+        </div>
       </div>
-      <div>
-        <ButtonLink id="upload-button" routeId="protected/documents/upload" params={params} variant="primary" data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Upload documents - Submitted documents click">
-          {t(($) => $.index.uploadDocuments)}
-        </ButtonLink>
-      </div>
-      <div>
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          to={t(($) => $.header.menuDashboardHref, {
-            baseUri: SCCH_BASE_URI,
-            ns: 'gcweb',
-          })}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Return to dashboard - Submitted documents click"
-        >
-          {t(($) => $.index.returnDashboard)}
-        </ButtonLink>
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/documents/not-required.tsx
+++ b/frontend/app/routes/protected/documents/not-required.tsx
@@ -5,6 +5,7 @@ import type { Route } from './+types/not-required';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -16,7 +17,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'documents:index.pageTitle', routeId: 'protected/documents/index' }],
   i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
   pageIdentifier: pageIds.protected.documents.notRequired,
-  pageTitleI18nKey: 'documents:notRequired.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -45,6 +45,7 @@ export default function NotRequired({ loaderData, params }: Route.ComponentProps
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.notRequired.pageTitle)}</AppPageTitle>
       <p>{t(($) => $.notRequired.description)}</p>
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <ButtonLink

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -16,6 +16,7 @@ import { TYPES } from '~/.server/constants';
 import type { DocumentUploadService } from '~/.server/domain/services';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -50,7 +51,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'documents:index.pageTitle', routeId: 'protected/documents/index' }],
   i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
   pageIdentifier: pageIds.protected.documents.upload,
-  pageTitleI18nKey: 'documents:upload.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -561,104 +561,107 @@ export default function DocumentsUpload({ loaderData, params }: Route.ComponentP
   }, [documentTypes, t]);
 
   return (
-    <div className="max-w-prose space-y-8">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
-          <CsrfTokenInput />
-          <div className="space-y-6">
-            <InputSelect id="applicant" name="applicant" label={t(($) => $.upload.whoAreYouUploadingFor)} required className="w-full" options={applicantOptions} defaultValue="" errorMessage={applicantError} />
-            <fieldset>
-              <InputLegend className="mb-2">{t(($) => $.upload.uploadDocument)}</InputLegend>
-              <p>
-                {t(($) => $.upload.maxFiles, {
-                  count: DOCUMENT_UPLOAD_MAX_FILE_COUNT,
-                  ns: 'documents',
-                })}
-              </p>
-              <p className="mb-2">
-                {t(($) => $.upload.maxSize, {
-                  filesize: bytesToFilesize(megabytesToBytes(env.DOCUMENT_UPLOAD_MAX_FILE_SIZE_MB), `${i18n.language}-CA`),
-                  extensions: DOCUMENT_UPLOAD_ALLOWED_FILE_EXTENSIONS.join(', '),
-                  ns: 'documents',
-                })}
-              </p>
-              {filesError && <InputError id="files-error" className="mb-2" fieldId="fileUploadTrigger" message={filesError} />}
-              <FileUpload id="file-upload" label={t(($) => $.upload.uploadDocument)} value={filesWithTypes} onValueChange={handleFileChange} accept={DOCUMENT_UPLOAD_ALLOWED_FILE_EXTENSIONS.join(',')} className="gap-4 sm:gap-6">
-                <div>
-                  <FileUploadTrigger asChild>
-                    <Button id="fileUploadTrigger" variant="secondary" className={cn(filesError !== undefined && 'border-red-500 text-red-500 hover:bg-red-100 focus:bg-red-100')} startIcon={faArrowUpFromBracket}>
-                      {t(($) => $.upload.addFile)}
-                    </Button>
-                  </FileUploadTrigger>
-                </div>
-                <FileUploadList className="gap-4 sm:gap-6">
-                  {filesWithTypes.map(({ id, file, documentType }) => {
-                    const fileError = errors?.properties?.files?.properties?.[id]?.properties?.file?.errors.at(0);
-                    const documentTypeError = errors?.properties?.files?.properties?.[id]?.properties?.documentType?.errors.at(0);
-                    return (
-                      <FileUploadItem
-                        id={`file-upload-item-${id}`}
-                        key={id}
-                        value={id}
-                        className={cn('flex-col items-stretch gap-3 sm:gap-4', fileError && 'border-red-500 focus:border-red-500 focus:ring-3 focus:ring-red-500 focus:outline-hidden')}
-                        tabIndex={-1}
-                      >
-                        {fileError && <InputError id={`file-error-${id}`} fieldId={`file-upload-item-${id}`} message={fileError} />}
-                        <dl className="space-y-3 sm:space-y-4">
-                          <div className="space-y-2">
-                            <dt className="font-semibold">{t(($) => $.upload.fileName)}</dt>
-                            <dd>{file.name}</dd>
-                          </div>
-                        </dl>
-                        <InputSelect
-                          id={`document-type-${id}`}
-                          name={`document-type-${id}`}
-                          label={t(($) => $.upload.documentType)}
-                          required
-                          className="w-full"
-                          options={docTypeOptions}
-                          value={documentType}
-                          onChange={(e) => {
-                            setFilesWithTypes((prev) => prev.map((p) => (p.id === id ? { ...p, documentType: e.target.value } : p)));
-                          }}
-                          errorMessage={documentTypeError}
-                        />
-                        <div className="mt-2">
-                          <FileUploadItemDelete asChild>
-                            <Button variant="secondary" size="sm" endIcon={faTimes}>
-                              {t(($) => $.upload.remove)}
-                            </Button>
-                          </FileUploadItemDelete>
-                        </div>
-                      </FileUploadItem>
-                    );
+    <>
+      <AppPageTitle>{t(($) => $.upload.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
+            <CsrfTokenInput />
+            <div className="space-y-6">
+              <InputSelect id="applicant" name="applicant" label={t(($) => $.upload.whoAreYouUploadingFor)} required className="w-full" options={applicantOptions} defaultValue="" errorMessage={applicantError} />
+              <fieldset>
+                <InputLegend className="mb-2">{t(($) => $.upload.uploadDocument)}</InputLegend>
+                <p>
+                  {t(($) => $.upload.maxFiles, {
+                    count: DOCUMENT_UPLOAD_MAX_FILE_COUNT,
+                    ns: 'documents',
                   })}
-                </FileUploadList>
-              </FileUpload>
-            </fieldset>
-          </div>
+                </p>
+                <p className="mb-2">
+                  {t(($) => $.upload.maxSize, {
+                    filesize: bytesToFilesize(megabytesToBytes(env.DOCUMENT_UPLOAD_MAX_FILE_SIZE_MB), `${i18n.language}-CA`),
+                    extensions: DOCUMENT_UPLOAD_ALLOWED_FILE_EXTENSIONS.join(', '),
+                    ns: 'documents',
+                  })}
+                </p>
+                {filesError && <InputError id="files-error" className="mb-2" fieldId="fileUploadTrigger" message={filesError} />}
+                <FileUpload id="file-upload" label={t(($) => $.upload.uploadDocument)} value={filesWithTypes} onValueChange={handleFileChange} accept={DOCUMENT_UPLOAD_ALLOWED_FILE_EXTENSIONS.join(',')} className="gap-4 sm:gap-6">
+                  <div>
+                    <FileUploadTrigger asChild>
+                      <Button id="fileUploadTrigger" variant="secondary" className={cn(filesError !== undefined && 'border-red-500 text-red-500 hover:bg-red-100 focus:bg-red-100')} startIcon={faArrowUpFromBracket}>
+                        {t(($) => $.upload.addFile)}
+                      </Button>
+                    </FileUploadTrigger>
+                  </div>
+                  <FileUploadList className="gap-4 sm:gap-6">
+                    {filesWithTypes.map(({ id, file, documentType }) => {
+                      const fileError = errors?.properties?.files?.properties?.[id]?.properties?.file?.errors.at(0);
+                      const documentTypeError = errors?.properties?.files?.properties?.[id]?.properties?.documentType?.errors.at(0);
+                      return (
+                        <FileUploadItem
+                          id={`file-upload-item-${id}`}
+                          key={id}
+                          value={id}
+                          className={cn('flex-col items-stretch gap-3 sm:gap-4', fileError && 'border-red-500 focus:border-red-500 focus:ring-3 focus:ring-red-500 focus:outline-hidden')}
+                          tabIndex={-1}
+                        >
+                          {fileError && <InputError id={`file-error-${id}`} fieldId={`file-upload-item-${id}`} message={fileError} />}
+                          <dl className="space-y-3 sm:space-y-4">
+                            <div className="space-y-2">
+                              <dt className="font-semibold">{t(($) => $.upload.fileName)}</dt>
+                              <dd>{file.name}</dd>
+                            </div>
+                          </dl>
+                          <InputSelect
+                            id={`document-type-${id}`}
+                            name={`document-type-${id}`}
+                            label={t(($) => $.upload.documentType)}
+                            required
+                            className="w-full"
+                            options={docTypeOptions}
+                            value={documentType}
+                            onChange={(e) => {
+                              setFilesWithTypes((prev) => prev.map((p) => (p.id === id ? { ...p, documentType: e.target.value } : p)));
+                            }}
+                            errorMessage={documentTypeError}
+                          />
+                          <div className="mt-2">
+                            <FileUploadItemDelete asChild>
+                              <Button variant="secondary" size="sm" endIcon={faTimes}>
+                                {t(($) => $.upload.remove)}
+                              </Button>
+                            </FileUploadItemDelete>
+                          </div>
+                        </FileUploadItem>
+                      );
+                    })}
+                  </FileUploadList>
+                </FileUpload>
+              </fieldset>
+            </div>
 
-          <div className="mt-8">
-            <LoadingButton id="submit-button" variant="primary" type="submit" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Submit - Upload my documents click">
-              {t(($) => $.upload.submit)}
-            </LoadingButton>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-      <div>
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          to={t(($) => $.header.menuDashboardHref, {
-            baseUri: SCCH_BASE_URI,
-            ns: 'gcweb',
-          })}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Return to dashboard - Upload my documents click"
-        >
-          {t(($) => $.index.returnDashboard)}
-        </ButtonLink>
+            <div className="mt-8">
+              <LoadingButton id="submit-button" variant="primary" type="submit" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Submit - Upload my documents click">
+                {t(($) => $.upload.submit)}
+              </LoadingButton>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+        <div>
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            to={t(($) => $.header.menuDashboardHref, {
+              baseUri: SCCH_BASE_URI,
+              ns: 'gcweb',
+            })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Return to dashboard - Upload my documents click"
+          >
+            {t(($) => $.index.returnDashboard)}
+          </ButtonLink>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -11,6 +11,7 @@ import type { Route } from './+types/index';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { InlineLink } from '~/components/inline-link';
@@ -26,7 +27,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'letters:index.pageTitle' }],
   i18nNamespaces: getTypedI18nNamespaces('letters', 'gcweb'),
   pageIdentifier: pageIds.protected.letters.index,
-  pageTitleI18nKey: 'letters:index.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -79,6 +79,7 @@ export default function LettersIndex({ loaderData, params }: Route.ComponentProp
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.index.pageTitle)}</AppPageTitle>
       {letters.length === 0 ? (
         <ContextualAlert type="info">
           <p>{t(($) => $.index.noLetter)}</p>

--- a/frontend/app/routes/protected/profile/applicant-information.tsx
+++ b/frontend/app/routes/protected/profile/applicant-information.tsx
@@ -4,6 +4,7 @@ import type { Route } from './+types/applicant-information';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { pageIds } from '~/page-ids';
@@ -16,7 +17,6 @@ import { formatSin, isValidSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.applicantInformation,
-  pageTitleI18nKey: 'protectedProfile:applicantInformation.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -64,41 +64,44 @@ export default function ProtectedApplicantInformation({ loaderData, params }: Ro
   const { primaryApplicant, children, SCCH_BASE_URI } = loaderData;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <p>
-        <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicantInformation.formInstructions} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
-      </p>
-      <section className="space-y-6">
-        <h2 className="font-lato text-2xl font-bold">{`${primaryApplicant.firstName} ${primaryApplicant.lastName}`}</h2>
-        <DefinitionList border>
-          <DefinitionListItem term={t(($) => $.applicantInformation.memberId)}>{primaryApplicant.id}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.applicantInformation.dob)}>{primaryApplicant.dob}</DefinitionListItem>
-          <DefinitionListItem term={t(($) => $.applicantInformation.sin)}>{isValidSin(primaryApplicant.sin) ? formatSin(primaryApplicant.sin) : primaryApplicant.sin}</DefinitionListItem>
-        </DefinitionList>
-      </section>
-      {children.map((child) => {
-        return (
-          <section className="space-y-6" key={child.id}>
-            <h2 className="font-lato text-2xl font-bold">{`${child.firstName} ${child.lastName}`}</h2>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.applicantInformation.memberId)}>{child.id}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.applicantInformation.dob)}>{child.dob}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.applicantInformation.sin)}>{typeof child.sin === 'string' && isValidSin(child.sin) ? formatSin(child.sin) : child.sin}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-        );
-      })}
-      <ButtonLink
-        variant="primary"
-        id="back-button"
-        to={t(($) => $.header.menuDashboardHref, {
-          baseUri: SCCH_BASE_URI,
-          ns: 'gcweb',
+    <>
+      <AppPageTitle>{t(($) => $.applicantInformation.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <p>
+          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicantInformation.formInstructions} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
+        </p>
+        <section className="space-y-6">
+          <h2 className="font-lato text-2xl font-bold">{`${primaryApplicant.firstName} ${primaryApplicant.lastName}`}</h2>
+          <DefinitionList border>
+            <DefinitionListItem term={t(($) => $.applicantInformation.memberId)}>{primaryApplicant.id}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.applicantInformation.dob)}>{primaryApplicant.dob}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.applicantInformation.sin)}>{isValidSin(primaryApplicant.sin) ? formatSin(primaryApplicant.sin) : primaryApplicant.sin}</DefinitionListItem>
+          </DefinitionList>
+        </section>
+        {children.map((child) => {
+          return (
+            <section className="space-y-6" key={child.id}>
+              <h2 className="font-lato text-2xl font-bold">{`${child.firstName} ${child.lastName}`}</h2>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.applicantInformation.memberId)}>{child.id}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.applicantInformation.dob)}>{child.dob}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.applicantInformation.sin)}>{typeof child.sin === 'string' && isValidSin(child.sin) ? formatSin(child.sin) : child.sin}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+          );
         })}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Applicant information return button click"
-      >
-        {t(($) => $.applicantInformation.returnButton)}
-      </ButtonLink>
-    </div>
+        <ButtonLink
+          variant="primary"
+          id="back-button"
+          to={t(($) => $.header.menuDashboardHref, {
+            baseUri: SCCH_BASE_URI,
+            ns: 'gcweb',
+          })}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Applicant information return button click"
+        >
+          {t(($) => $.applicantInformation.returnButton)}
+        </ButtonLink>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/communication-preferences.tsx
@@ -4,6 +4,7 @@ import type { Route } from './+types/communication-preferences';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
@@ -15,7 +16,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.communicationPreferences,
-  pageTitleI18nKey: 'protectedProfile:communicationPreferences.pageTitle',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -58,28 +58,31 @@ export default function ViewCommunicationPreferences({ loaderData, params }: Rou
   const { preferredLanguage, preferredMethodSunLife, preferredMethodGovernmentOfCanada, SCCH_BASE_URI } = loaderData;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <DefinitionList border>
-        <DefinitionListItem term={t(($) => $.communicationPreferences.languagePreference)}>{preferredLanguage?.name}</DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.communicationPreferences.sunlifeCommunicationPreference)}>{preferredMethodSunLife?.name}</DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.communicationPreferences.gocCommunicationPreference)}>{preferredMethodGovernmentOfCanada?.name}</DefinitionListItem>
-      </DefinitionList>
-      <div>
-        <InlineLink id="update-communication-preferences" routeId="protected/profile/communication-preferences/edit" params={params}>
-          {t(($) => $.communicationPreferences.updateLinkText)}
-        </InlineLink>
+    <>
+      <AppPageTitle>{t(($) => $.communicationPreferences.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <DefinitionList border>
+          <DefinitionListItem term={t(($) => $.communicationPreferences.languagePreference)}>{preferredLanguage?.name}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.communicationPreferences.sunlifeCommunicationPreference)}>{preferredMethodSunLife?.name}</DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.communicationPreferences.gocCommunicationPreference)}>{preferredMethodGovernmentOfCanada?.name}</DefinitionListItem>
+        </DefinitionList>
+        <div>
+          <InlineLink id="update-communication-preferences" routeId="protected/profile/communication-preferences/edit" params={params}>
+            {t(($) => $.communicationPreferences.updateLinkText)}
+          </InlineLink>
+        </div>
+        <ButtonLink
+          variant="primary"
+          id="back-button"
+          to={t(($) => $.header.menuDashboardHref, {
+            baseUri: SCCH_BASE_URI,
+            ns: 'gcweb',
+          })}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - My communication preferences return button click"
+        >
+          {t(($) => $.communicationPreferences.returnButton)}
+        </ButtonLink>
       </div>
-      <ButtonLink
-        variant="primary"
-        id="back-button"
-        to={t(($) => $.header.menuDashboardHref, {
-          baseUri: SCCH_BASE_URI,
-          ns: 'gcweb',
-        })}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - My communication preferences return button click"
-      >
-        {t(($) => $.communicationPreferences.returnButton)}
-      </ButtonLink>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/contact-information.tsx
+++ b/frontend/app/routes/protected/profile/contact-information.tsx
@@ -8,6 +8,7 @@ import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import type { AddressDetails } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Badge } from '~/components/badge';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.contactInformation,
-  pageTitleI18nKey: 'protectedProfile:contactInformation.pageTitle',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -87,63 +87,66 @@ export default function ViewContactInformation({ loaderData, params }: Route.Com
   const emailVerificationStatus = loaderData.emailAddress ? (loaderData.emailAddressVerified ? 'verified' : 'unverified') : undefined;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <DefinitionList border>
-        <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)} className="border-none pb-0 sm:pb-0">
-          {phoneNumber ?? t(($) => $.none)}
-        </DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>
-          <p>{altPhoneNumber ?? t(($) => $.none)}</p>
-          <div className="mt-4 sm:mt-6">
-            <InlineLink id="update-contact-information-phone" routeId="protected/profile/contact/phone" params={params}>
-              {t(($) => $.contactInformation.updatePhoneLinkText)}
-            </InlineLink>
-          </div>
-        </DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.contactInformation.email)}>
-          <p>{emailAddress ?? t(($) => $.none)}</p>
-          {emailVerificationStatus && (
-            <Badge asChild size="lg" variant={emailVerificationStatus === 'unverified' ? 'warning' : 'success'}>
-              <p className="mt-3">
-                <FontAwesomeIcon icon={emailVerificationStatus === 'unverified' ? faExclamationTriangle : faCheckCircle} />
-                {t(($) => $.contactInformation.emailVerificationStatus[emailVerificationStatus])}
-              </p>
-            </Badge>
-          )}
-          <div className="mt-4 sm:mt-6">
-            <InlineLink id="update-contact-information-email" routeId="protected/profile/contact/email-address" params={params}>
-              {t(($) => $.contactInformation.updateEmailLinkText)}
-            </InlineLink>
-          </div>
-        </DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
-          <Address address={mailingAddressDetails} />
-          <div className="mt-4 sm:mt-6">
-            <InlineLink id="update-contact-information-mailing-address" routeId="protected/profile/contact/mailing-address" params={params}>
-              {t(($) => $.contactInformation.updateMailingAddressLinkText)}
-            </InlineLink>
-          </div>
-        </DefinitionListItem>
-        <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
-          {homeAddressDetails && <Address address={homeAddressDetails} />}
-          <div className="mt-4 sm:mt-6">
-            <InlineLink id="update-contact-information-home-address" routeId="protected/profile/contact/home-address" params={params}>
-              {t(($) => $.contactInformation.updateHomeAddressLinkText)}
-            </InlineLink>
-          </div>
-        </DefinitionListItem>
-      </DefinitionList>
-      <ButtonLink
-        variant="primary"
-        id="back-button"
-        to={t(($) => $.header.menuDashboardHref, {
-          baseUri: SCCH_BASE_URI,
-          ns: 'gcweb',
-        })}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - My contact information return button click"
-      >
-        {t(($) => $.contactInformation.returnButton)}
-      </ButtonLink>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <DefinitionList border>
+          <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)} className="border-none pb-0 sm:pb-0">
+            {phoneNumber ?? t(($) => $.none)}
+          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>
+            <p>{altPhoneNumber ?? t(($) => $.none)}</p>
+            <div className="mt-4 sm:mt-6">
+              <InlineLink id="update-contact-information-phone" routeId="protected/profile/contact/phone" params={params}>
+                {t(($) => $.contactInformation.updatePhoneLinkText)}
+              </InlineLink>
+            </div>
+          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.email)}>
+            <p>{emailAddress ?? t(($) => $.none)}</p>
+            {emailVerificationStatus && (
+              <Badge asChild size="lg" variant={emailVerificationStatus === 'unverified' ? 'warning' : 'success'}>
+                <p className="mt-3">
+                  <FontAwesomeIcon icon={emailVerificationStatus === 'unverified' ? faExclamationTriangle : faCheckCircle} />
+                  {t(($) => $.contactInformation.emailVerificationStatus[emailVerificationStatus])}
+                </p>
+              </Badge>
+            )}
+            <div className="mt-4 sm:mt-6">
+              <InlineLink id="update-contact-information-email" routeId="protected/profile/contact/email-address" params={params}>
+                {t(($) => $.contactInformation.updateEmailLinkText)}
+              </InlineLink>
+            </div>
+          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
+            <Address address={mailingAddressDetails} />
+            <div className="mt-4 sm:mt-6">
+              <InlineLink id="update-contact-information-mailing-address" routeId="protected/profile/contact/mailing-address" params={params}>
+                {t(($) => $.contactInformation.updateMailingAddressLinkText)}
+              </InlineLink>
+            </div>
+          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
+            {homeAddressDetails && <Address address={homeAddressDetails} />}
+            <div className="mt-4 sm:mt-6">
+              <InlineLink id="update-contact-information-home-address" routeId="protected/profile/contact/home-address" params={params}>
+                {t(($) => $.contactInformation.updateHomeAddressLinkText)}
+              </InlineLink>
+            </div>
+          </DefinitionListItem>
+        </DefinitionList>
+        <ButtonLink
+          variant="primary"
+          id="back-button"
+          to={t(($) => $.header.menuDashboardHref, {
+            baseUri: SCCH_BASE_URI,
+            ns: 'gcweb',
+          })}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - My contact information return button click"
+        >
+          {t(($) => $.contactInformation.returnButton)}
+        </ButtonLink>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/dental-benefits.tsx
@@ -4,6 +4,7 @@ import type { Route } from './+types/dental-benefits';
 
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
@@ -15,7 +16,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.dentalBenefits,
-  pageTitleI18nKey: 'protectedProfile:dentalBenefits.pageTitle',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -74,70 +74,73 @@ export default function ViewGovernmentDentalBenefits({ loaderData, params }: Rou
   const { clientApplication, clientDentalBenefits, children, SCCH_BASE_URI } = loaderData;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental)}</p>
-      <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria)}</p>
-      <section className="space-y-6">
-        <h2 className="font-lato text-2xl font-bold">{`${clientApplication.applicantInformation.firstName} ${clientApplication.applicantInformation.lastName}`}</h2>
-        <DefinitionList border>
-          <DefinitionListItem term={t(($) => $.dentalBenefits.haveAccess)}>
-            <div className="space-y-4">
-              <p>{clientDentalBenefits && clientDentalBenefits.length > 0 ? t(($) => $.dentalBenefits.yes) : t(($) => $.dentalBenefits.no)}</p>
-              {clientDentalBenefits && clientDentalBenefits.length > 0 && (
-                <ul className="list-disc space-y-2 pl-10">
-                  {clientDentalBenefits.map((benefit, index) => (
-                    <li key={index}>{benefit}</li>
-                  ))}
-                </ul>
-              )}
-            </div>
-            <div className="mt-4 sm:mt-6">
-              <InlineLink routeId="protected/profile/dental-benefits/edit" params={params}>
-                {t(($) => $.dentalBenefits.updateLinkText)}
-              </InlineLink>
-            </div>
-          </DefinitionListItem>
-        </DefinitionList>
-      </section>
-      {children.map((child) => {
-        const childParams = { ...params, childId: child.information.clientId };
-        const childName = `${child.information.firstName} ${child.information.lastName}`;
-        return (
-          <section className="space-y-6" key={child.information.clientId}>
-            <h2 className="font-lato text-2xl font-bold">{childName}</h2>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.dentalBenefits.haveAccess)}>
-                <div className="space-y-4">
-                  <p>{child.dentalBenefits.length > 0 ? t(($) => $.dentalBenefits.yes) : t(($) => $.dentalBenefits.no)}</p>
-                  {child.dentalBenefits.length > 0 && (
-                    <ul className="list-disc space-y-2 pl-10">
-                      {child.dentalBenefits.map((benefit) => (
-                        <li key={benefit}>{benefit}</li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-                <div className="mt-4 sm:mt-6">
-                  <InlineLink routeId="protected/profile/dental-benefits/:childId/edit" params={childParams}>
-                    {t(($) => $.dentalBenefits.updateLinkText)}
-                  </InlineLink>
-                </div>
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-        );
-      })}
-      <ButtonLink
-        variant="primary"
-        id="back-button"
-        to={t(($) => $.header.menuDashboardHref, {
-          baseUri: SCCH_BASE_URI,
-          ns: 'gcweb',
+    <>
+      <AppPageTitle>{t(($) => $.dentalBenefits.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental)}</p>
+        <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria)}</p>
+        <section className="space-y-6">
+          <h2 className="font-lato text-2xl font-bold">{`${clientApplication.applicantInformation.firstName} ${clientApplication.applicantInformation.lastName}`}</h2>
+          <DefinitionList border>
+            <DefinitionListItem term={t(($) => $.dentalBenefits.haveAccess)}>
+              <div className="space-y-4">
+                <p>{clientDentalBenefits && clientDentalBenefits.length > 0 ? t(($) => $.dentalBenefits.yes) : t(($) => $.dentalBenefits.no)}</p>
+                {clientDentalBenefits && clientDentalBenefits.length > 0 && (
+                  <ul className="list-disc space-y-2 pl-10">
+                    {clientDentalBenefits.map((benefit, index) => (
+                      <li key={index}>{benefit}</li>
+                    ))}
+                  </ul>
+                )}
+              </div>
+              <div className="mt-4 sm:mt-6">
+                <InlineLink routeId="protected/profile/dental-benefits/edit" params={params}>
+                  {t(($) => $.dentalBenefits.updateLinkText)}
+                </InlineLink>
+              </div>
+            </DefinitionListItem>
+          </DefinitionList>
+        </section>
+        {children.map((child) => {
+          const childParams = { ...params, childId: child.information.clientId };
+          const childName = `${child.information.firstName} ${child.information.lastName}`;
+          return (
+            <section className="space-y-6" key={child.information.clientId}>
+              <h2 className="font-lato text-2xl font-bold">{childName}</h2>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.dentalBenefits.haveAccess)}>
+                  <div className="space-y-4">
+                    <p>{child.dentalBenefits.length > 0 ? t(($) => $.dentalBenefits.yes) : t(($) => $.dentalBenefits.no)}</p>
+                    {child.dentalBenefits.length > 0 && (
+                      <ul className="list-disc space-y-2 pl-10">
+                        {child.dentalBenefits.map((benefit) => (
+                          <li key={benefit}>{benefit}</li>
+                        ))}
+                      </ul>
+                    )}
+                  </div>
+                  <div className="mt-4 sm:mt-6">
+                    <InlineLink routeId="protected/profile/dental-benefits/:childId/edit" params={childParams}>
+                      {t(($) => $.dentalBenefits.updateLinkText)}
+                    </InlineLink>
+                  </div>
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+          );
         })}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Other government dental benefits return button click"
-      >
-        {t(($) => $.dentalBenefits.returnButton)}
-      </ButtonLink>
-    </div>
+        <ButtonLink
+          variant="primary"
+          id="back-button"
+          to={t(($) => $.header.menuDashboardHref, {
+            baseUri: SCCH_BASE_URI,
+            ns: 'gcweb',
+          })}
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Other government dental benefits return button click"
+        >
+          {t(($) => $.dentalBenefits.returnButton)}
+        </ButtonLink>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
@@ -11,6 +11,7 @@ import type { Route } from './+types/edit-child-dental-benefits';
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -48,7 +49,6 @@ export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   transformAdobeAnalyticsUrl,
   pageIdentifier: pageIds.protected.profile.editChildDentalBenefits,
-  pageTitleI18nKey: 'protectedProfile:editChildDentalBenefits.title',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -104,7 +104,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     provincialTerritorialSocialPrograms,
     regions,
     childName,
-    i18nOptions: { childName },
   };
 }
 
@@ -258,145 +257,148 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4">{t(($) => $.editChildDentalBenefits.accessToDental)}</p>
-      <p className="mb-4">{t(($) => $.editChildDentalBenefits.eligibilityCriteria)}</p>
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">
-              {t(($) => $.editChildDentalBenefits.federalBenefits.title, {
-                childName: childName,
-                ns: 'protectedProfile',
-              })}
-            </legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.editChildDentalBenefits.federalBenefits.legend, {
-                childName: childName,
-                ns: 'protectedProfile',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.editChildDentalBenefits.federalBenefits.socialPrograms.legend)}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: federalProgram?.id === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.title)}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.legend, {
-                childName: childName,
-                ns: 'protectedProfile',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: provincialTerritorialProgram !== undefined,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.editChildDentalBenefits.selectOne),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.editChildDentalBenefits.title, { childName })}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4">{t(($) => $.editChildDentalBenefits.accessToDental)}</p>
+        <p className="mb-4">{t(($) => $.editChildDentalBenefits.eligibilityCriteria)}</p>
+        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">
+                {t(($) => $.editChildDentalBenefits.federalBenefits.title, {
+                  childName: childName,
+                  ns: 'protectedProfile',
+                })}
+              </legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.editChildDentalBenefits.federalBenefits.legend, {
+                  childName: childName,
+                  ns: 'protectedProfile',
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.editChildDentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: federalProgram?.id === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.legend, {
+                  childName: childName,
+                  ns: 'protectedProfile',
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: provincialTerritorialProgram !== undefined,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.editChildDentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: provincialTerritorialProgram === undefined,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" name="_action" value={FORM_ACTION.save} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Access to other dental benefits click">
-              {t(($) => $.editDentalBenefits.button.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              variant="secondary"
-              id="back-button"
-              routeId="protected/profile/dental-benefits"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Access to other dental benefits click"
-            >
-              {t(($) => $.editDentalBenefits.button.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.editChildDentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editChildDentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: provincialTerritorialProgram === undefined,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" name="_action" value={FORM_ACTION.save} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Access to other dental benefits click">
+                {t(($) => $.editDentalBenefits.button.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                variant="secondary"
+                id="back-button"
+                routeId="protected/profile/dental-benefits"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Access to other dental benefits click"
+              >
+                {t(($) => $.editDentalBenefits.button.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
@@ -13,6 +13,7 @@ import { TYPES } from '~/.server/constants';
 import type { ClientApplicationDto } from '~/.server/domain/dtos';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -35,7 +36,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:communicationPreferences.pageTitle', routeId: 'protected/profile/communication-preferences' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.editCommunicationPreferences,
-  pageTitleI18nKey: 'protectedProfile:editCommunicationPreferences.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -244,48 +244,51 @@ export default function EditCommunicationPreferences({ loaderData, params }: Rou
   const submitButtonText = isDigitalCommunicationMethodSelected && !isClientApplicationEmailAddressVerified ? t(($) => $.editCommunicationPreferences.continue) : t(($) => $.editCommunicationPreferences.save);
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.editCommunicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
-            <InputRadios
-              id="preferred-method-sunlife"
-              legend={t(($) => $.editCommunicationPreferences.preferredMethodSunlife)}
-              name="preferredMethodSunLife"
-              options={sunLifeCommunicationMethodOptions}
-              errorMessage={errors?.preferredMethodSunLife}
-              required
-            />
-            <InputRadios
-              id="preferred-method-gc"
-              name="preferredMethodGovernmentOfCanada"
-              legend={t(($) => $.editCommunicationPreferences.preferredMethodGc)}
-              options={gcCommunicationMethodOptions}
-              required
-              errorMessage={errors?.preferredMethodGovernmentOfCanada}
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Communication preferences click">
-              {submitButtonText}
-            </LoadingButton>
-            <ButtonLink
-              variant="secondary"
-              id="back-button"
-              routeId="protected/profile/communication-preferences"
-              params={params}
-              disabled={isSubmittingOrSuccess}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Communication preferences click"
-            >
-              {t(($) => $.editCommunicationPreferences.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.editCommunicationPreferences.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.editCommunicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
+              <InputRadios
+                id="preferred-method-sunlife"
+                legend={t(($) => $.editCommunicationPreferences.preferredMethodSunlife)}
+                name="preferredMethodSunLife"
+                options={sunLifeCommunicationMethodOptions}
+                errorMessage={errors?.preferredMethodSunLife}
+                required
+              />
+              <InputRadios
+                id="preferred-method-gc"
+                name="preferredMethodGovernmentOfCanada"
+                legend={t(($) => $.editCommunicationPreferences.preferredMethodGc)}
+                options={gcCommunicationMethodOptions}
+                required
+                errorMessage={errors?.preferredMethodGovernmentOfCanada}
+              />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Communication preferences click">
+                {submitButtonText}
+              </LoadingButton>
+              <ButtonLink
+                variant="secondary"
+                id="back-button"
+                routeId="protected/profile/communication-preferences"
+                params={params}
+                disabled={isSubmittingOrSuccess}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Communication preferences click"
+              >
+                {t(($) => $.editCommunicationPreferences.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
@@ -11,6 +11,7 @@ import type { Route } from './+types/edit-dental-benefits';
 import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -45,7 +46,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:editDentalBenefits.breadcrumb', routeId: 'protected/profile/dental-benefits' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.editDentalBenefits,
-  pageTitleI18nKey: 'protectedProfile:editDentalBenefits.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -94,7 +94,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     provincialTerritorialSocialPrograms,
     provinceTerritoryStates,
     applicantName,
-    i18nOptions: { applicantName },
   };
 }
 
@@ -242,139 +241,142 @@ export default function ProtectedAccessToDentalInsuranceQuestion({ loaderData, p
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4">{t(($) => $.editDentalBenefits.accessToDental)}</p>
-      <p className="mb-4">{t(($) => $.editDentalBenefits.eligibilityCriteria)}</p>
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">
-              {t(($) => $.editDentalBenefits.federalBenefits.title, {
-                applicantName: applicantName,
-                ns: 'protectedProfile',
-              })}
-            </legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.editDentalBenefits.federalBenefits.legend)}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.editDentalBenefits.federalBenefits.socialPrograms.legend)}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: federalProgram?.id === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.editDentalBenefits.provincialTerritorialBenefits.title)}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.legend)}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: provincialTerritorialProgram !== undefined,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.editDentalBenefits.selectOne),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.editDentalBenefits.title, { applicantName })}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4">{t(($) => $.editDentalBenefits.accessToDental)}</p>
+        <p className="mb-4">{t(($) => $.editDentalBenefits.eligibilityCriteria)}</p>
+        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">
+                {t(($) => $.editDentalBenefits.federalBenefits.title, {
+                  applicantName: applicantName,
+                  ns: 'protectedProfile',
+                })}
+              </legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.editDentalBenefits.federalBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.editDentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: federalProgram?.id === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.editDentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: provincialTerritorialProgram !== undefined,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.editDentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: provincialTerritorialProgram === undefined,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" name="_action" value={FORM_ACTION.save} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Access to other dental benefits click">
-              {t(($) => $.editDentalBenefits.button.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              variant="secondary"
-              id="back-button"
-              routeId="protected/profile/dental-benefits"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Access to other dental benefits click"
-            >
-              {t(($) => $.editDentalBenefits.button.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.editDentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.editDentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: provincialTerritorialProgram === undefined,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" name="_action" value={FORM_ACTION.save} loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Access to other dental benefits click">
+                {t(($) => $.editDentalBenefits.button.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                variant="secondary"
+                id="back-button"
+                routeId="protected/profile/dental-benefits"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Access to other dental benefits click"
+              >
+                {t(($) => $.editDentalBenefits.button.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/eligibility.tsx
+++ b/frontend/app/routes/protected/profile/eligibility.tsx
@@ -9,6 +9,7 @@ import type { Route } from './+types/eligibility';
 import { TYPES } from '~/.server/constants';
 import { isWithinRenewalPeriod } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.eligibility,
-  pageTitleI18nKey: 'protectedProfile:eligibility.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -91,62 +91,65 @@ export default function ProtectedProfileEligibility({ loaderData, params }: Rout
   const { ELIGIBILITY_STATUS_CODE_ELIGIBLE } = useClientEnv();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <p>{t(($) => $.eligibility.details)}</p>
-      <section className="space-y-6">
-        <h2 className="font-lato text-2xl font-bold">{t(($) => $.eligibility.currentYear)}</h2>
-        <p>
-          {t(($) => $.eligibility.currentYearDetails, {
-            end: currentCoverage.endYear,
-            ns: 'protectedProfile',
+    <>
+      <AppPageTitle>{t(($) => $.eligibility.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <p>{t(($) => $.eligibility.details)}</p>
+        <section className="space-y-6">
+          <h2 className="font-lato text-2xl font-bold">{t(($) => $.eligibility.currentYear)}</h2>
+          <p>
+            {t(($) => $.eligibility.currentYearDetails, {
+              end: currentCoverage.endYear,
+              ns: 'protectedProfile',
+            })}
+          </p>
+          <DefinitionList border>
+            {applicants.map((applicant) => {
+              const eligibilityStatus = getEligibilityStatus({ applicant, taxationYear: currentCoverage.taxationYear, isNextYear: false, ELIGIBILITY_STATUS_CODE_ELIGIBLE });
+              return (
+                <DefinitionListItem key={applicant.clientId} term={`${applicant.firstName} ${applicant.lastName}`}>
+                  <EligibilityStatusIndicator status={eligibilityStatus} coverageStartYear={currentCoverage.startYear} coverageEndYear={currentCoverage.endYear} />
+                </DefinitionListItem>
+              );
+            })}
+          </DefinitionList>
+        </section>
+        <section className="space-y-6">
+          <h2 className="font-lato text-2xl font-bold">{t(($) => $.eligibility.nextYear)}</h2>
+          <p>
+            {t(($) => $.eligibility.benefitYearRange, {
+              start: currentCoverage.startYear + 1,
+              end: currentCoverage.endYear + 1,
+              ns: 'protectedProfile',
+            })}
+          </p>
+          <DefinitionList border>
+            {applicants.map((applicant) => {
+              const taxationYear = currentCoverage.taxationYear + 1;
+              const coverageStartYear = currentCoverage.startYear + 1;
+              const coverageEndYear = currentCoverage.endYear + 1;
+              const eligibilityStatus = getEligibilityStatus({ applicant, taxationYear, isNextYear: true, ELIGIBILITY_STATUS_CODE_ELIGIBLE });
+              return (
+                <DefinitionListItem key={applicant.clientId} term={`${applicant.firstName} ${applicant.lastName}`}>
+                  <EligibilityStatusIndicator status={eligibilityStatus} coverageStartYear={coverageStartYear} coverageEndYear={coverageEndYear} showApplyLink={showApplyLink} />
+                </DefinitionListItem>
+              );
+            })}
+          </DefinitionList>
+        </section>
+        <ButtonLink
+          variant="primary"
+          id="back-button"
+          to={t(($) => $.header.menuDashboardHref, {
+            baseUri: SCCH_BASE_URI,
+            ns: 'gcweb',
           })}
-        </p>
-        <DefinitionList border>
-          {applicants.map((applicant) => {
-            const eligibilityStatus = getEligibilityStatus({ applicant, taxationYear: currentCoverage.taxationYear, isNextYear: false, ELIGIBILITY_STATUS_CODE_ELIGIBLE });
-            return (
-              <DefinitionListItem key={applicant.clientId} term={`${applicant.firstName} ${applicant.lastName}`}>
-                <EligibilityStatusIndicator status={eligibilityStatus} coverageStartYear={currentCoverage.startYear} coverageEndYear={currentCoverage.endYear} />
-              </DefinitionListItem>
-            );
-          })}
-        </DefinitionList>
-      </section>
-      <section className="space-y-6">
-        <h2 className="font-lato text-2xl font-bold">{t(($) => $.eligibility.nextYear)}</h2>
-        <p>
-          {t(($) => $.eligibility.benefitYearRange, {
-            start: currentCoverage.startYear + 1,
-            end: currentCoverage.endYear + 1,
-            ns: 'protectedProfile',
-          })}
-        </p>
-        <DefinitionList border>
-          {applicants.map((applicant) => {
-            const taxationYear = currentCoverage.taxationYear + 1;
-            const coverageStartYear = currentCoverage.startYear + 1;
-            const coverageEndYear = currentCoverage.endYear + 1;
-            const eligibilityStatus = getEligibilityStatus({ applicant, taxationYear, isNextYear: true, ELIGIBILITY_STATUS_CODE_ELIGIBLE });
-            return (
-              <DefinitionListItem key={applicant.clientId} term={`${applicant.firstName} ${applicant.lastName}`}>
-                <EligibilityStatusIndicator status={eligibilityStatus} coverageStartYear={coverageStartYear} coverageEndYear={coverageEndYear} showApplyLink={showApplyLink} />
-              </DefinitionListItem>
-            );
-          })}
-        </DefinitionList>
-      </section>
-      <ButtonLink
-        variant="primary"
-        id="back-button"
-        to={t(($) => $.header.menuDashboardHref, {
-          baseUri: SCCH_BASE_URI,
-          ns: 'gcweb',
-        })}
-        data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Member eligibility return button click"
-      >
-        {t(($) => $.eligibility.returnButton)}
-      </ButtonLink>
-    </div>
+          data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Return to dashboard - Member eligibility return button click"
+        >
+          {t(($) => $.eligibility.returnButton)}
+        </ButtonLink>
+      </div>
+    </>
   );
 }
 

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -9,6 +9,7 @@ import type { Route } from './+types/email';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -61,7 +62,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.email,
-  pageTitleI18nKey: 'protectedProfile:email.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -180,28 +180,31 @@ export default function ProtectedProfileEmailAddress({ loaderData, params }: Rou
   const backButtonRouteId = context === 'communication-preferences' ? 'protected/profile/communication-preferences/edit' : 'protected/profile/contact-information';
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
-          <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
-          <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-          <div className="mb-6">
-            <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
-          </div>
+    <>
+      <AppPageTitle>{t(($) => $.email.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
+            <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
+            <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+            <div className="mb-6">
+              <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
+            </div>
 
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Email address click">
-              {t(($) => $.email.continueBtn)}
-            </LoadingButton>
-            <ButtonLink variant="secondary" id="back-button" routeId={backButtonRouteId} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Email address click">
-              {t(($) => $.email.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Email address click">
+                {t(($) => $.email.continueBtn)}
+              </LoadingButton>
+              <ButtonLink variant="secondary" id="back-button" routeId={backButtonRouteId} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Email address click">
+                {t(($) => $.email.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/home-address.tsx
+++ b/frontend/app/routes/protected/profile/home-address.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -42,7 +43,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.editHomeAddress,
-  pageTitleI18nKey: 'protectedProfile:homeAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -280,110 +280,113 @@ export default function EditHomeAddress({ loaderData, params }: Route.ComponentP
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="homeAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.homeAddress.address)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.homeAddress.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.homeAddress.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.homeAddress.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue={defaultState.apartment}
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.homeAddress.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="home-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.homeAddress.postalCode) : t(($) => $.homeAddress.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {homeRegions.length > 0 && (
-                <InputSelect
-                  id="home-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.homeAddress.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...homeRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.homeAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="homeAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.homeAddress.address)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.homeAddress.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.homeAddress.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
+                <InputSanitizeField
+                  id="apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.homeAddress.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.homeAddress.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue={defaultState.apartment}
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.homeAddress.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.homeAddress.postalCode) : t(($) => $.homeAddress.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {homeRegions.length > 0 && (
+                  <InputSelect
+                    id="home-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.homeAddress.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...homeRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="home-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.homeAddress.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={homeCountryChangeHandler}
+                  required
+                />
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Home address click"
+                  >
+                    {t(($) => $.homeAddress.saveBtn)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Home address click">
+                {t(($) => $.homeAddress.backBtn)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Home address click"
-                >
-                  {t(($) => $.homeAddress.saveBtn)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Home address click">
-              {t(($) => $.homeAddress.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/mailing-address.tsx
+++ b/frontend/app/routes/protected/profile/mailing-address.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -43,7 +44,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.editMailingAddress,
-  pageTitleI18nKey: 'protectedProfile:mailingAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -299,115 +299,118 @@ export default function EditMailingAddress({ loaderData, params }: Route.Compone
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="mailingAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.mailingAddress.address)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.mailingAddress.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.mailingAddress.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.mailingAddress.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue={defaultState.apartment}
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.mailingAddress.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="mailing-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.mailingAddress.postalCode) : t(($) => $.mailingAddress.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {mailingRegions.length > 0 && (
-                <InputSelect
-                  id="mailing-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.mailingAddress.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...mailingRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.mailingAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="mailingAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.mailingAddress.address)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.mailingAddress.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.mailingAddress.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
-              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
-                {t(($) => $.mailingAddress.useMailingAddress)}
-              </InputCheckbox>
+                <InputSanitizeField
+                  id="apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.mailingAddress.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.mailingAddress.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue={defaultState.apartment}
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.mailingAddress.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="mailing-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.mailingAddress.postalCode) : t(($) => $.mailingAddress.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {mailingRegions.length > 0 && (
+                  <InputSelect
+                    id="mailing-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.mailingAddress.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...mailingRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="mailing-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.mailingAddress.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={mailingCountryChangeHandler}
+                  required
+                />
+                <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
+                  {t(($) => $.mailingAddress.useMailingAddress)}
+                </InputCheckbox>
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Mailing address click"
+                  >
+                    {copyAddressChecked ? t(($) => $.mailingAddress.saveBtn) : t(($) => $.mailingAddress.continueBtn)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && (
+                      <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
+                    )}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Mailing address click">
+                {t(($) => $.mailingAddress.backBtn)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Mailing address click"
-                >
-                  {copyAddressChecked ? t(($) => $.mailingAddress.saveBtn) : t(($) => $.mailingAddress.continueBtn)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && (
-                    <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
-                  )}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Mailing address click">
-              {t(($) => $.mailingAddress.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/phone-number.tsx
+++ b/frontend/app/routes/protected/profile/phone-number.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { phoneSchema } from '~/.server/validation/phone-schema';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -27,7 +28,6 @@ export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.phoneNumber,
-  pageTitleI18nKey: 'protectedProfile:phoneNumber.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -107,55 +107,58 @@ export default function PhoneNumber({ loaderData, params }: Route.ComponentProps
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <p className="mb-4">{t(($) => $.phoneNumber.addPhoneNumber)}</p>
-            <p className="mb-4 italic">{t(($) => $.allOptionalLabel)}</p>
-            <div className="grid items-end gap-6">
-              <InputPhoneField
-                id="phone-number"
-                name="phoneNumber"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumber ?? ''}
-                errorMessage={errors?.phoneNumber}
-                label={t(($) => $.phoneNumber.phoneNumber)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
-              <InputPhoneField
-                id="phone-number-alt"
-                name="phoneNumberAlt"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumberAlt ?? ''}
-                errorMessage={errors?.phoneNumberAlt}
-                label={t(($) => $.phoneNumber.phoneNumberAlt)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
+    <>
+      <AppPageTitle>{t(($) => $.phoneNumber.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-6">
+              <p className="mb-4">{t(($) => $.phoneNumber.addPhoneNumber)}</p>
+              <p className="mb-4 italic">{t(($) => $.allOptionalLabel)}</p>
+              <div className="grid items-end gap-6">
+                <InputPhoneField
+                  id="phone-number"
+                  name="phoneNumber"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumber ?? ''}
+                  errorMessage={errors?.phoneNumber}
+                  label={t(($) => $.phoneNumber.phoneNumber)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+                <InputPhoneField
+                  id="phone-number-alt"
+                  name="phoneNumberAlt"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumberAlt ?? ''}
+                  errorMessage={errors?.phoneNumberAlt}
+                  label={t(($) => $.phoneNumber.phoneNumberAlt)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+              </div>
             </div>
-          </div>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Phone number click">
-              {t(($) => $.phoneNumber.saveBtn)}
-            </LoadingButton>
-            <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Phone number click">
-              {t(($) => $.phoneNumber.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Save - Phone number click">
+                {t(($) => $.phoneNumber.saveBtn)}
+              </LoadingButton>
+              <ButtonLink variant="secondary" id="back-button" routeId="protected/profile/contact-information" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Phone number click">
+                {t(($) => $.phoneNumber.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -11,6 +11,7 @@ import type { Route } from './+types/verify-email';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
@@ -51,7 +52,6 @@ export const handle = {
   ],
   i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
   pageIdentifier: pageIds.protected.profile.verifyEmail,
-  pageTitleI18nKey: 'protectedProfile:verifyEmail.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -234,95 +234,98 @@ export default function ProtectedProfileVerifyEmail({ loaderData, params }: Rout
   const backButtonTo = getPathById('protected/profile/contact/email-address', params) + (backButtonSearchParams ? `?${backButtonSearchParams.toString()}` : '');
 
   return (
-    <div className="max-w-prose">
-      <ErrorAlert>
-        <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
-        <p className="-mb-3">{t(($) => $.verifyEmail.verificationCodeAlert.detail)}</p>
-        <LoadingButton
-          id="request-button"
-          type="button"
-          name="_action"
-          variant="link"
-          className="text-[17px]"
-          disabled={isSubmitting}
-          loading={isSubmitting && submittedAction === FORM_ACTION.request}
-          value={FORM_ACTION.request}
-          onClick={handleRequestNewCode}
-        >
-          {t(($) => $.verifyEmail.verificationCodeAlert.requestNewCode)}
-        </LoadingButton>
-      </ErrorAlert>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <p className="mb-4">
-              {t(($) => $.verifyEmail.verificationCode, {
+    <>
+      <AppPageTitle>{t(($) => $.verifyEmail.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
+          <p className="-mb-3">{t(($) => $.verifyEmail.verificationCodeAlert.detail)}</p>
+          <LoadingButton
+            id="request-button"
+            type="button"
+            name="_action"
+            variant="link"
+            className="text-[17px]"
+            disabled={isSubmitting}
+            loading={isSubmitting && submittedAction === FORM_ACTION.request}
+            value={FORM_ACTION.request}
+            onClick={handleRequestNewCode}
+          >
+            {t(($) => $.verifyEmail.verificationCodeAlert.requestNewCode)}
+          </LoadingButton>
+        </ErrorAlert>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <p className="mb-4">
+                {t(($) => $.verifyEmail.verificationCode, {
+                  email: email,
+                  ns: 'protectedProfile',
+                })}
+              </p>
+              <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
+              <p className="mb-8">
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
+              </p>
+              <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
+              </div>
+              <LoadingButton
+                id="request-button"
+                type="button"
+                name="_action"
+                variant="link"
+                className="no-underline hover:underline"
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.request}
+                value={FORM_ACTION.request}
+                onClick={handleRequestNewCode}
+              >
+                {t(($) => $.verifyEmail.requestNewCode)}
+              </LoadingButton>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                variant="primary"
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.submit}
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.submit}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Verify your email address click"
+              >
+                {t(($) => $.verifyEmail.continue)}
+              </LoadingButton>
+              <ButtonLink variant="secondary" id="back-button" to={backButtonTo} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Verify your email address click">
+                {t(($) => $.verifyEmail.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+        <Dialog open={showDialog} onOpenChange={setShowDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
+            </DialogHeader>
+            <DialogDescription>
+              {t(($) => $.verifyEmail.codeSent.detail, {
                 email: email,
                 ns: 'protectedProfile',
               })}
-            </p>
-            <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
-            <p className="mb-8">
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
-            </p>
-            <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-            <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
-            </div>
-            <LoadingButton
-              id="request-button"
-              type="button"
-              name="_action"
-              variant="link"
-              className="no-underline hover:underline"
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.request}
-              value={FORM_ACTION.request}
-              onClick={handleRequestNewCode}
-            >
-              {t(($) => $.verifyEmail.requestNewCode)}
-            </LoadingButton>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton
-              variant="primary"
-              id="continue-button"
-              name="_action"
-              value={FORM_ACTION.submit}
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.submit}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Continue - Verify your email address click"
-            >
-              {t(($) => $.verifyEmail.continue)}
-            </LoadingButton>
-            <ButtonLink variant="secondary" id="back-button" to={backButtonTo} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Profile-Protected:Back - Verify your email address click">
-              {t(($) => $.verifyEmail.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-      <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
-          </DialogHeader>
-          <DialogDescription>
-            {t(($) => $.verifyEmail.codeSent.detail, {
-              email: email,
-              ns: 'protectedProfile',
-            })}
-          </DialogDescription>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm">
-                {t(($) => $.verifyEmail.continue)}
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+            </DialogDescription>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm">
+                  {t(($) => $.verifyEmail.continue)}
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -10,6 +10,7 @@ import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken, UserinfoToken } from '~/.server/utils/raoidc.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button } from '~/components/buttons';
 import { ErrorSummary } from '~/components/error-summary';
 import { ErrorSummaryProvider } from '~/components/error-summary-context';
@@ -26,7 +27,6 @@ import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('stubLogin', 'gcweb'),
   pageIdentifier: 'CDCP-00XX',
-  pageTitleI18nKey: 'stubLogin:index.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -151,66 +151,69 @@ export default function StubLogin({ loaderData, params }: Route.ComponentProps) 
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate className="space-y-6">
-          <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.index.sin)} required inputMode="numeric" defaultValue={defaultValues.sin} errorMessage={errors?.sin} />
-          <InputSelect
-            id="destination-page"
-            name="destinationRouteId"
-            label={t(($) => $.index.destination)}
-            errorMessage={errors?.destinationRouteId}
-            defaultValue=""
-            required
-            options={[
-              { children: 'Select a destination', value: '', disabled: true, hidden: true },
-              {
-                children: 'Application',
-                value: 'protected/application/index',
-              },
-              {
-                children: 'Documents',
-                value: 'protected/documents/index',
-              },
-              {
-                children: 'Letters',
-                value: 'protected/letters/index',
-              },
-              {
-                children: 'Member Eligibility',
-                value: 'protected/profile/eligibility',
-              },
-              {
-                children: 'Profile - Applicant Information',
-                value: 'protected/profile/applicant-information',
-              },
-              {
-                children: 'Profile - Communication Preferences',
-                value: 'protected/profile/communication-preferences',
-              },
-              {
-                children: 'Profile - Contact Information',
-                value: 'protected/profile/contact-information',
-              },
-              {
-                children: 'Profile - Dental Benefits',
-                value: 'protected/profile/dental-benefits',
-              },
-            ]}
-          />
-          <fieldset>
-            <legend className="mb-2 text-xl font-semibold">{t(($) => $.index.raoidc)}</legend>
-            <div className="space-y-6">
-              <InputField id="sid" name="sid" className="w-full" inputMode="text" label={t(($) => $.index.sid)} defaultValue={defaultValues.sid} errorMessage={errors?.sid} />
-              <InputField id="sub" name="sub" className="w-full" inputMode="text" label={t(($) => $.index.sub)} defaultValue={defaultValues.sub} errorMessage={errors?.sub} />
-            </div>
-          </fieldset>
-          <Button variant="primary" id="login-button">
-            {t(($) => $.index.login)}
-          </Button>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.index.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate className="space-y-6">
+            <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.index.sin)} required inputMode="numeric" defaultValue={defaultValues.sin} errorMessage={errors?.sin} />
+            <InputSelect
+              id="destination-page"
+              name="destinationRouteId"
+              label={t(($) => $.index.destination)}
+              errorMessage={errors?.destinationRouteId}
+              defaultValue=""
+              required
+              options={[
+                { children: 'Select a destination', value: '', disabled: true, hidden: true },
+                {
+                  children: 'Application',
+                  value: 'protected/application/index',
+                },
+                {
+                  children: 'Documents',
+                  value: 'protected/documents/index',
+                },
+                {
+                  children: 'Letters',
+                  value: 'protected/letters/index',
+                },
+                {
+                  children: 'Member Eligibility',
+                  value: 'protected/profile/eligibility',
+                },
+                {
+                  children: 'Profile - Applicant Information',
+                  value: 'protected/profile/applicant-information',
+                },
+                {
+                  children: 'Profile - Communication Preferences',
+                  value: 'protected/profile/communication-preferences',
+                },
+                {
+                  children: 'Profile - Contact Information',
+                  value: 'protected/profile/contact-information',
+                },
+                {
+                  children: 'Profile - Dental Benefits',
+                  value: 'protected/profile/dental-benefits',
+                },
+              ]}
+            />
+            <fieldset>
+              <legend className="mb-2 text-xl font-semibold">{t(($) => $.index.raoidc)}</legend>
+              <div className="space-y-6">
+                <InputField id="sid" name="sid" className="w-full" inputMode="text" label={t(($) => $.index.sid)} defaultValue={defaultValues.sid} errorMessage={errors?.sid} />
+                <InputField id="sub" name="sub" className="w-full" inputMode="text" label={t(($) => $.index.sub)} defaultValue={defaultValues.sub} errorMessage={errors?.sub} />
+              </div>
+            </fieldset>
+            <Button variant="primary" id="login-button">
+              {t(($) => $.index.login)}
+            </Button>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/protected/unable-to-process-request.tsx
+++ b/frontend/app/routes/protected/unable-to-process-request.tsx
@@ -5,6 +5,7 @@ import type { Route } from './+types/unable-to-process-request';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import type { IdToken } from '~/.server/utils/raoidc.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { getTypedI18nNamespaces } from '~/utils/locale-utils';
@@ -15,7 +16,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('unableToProcessRequest', 'gcweb'),
   pageIdentifier: pageIds.protected.unableToProcessRequest,
-  pageTitleI18nKey: 'unableToProcessRequest:pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -43,28 +43,31 @@ export default function ProtectedUnableToProcessRequest({ loaderData, params }: 
   const cdcpLink = <InlineLink to={t(($) => $.cdcpLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="space-y-4">
-        <p>{t(($) => $.unableToProcess)}</p>
-        <p>{t(($) => $.tryAgain)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.disableVpn)}</li>
-          <li>{t(($) => $.anotherDevice)}</li>
-        </ul>
-        <p>{t(($) => $.difficulties)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.callCentre} components={{ noWrap }} />
-          </li>
-          <li>{t(($) => $.visitCentre)}</li>
-          <li>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.submitRequest} components={{ eServiceCanadaLink }} />
-          </li>
-        </ul>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.returnCdcp} components={{ cdcpLink }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="space-y-4">
+          <p>{t(($) => $.unableToProcess)}</p>
+          <p>{t(($) => $.tryAgain)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.disableVpn)}</li>
+            <li>{t(($) => $.anotherDevice)}</li>
+          </ul>
+          <p>{t(($) => $.difficulties)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.callCentre} components={{ noWrap }} />
+            </li>
+            <li>{t(($) => $.visitCentre)}</li>
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.submitRequest} components={{ eServiceCanadaLink }} />
+            </li>
+          </ul>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.returnCdcp} components={{ cdcpLink }} />
+          </p>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/entry/eligibility-requirements.tsx
+++ b/frontend/app/routes/public/application/entry/eligibility-requirements.tsx
@@ -6,6 +6,7 @@ import type { Route } from './+types/eligibility-requirements';
 import { isTaxFilingSectionCompleted, isTermsAndConditionsSectionCompleted } from '~/.server/routes/helpers/public-application-entry-section-checks';
 import { getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
   pageIdentifier: pageIds.public.application.eligibilityRequirements,
-  pageTitleI18nKey: 'application:eligibilityRequirements.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -51,108 +51,111 @@ export default function ApplyIndex({ loaderData, params }: Route.ComponentProps)
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <div className="max-w-prose space-y-8">
-      <div className="space-y-4">
-        <p>{t(($) => $.completeAllSections)}</p>
-        <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.eligibilityRequirements.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <div className="space-y-4">
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+          <p>{completedSectionsLabel}</p>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t(($) => $.eligibilityRequirements.termsConditionsSection.title)}</h2>
+            </CardTitle>
+            <CardAction>{sections.termsAndConditions.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {state.termsAndConditions === undefined ? (
+              <p>{t(($) => $.eligibilityRequirements.termsConditionsSection.instructions)}</p>
+            ) : (
+              <ul className="list-disc space-y-1 pl-7">
+                {state.termsAndConditions.acknowledgeTerms && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgeTerms)}</li>}
+                {state.termsAndConditions.acknowledgePrivacy && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgePrivacy)}</li>}
+                {state.termsAndConditions.shareData && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.shareData)}</li>}
+              </ul>
+            )}
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            {sections.termsAndConditions.completed ? (
+              <ButtonLink
+                id="edit-terms-conditions-button" //
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/terms-conditions"
+                params={params}
+                startIcon={faPenToSquare}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit terms conditions click"
+                aria-label={t(($) => $.eligibilityRequirements.termsConditionsSection.editButtonAria)}
+              >
+                {t(($) => $.eligibilityRequirements.termsConditionsSection.editButton)}
+              </ButtonLink>
+            ) : (
+              <ButtonLink
+                id="add-terms-conditions-button" //
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/terms-conditions"
+                params={params}
+                startIcon={faCircleCheck}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Add terms conditions click"
+              >
+                {t(($) => $.eligibilityRequirements.termsConditionsSection.addButton)}
+              </ButtonLink>
+            )}
+          </CardFooter>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t(($) => $.eligibilityRequirements.taxFilingSection.title)}</h2>
+            </CardTitle>
+            <CardAction>{sections.taxFiling.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            <p>
+              {state.hasFiledTaxes === true //
+                ? t(($) => $.eligibilityRequirements.taxFilingSection.haveFiledTaxes)
+                : t(($) => $.eligibilityRequirements.taxFilingSection.instructions)}
+            </p>
+          </CardContent>
+          <CardFooter className="border-t bg-zinc-100">
+            {sections.taxFiling.completed ? (
+              <ButtonLink
+                id="edit-tax-filing-button" //
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/tax-filing"
+                params={params}
+                startIcon={faPenToSquare}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit tax filing click"
+                aria-label={t(($) => $.eligibilityRequirements.taxFilingSection.editButtonAria)}
+              >
+                {t(($) => $.eligibilityRequirements.taxFilingSection.editButton)}
+              </ButtonLink>
+            ) : (
+              <ButtonLink
+                id="add-tax-filing-button" //
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/tax-filing"
+                params={params}
+                startIcon={faCircleCheck}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Add tax filing click"
+              >
+                {t(($) => $.eligibilityRequirements.taxFilingSection.addButton)}
+              </ButtonLink>
+            )}
+          </CardFooter>
+        </Card>
+        <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Continue click">
+          {t(($) => $.eligibilityRequirements.nextButton)}
+        </NavigationButtonLink>
       </div>
-      <Card>
-        <CardHeader>
-          <CardTitle asChild>
-            <h2>{t(($) => $.eligibilityRequirements.termsConditionsSection.title)}</h2>
-          </CardTitle>
-          <CardAction>{sections.termsAndConditions.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {state.termsAndConditions === undefined ? (
-            <p>{t(($) => $.eligibilityRequirements.termsConditionsSection.instructions)}</p>
-          ) : (
-            <ul className="list-disc space-y-1 pl-7">
-              {state.termsAndConditions.acknowledgeTerms && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgeTerms)}</li>}
-              {state.termsAndConditions.acknowledgePrivacy && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.acknowledgePrivacy)}</li>}
-              {state.termsAndConditions.shareData && <li>{t(($) => $.eligibilityRequirements.termsConditionsSection.shareData)}</li>}
-            </ul>
-          )}
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          {sections.termsAndConditions.completed ? (
-            <ButtonLink
-              id="edit-terms-conditions-button" //
-              variant="link"
-              className="p-0"
-              routeId="public/application/$id/terms-conditions"
-              params={params}
-              startIcon={faPenToSquare}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit terms conditions click"
-              aria-label={t(($) => $.eligibilityRequirements.termsConditionsSection.editButtonAria)}
-            >
-              {t(($) => $.eligibilityRequirements.termsConditionsSection.editButton)}
-            </ButtonLink>
-          ) : (
-            <ButtonLink
-              id="add-terms-conditions-button" //
-              variant="link"
-              className="p-0"
-              routeId="public/application/$id/terms-conditions"
-              params={params}
-              startIcon={faCircleCheck}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Add terms conditions click"
-            >
-              {t(($) => $.eligibilityRequirements.termsConditionsSection.addButton)}
-            </ButtonLink>
-          )}
-        </CardFooter>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle asChild>
-            <h2>{t(($) => $.eligibilityRequirements.taxFilingSection.title)}</h2>
-          </CardTitle>
-          <CardAction>{sections.taxFiling.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          <p>
-            {state.hasFiledTaxes === true //
-              ? t(($) => $.eligibilityRequirements.taxFilingSection.haveFiledTaxes)
-              : t(($) => $.eligibilityRequirements.taxFilingSection.instructions)}
-          </p>
-        </CardContent>
-        <CardFooter className="border-t bg-zinc-100">
-          {sections.taxFiling.completed ? (
-            <ButtonLink
-              id="edit-tax-filing-button" //
-              variant="link"
-              className="p-0"
-              routeId="public/application/$id/tax-filing"
-              params={params}
-              startIcon={faPenToSquare}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit tax filing click"
-              aria-label={t(($) => $.eligibilityRequirements.taxFilingSection.editButtonAria)}
-            >
-              {t(($) => $.eligibilityRequirements.taxFilingSection.editButton)}
-            </ButtonLink>
-          ) : (
-            <ButtonLink
-              id="add-tax-filing-button" //
-              variant="link"
-              className="p-0"
-              routeId="public/application/$id/tax-filing"
-              params={params}
-              startIcon={faCircleCheck}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Add tax filing click"
-            >
-              {t(($) => $.eligibilityRequirements.taxFilingSection.addButton)}
-            </ButtonLink>
-          )}
-        </CardFooter>
-      </Card>
-      <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Continue click">
-        {t(($) => $.eligibilityRequirements.nextButton)}
-      </NavigationButtonLink>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/entry/your-application.tsx
+++ b/frontend/app/routes/public/application/entry/your-application.tsx
@@ -8,6 +8,7 @@ import { getTypeOfApplicationSectionCompletionResult, isNewOrReturningMemberSect
 import type { ApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getContextualAgeCategoryFromDate, getInitialApplicationFlowUrl, getPublicApplicationState, shouldSkipNewOrReturningMember } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { ContextualAlert } from '~/components/contextual-alert';
@@ -29,7 +30,6 @@ const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children' 
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
   pageIdentifier: pageIds.public.application.typeOfApplication,
-  pageTitleI18nKey: 'application:yourApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -98,136 +98,139 @@ export default function TypeOfApplication({ loaderData, params }: Route.Componen
   const isTypeOfApplicationTypeMismatched = typeOfApplicationSectionCompletionResult === 'TYPE-MISMATCHED';
 
   return (
-    <div className="max-w-prose space-y-8">
-      <div className="space-y-4">
-        <p>{t(($) => $.completeAllSections)}</p>
-        <p>{completedSectionsLabel}</p>
-      </div>
-      <Card className={cn(isTypeOfApplicationTypeMismatched && 'border-red-600')}>
-        <CardHeader>
-          <CardTitle asChild>
-            <h2>{t(($) => $.yourApplication.typeApplicationHeading)}</h2>
-          </CardTitle>
-          <CardAction>
-            {isTypeOfApplicationTypeMismatched && <StatusTag status="error" />}
-            {sections.typeOfApplication.completed && <StatusTag status="complete" />}
-          </CardAction>
-        </CardHeader>
-        <CardContent className="space-y-6">
-          {defaultState.typeOfApplication === undefined ? (
-            <p>{t(($) => $.yourApplication.typeApplicationDescription)}</p>
-          ) : (
-            <DefinitionList layout="single-column">
-              <DefinitionListItem term={t(($) => $.yourApplication.typeApplicationLegend)}>{getTypeOfApplication(defaultState.typeOfApplication)}</DefinitionListItem>
-            </DefinitionList>
-          )}
-          {isTypeOfApplicationTypeMismatched && (
-            <ContextualAlert type="danger" role="region" aria-live="polite">
-              <p>{t(($) => $.yourApplication.typeApplicationMismatch)}</p>
-            </ContextualAlert>
-          )}
-        </CardContent>
-        <CardFooter className={cn('border-t bg-zinc-100', isTypeOfApplicationTypeMismatched && 'bg-red-100')}>
-          <ButtonLink
-            id="type-of-application-edit-button"
-            variant="link"
-            className={cn('p-0', isTypeOfApplicationTypeMismatched && 'text-red-700 hover:text-red-800 focus:text-red-800')}
-            routeId="public/application/$id/type-application"
-            params={params}
-            startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
-            size="lg"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit type of application click"
-          >
-            {defaultState.typeOfApplication === undefined ? t(($) => $.yourApplication.addTypeApplication) : t(($) => $.yourApplication.editTypeApplication)}
-          </ButtonLink>
-        </CardFooter>
-      </Card>
-      <Card>
-        <CardHeader>
-          <CardTitle asChild>
-            <h2>{t(($) => $.yourApplication.personalInfoHeading)}</h2>
-          </CardTitle>
-          <CardAction>{sections.personalInformation.completed && <StatusTag status="complete" />}</CardAction>
-        </CardHeader>
-        <CardContent>
-          {defaultState.personalInformation === undefined ? (
-            <p>{t(($) => $.yourApplication.personalInfoDescription[defaultState.context])}</p>
-          ) : (
-            <DefinitionList layout="single-column">
-              {defaultState.personalInformation.memberId && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{formatClientNumber(defaultState.personalInformation.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.yourApplication.fullName)}>{`${defaultState.personalInformation.firstName} ${defaultState.personalInformation.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.yourApplication.dateOfBirth)}>{formattedDate}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.yourApplication.sin)}>{formatSin(defaultState.personalInformation.socialInsuranceNumber)}</DefinitionListItem>
-              {defaultState.livingIndependently !== undefined && (
-                <DefinitionListItem term={t(($) => $.yourApplication.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.yourApplication.livingIndependentlyYes) : t(($) => $.yourApplication.livingIndependentlyNo)}</DefinitionListItem>
-              )}
-            </DefinitionList>
-          )}
-        </CardContent>
-        {isRenewalContext && !sections.personalInformation.completed && (
-          <CardFooter className="border-t bg-zinc-100">
+    <>
+      <AppPageTitle>{t(($) => $.yourApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-8">
+        <div className="space-y-4">
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+          <p>{completedSectionsLabel}</p>
+        </div>
+        <Card className={cn(isTypeOfApplicationTypeMismatched && 'border-red-600')}>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t(($) => $.yourApplication.typeApplicationHeading)}</h2>
+            </CardTitle>
+            <CardAction>
+              {isTypeOfApplicationTypeMismatched && <StatusTag status="error" />}
+              {sections.typeOfApplication.completed && <StatusTag status="complete" />}
+            </CardAction>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            {defaultState.typeOfApplication === undefined ? (
+              <p>{t(($) => $.yourApplication.typeApplicationDescription)}</p>
+            ) : (
+              <DefinitionList layout="single-column">
+                <DefinitionListItem term={t(($) => $.yourApplication.typeApplicationLegend)}>{getTypeOfApplication(defaultState.typeOfApplication)}</DefinitionListItem>
+              </DefinitionList>
+            )}
+            {isTypeOfApplicationTypeMismatched && (
+              <ContextualAlert type="danger" role="region" aria-live="polite">
+                <p>{t(($) => $.yourApplication.typeApplicationMismatch)}</p>
+              </ContextualAlert>
+            )}
+          </CardContent>
+          <CardFooter className={cn('border-t bg-zinc-100', isTypeOfApplicationTypeMismatched && 'bg-red-100')}>
             <ButtonLink
-              id="personal-information-edit-button"
+              id="type-of-application-edit-button"
               variant="link"
-              className="p-0"
-              routeId="public/application/$id/personal-information"
-              params={params}
-              startIcon={faCirclePlus}
-              size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit personal information click"
-            >
-              {t(($) => $.yourApplication.addPersonalInformation)}
-            </ButtonLink>
-          </CardFooter>
-        )}
-        {!isRenewalContext && (
-          <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink
-              id="personal-information-edit-button"
-              variant="link"
-              className="p-0"
-              routeId="public/application/$id/personal-information"
+              className={cn('p-0', isTypeOfApplicationTypeMismatched && 'text-red-700 hover:text-red-800 focus:text-red-800')}
+              routeId="public/application/$id/type-application"
               params={params}
               startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
               size="lg"
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit personal information click"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit type of application click"
             >
-              {defaultState.personalInformation === undefined ? t(($) => $.yourApplication.addPersonalInformation) : t(($) => $.yourApplication.editPersonalInformation)}
-            </ButtonLink>
-          </CardFooter>
-        )}
-      </Card>
-      {showNewOrReturningMemberSection && (
-        <Card>
-          <CardHeader>
-            <CardTitle>{t(($) => $.yourApplication.newOrReturningHeading)}</CardTitle>
-            <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CardContent>
-            {defaultState.newOrReturningMember === undefined ? (
-              <p>{t(($) => $.yourApplication.newOrReturningDescription)}</p>
-            ) : (
-              <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.yourApplication.previouslyEnrolled)}>{defaultState.newOrReturningMember.isNewOrReturningMember ? t(($) => $.yourApplication.yes) : t(($) => $.yourApplication.no)}</DefinitionListItem>
-                {defaultState.newOrReturningMember.isNewOrReturningMember === true && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{defaultState.newOrReturningMember.memberId}</DefinitionListItem>}
-              </DefinitionList>
-            )}
-          </CardContent>
-          <CardFooter className="border-t bg-zinc-100">
-            <ButtonLink id="edit-button" variant="link" className="p-0" routeId="public/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
-              {defaultState.newOrReturningMember === undefined ? t(($) => $.yourApplication.addAnswer) : t(($) => $.yourApplication.editAnswer)}
+              {defaultState.typeOfApplication === undefined ? t(($) => $.yourApplication.addTypeApplication) : t(($) => $.yourApplication.editTypeApplication)}
             </ButtonLink>
           </CardFooter>
         </Card>
-      )}
-      <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-        <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Continue click">
-          {t(($) => $.yourApplication.application)}
-        </NavigationButtonLink>
-        <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Back click">
-          {t(($) => $.yourApplication.beforeYouStart)}
-        </NavigationButtonLink>
+        <Card>
+          <CardHeader>
+            <CardTitle asChild>
+              <h2>{t(($) => $.yourApplication.personalInfoHeading)}</h2>
+            </CardTitle>
+            <CardAction>{sections.personalInformation.completed && <StatusTag status="complete" />}</CardAction>
+          </CardHeader>
+          <CardContent>
+            {defaultState.personalInformation === undefined ? (
+              <p>{t(($) => $.yourApplication.personalInfoDescription[defaultState.context])}</p>
+            ) : (
+              <DefinitionList layout="single-column">
+                {defaultState.personalInformation.memberId && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{formatClientNumber(defaultState.personalInformation.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.yourApplication.fullName)}>{`${defaultState.personalInformation.firstName} ${defaultState.personalInformation.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.yourApplication.dateOfBirth)}>{formattedDate}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.yourApplication.sin)}>{formatSin(defaultState.personalInformation.socialInsuranceNumber)}</DefinitionListItem>
+                {defaultState.livingIndependently !== undefined && (
+                  <DefinitionListItem term={t(($) => $.yourApplication.livingIndependently)}>{defaultState.livingIndependently ? t(($) => $.yourApplication.livingIndependentlyYes) : t(($) => $.yourApplication.livingIndependentlyNo)}</DefinitionListItem>
+                )}
+              </DefinitionList>
+            )}
+          </CardContent>
+          {isRenewalContext && !sections.personalInformation.completed && (
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink
+                id="personal-information-edit-button"
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/personal-information"
+                params={params}
+                startIcon={faCirclePlus}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit personal information click"
+              >
+                {t(($) => $.yourApplication.addPersonalInformation)}
+              </ButtonLink>
+            </CardFooter>
+          )}
+          {!isRenewalContext && (
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink
+                id="personal-information-edit-button"
+                variant="link"
+                className="p-0"
+                routeId="public/application/$id/personal-information"
+                params={params}
+                startIcon={defaultState.typeOfApplication ? faPenToSquare : faCirclePlus}
+                size="lg"
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Edit personal information click"
+              >
+                {defaultState.personalInformation === undefined ? t(($) => $.yourApplication.addPersonalInformation) : t(($) => $.yourApplication.editPersonalInformation)}
+              </ButtonLink>
+            </CardFooter>
+          )}
+        </Card>
+        {showNewOrReturningMemberSection && (
+          <Card>
+            <CardHeader>
+              <CardTitle>{t(($) => $.yourApplication.newOrReturningHeading)}</CardTitle>
+              <CardAction>{sections.newOrReturningMember?.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CardContent>
+              {defaultState.newOrReturningMember === undefined ? (
+                <p>{t(($) => $.yourApplication.newOrReturningDescription)}</p>
+              ) : (
+                <DefinitionList layout="single-column">
+                  <DefinitionListItem term={t(($) => $.yourApplication.previouslyEnrolled)}>{defaultState.newOrReturningMember.isNewOrReturningMember ? t(($) => $.yourApplication.yes) : t(($) => $.yourApplication.no)}</DefinitionListItem>
+                  {defaultState.newOrReturningMember.isNewOrReturningMember === true && <DefinitionListItem term={t(($) => $.yourApplication.memberId)}>{defaultState.newOrReturningMember.memberId}</DefinitionListItem>}
+                </DefinitionList>
+              )}
+            </CardContent>
+            <CardFooter className="border-t bg-zinc-100">
+              <ButtonLink id="edit-button" variant="link" className="p-0" routeId="public/application/$id/new-or-returning-member" params={params} startIcon={faCirclePlus} size="lg">
+                {defaultState.newOrReturningMember === undefined ? t(($) => $.yourApplication.addAnswer) : t(($) => $.yourApplication.editAnswer)}
+              </ButtonLink>
+            </CardFooter>
+          </Card>
+        )}
+        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+          <NavigationButtonLink disabled={!allSectionsCompleted} variant="primary" direction="next" to={nextRouteId} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Continue click">
+            {t(($) => $.yourApplication.application)}
+          </NavigationButtonLink>
+          <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/eligibility-requirements" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Entry:Back click">
+            {t(($) => $.yourApplication.beforeYouStart)}
+          </NavigationButtonLink>
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/pu
 import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.confirmation,
-  pageTitleI18nKey: 'applicationFullAdult:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -156,229 +156,232 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
   const cdcpLink = <InlineLink to={t(($) => $.confirm.statusCheckerLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
-        {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
+          {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
+              </section>
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                  </DefinitionListItem>
                 )}
-              </DefinitionListItem>
-            </DefinitionList>
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
           </section>
         </section>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </div>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-adult/contact-information.tsx
+++ b/frontend/app/routes/public/application/full-adult/contact-information.tsx
@@ -10,6 +10,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.contactInformation,
-  pageTitleI18nKey: 'applicationFullAdult:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'applicationFullAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -89,27 +89,28 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="contactInformation" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'applicationFullAdult' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'applicationFullAdult' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -123,7 +124,7 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'applicationFullAdult' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationFullAdult' })}
+              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -131,16 +132,16 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.contactInformation.addressHelp, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.contactInformation.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'applicationFullAdult' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -151,7 +152,7 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'applicationFullAdult' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -176,7 +177,7 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'applicationFullAdult' }) : t(($) => $.contactInformation.addAddress, { ns: 'applicationFullAdult' })}
+              {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -184,20 +185,20 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'applicationFullAdult' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'applicationFullAdult' })}>{preferredMethod?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod, { ns: 'applicationFullAdult' })}>{preferredNotificationMethod?.name}</DefinitionListItem>
-                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'applicationFullAdult' })}>{state.email}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod)}>{preferredNotificationMethod?.name}</DefinitionListItem>
+                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email)}>{state.email}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -211,7 +212,7 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit comms click"
             >
-              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'applicationFullAdult' }) : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationFullAdult' })}
+              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -225,10 +226,10 @@ export default function NewAdultContactInformation({ loaderData, params }: Route
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Continue click"
           >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'applicationFullAdult' })}
+            {t(($) => $.contactInformation.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/full-adult/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back click">
-            {t(($) => $.contactInformation.prevBtn, { ns: 'applicationFullAdult' })}
+            {t(($) => $.contactInformation.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/full-adult/dental-insurance.tsx
@@ -8,6 +8,7 @@ import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/pu
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -22,9 +23,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.dentalInsurance,
-  pageTitleI18nKey: 'applicationFullAdult:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -36,7 +36,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'applicationFullAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram
@@ -80,28 +80,29 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalInsurance?.dentalInsuranceEligibilityConfirmation === true ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'applicationFullAdult' })}>
-                  {state.dentalInsurance.hasDentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'applicationFullAdult' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'applicationFullAdult' })}
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>
+                  {state.dentalInsurance.hasDentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -113,14 +114,10 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
               params={params}
               startIcon={sections.dentalInsurance.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalInsurance === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullAdult' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationFullAdult' })}`
-                  : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationFullAdult' })
-              }
+              aria-label={state.dentalInsurance === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}` : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit insurance click"
             >
-              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullAdult' }) : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationFullAdult' })}
+              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -128,29 +125,29 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalBenefits ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationFullAdult' })}>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
                   {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
                     <div className="space-y-3">
-                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationFullAdult' })}</p>
+                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                       <ul className="list-disc space-y-1 pl-7">
                         {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                         {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                       </ul>
                     </div>
                   ) : (
-                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationFullAdult' })}</p>
+                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
                   )}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -162,14 +159,10 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
               params={params}
               startIcon={sections.dentalBenefits.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalBenefits === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullAdult' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationFullAdult' })}`
-                  : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationFullAdult' })
-              }
+              aria-label={state.dentalBenefits === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}` : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit benefits click"
             >
-              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullAdult' }) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationFullAdult' })}
+              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -183,10 +176,10 @@ export default function NewAdultDentalInsurance({ loaderData, params }: Route.Co
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Continue click"
           >
-            {t(($) => $.dentalInsurance.submit, { ns: 'applicationFullAdult' })}
+            {t(($) => $.dentalInsurance.submit)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/full-adult/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back click">
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'applicationFullAdult' })}
+            {t(($) => $.dentalInsurance.contactInformation)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-adult/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-adult/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/public-application-full-adult-route-helpers';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.exitApplication,
-  pageTitleI18nKey: 'applicationFullAdult:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function NewAdultExitApplication({ loaderData, params }: Route.Co
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/full-adult/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/full-adult/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-adult/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-adult/marital-status.tsx
@@ -8,6 +8,7 @@ import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/pu
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -23,9 +24,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.maritalStatus,
-  pageTitleI18nKey: 'applicationFullAdult:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -36,7 +36,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'applicationFullAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -59,30 +59,31 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'applicationFullAdult' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'applicationFullAdult' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'applicationFullAdult' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'applicationFullAdult' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'applicationFullAdult' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'applicationFullAdult' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'applicationFullAdult' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -99,7 +100,7 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'applicationFullAdult' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'applicationFullAdult' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -112,10 +113,10 @@ export default function NewAdultMaritalStatus({ loaderData, params }: Route.Comp
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Continue click"
           >
-            {t(($) => $.maritalStatus.contactInformation, { ns: 'applicationFullAdult' })}
+            {t(($) => $.maritalStatus.contactInformation)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back click">
-            {t(($) => $.maritalStatus.yourApplication, { ns: 'applicationFullAdult' })}
+            {t(($) => $.maritalStatus.yourApplication)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-adult/submit.tsx
+++ b/frontend/app/routes/public/application/full-adult/submit.tsx
@@ -11,6 +11,7 @@ import { loadPublicApplicationFullAdultStateForReview } from '~/.server/routes/h
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullAdult.submit,
-  pageTitleI18nKey: 'applicationFullAdult:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationFullAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const { ENABLED_FEATURES } = appContainer.get(TYPES.ClientConfig);
@@ -87,10 +87,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationFullAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationFullAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -125,75 +125,78 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationFullAdult' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationFullAdult' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationFullAdult' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationFullAdult' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationFullAdult' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationFullAdult' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationFullAdult' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationFullAdult' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationFullAdult' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationFullAdult' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationFullAdult' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/full-adult/dental-insurance"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back click"
-                >
-                  {t(($) => $.submit.dentalInsurance, { ns: 'applicationFullAdult' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/full-adult/dental-insurance"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Adult:Back click"
+                  >
+                    {t(($) => $.submit.dentalInsurance)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/full-adult/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/full-adult/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationFullAdult' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -12,6 +12,7 @@ import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/pu
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -35,7 +36,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb', 'common'),
   pageIdentifier: pageIds.public.application.fullChild.childApplication,
-  pageTitleI18nKey: 'applicationFullChild:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -150,6 +150,7 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -166,7 +167,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'applicationFullChild',
                 })}
               </h2>
               <div className="space-y-4">
@@ -185,7 +185,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'applicationFullChild',
                       })}
                     </h2>
                   </CardTitle>
@@ -219,7 +218,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'applicationFullChild',
                         })}
                   </ButtonLink>
                 </CardFooter>
@@ -257,7 +255,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                         ? `${t(($) => $.childrensApplication.addAnswer)} - ${t(($) => $.childrensApplication.dentalInsuranceTitle)}`
                         : t(($) => $.childrensApplication.editChildDentalInsurance, {
                             childNumber: index + 1,
-                            ns: 'applicationFullChild',
                           })
                     }
                   >
@@ -265,7 +262,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                       ? t(($) => $.childrensApplication.addAnswer)
                       : t(($) => $.childrensApplication.editChildDentalInsurance, {
                           childNumber: index + 1,
-                          ns: 'applicationFullChild',
                         })}
                   </ButtonLink>
                 </CardFooter>
@@ -313,7 +309,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                         ? `${t(($) => $.childrensApplication.addAnswer)} - ${t(($) => $.childrensApplication.dentalBenefitsTitle)}`
                         : t(($) => $.childrensApplication.editChildDentalBenefits, {
                             childNumber: index + 1,
-                            ns: 'applicationFullChild',
                           })
                     }
                   >
@@ -321,7 +316,6 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
                       ? t(($) => $.childrensApplication.addAnswer)
                       : t(($) => $.childrensApplication.editChildDentalBenefits, {
                           childNumber: index + 1,
-                          ns: 'applicationFullChild',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/pu
 import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullChild.confirmation,
-  pageTitleI18nKey: 'applicationFullChild:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -183,259 +183,260 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
-        {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
+          {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
         <section className="space-y-8">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
               </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
             </DefinitionList>
-          </section>
+          </div>
 
-          {spouseInfo && (
+          <section className="space-y-8">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'applicationFullChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'applicationFullChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-children/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-children/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/public-application-full-child-route-helpers';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullChild.exitApplication,
-  pageTitleI18nKey: 'applicationFullChild:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function NewChildrenExitApplication({ loaderData, params }: Route
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/full-children/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/full-children/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
@@ -9,6 +9,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullChild.parentOrGuardian,
-  pageTitleI18nKey: 'applicationFullChild:parentOrGuardian.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle, { ns: 'applicationFullChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -92,30 +92,31 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.maritalStatus, { ns: 'applicationFullChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.parentOrGuardian.selectYourStatus, { ns: 'applicationFullChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus, { ns: 'applicationFullChild' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin, { ns: 'applicationFullChild' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob, { ns: 'applicationFullChild' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.parentOrGuardian.consent, { ns: 'applicationFullChild' })}>{t(($) => $.parentOrGuardian.consentYes, { ns: 'applicationFullChild' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.parentOrGuardian.consent)}>{t(($) => $.parentOrGuardian.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -132,7 +133,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus, { ns: 'applicationFullChild' }) : t(($) => $.parentOrGuardian.editMaritalStatus, { ns: 'applicationFullChild' })}
+              {state.maritalStatus === undefined ? t(($) => $.parentOrGuardian.addMaritalStatus) : t(($) => $.parentOrGuardian.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -140,18 +141,18 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.phoneNumber, { ns: 'applicationFullChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber, { ns: 'applicationFullChild' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber, { ns: 'applicationFullChild' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.parentOrGuardian.phoneNumberHelp, { ns: 'applicationFullChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -165,7 +166,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber, { ns: 'applicationFullChild' }) : t(($) => $.parentOrGuardian.addPhoneNumber, { ns: 'applicationFullChild' })}
+              {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber) : t(($) => $.parentOrGuardian.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -173,16 +174,16 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress, { ns: 'applicationFullChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.parentOrGuardian.addressHelp, { ns: 'applicationFullChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress, { ns: 'applicationFullChild' })}>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -193,7 +194,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress, { ns: 'applicationFullChild' })}>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -218,7 +219,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress, { ns: 'applicationFullChild' }) : t(($) => $.parentOrGuardian.addAddress, { ns: 'applicationFullChild' })}
+              {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress) : t(($) => $.parentOrGuardian.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -226,20 +227,20 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.communicationPreferences, { ns: 'applicationFullChild' })}</h2>
+              <h2>{t(($) => $.parentOrGuardian.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'applicationFullChild' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'applicationFullChild' })}>{preferredMethod?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod, { ns: 'applicationFullChild' })}>{preferredNotificationMethod?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.parentOrGuardian.email, { ns: 'applicationFullChild' })}>{state.email}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod)}>{preferredNotificationMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.parentOrGuardian.email)}>{state.email}</DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp, { ns: 'applicationFullChild' })}</p>
+              <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -253,7 +254,7 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Edit comms click"
             >
-              {sections.communicationPreferences.completed ? t(($) => $.parentOrGuardian.editCommunicationPreferences, { ns: 'applicationFullChild' }) : t(($) => $.parentOrGuardian.addCommunicationPreferences, { ns: 'applicationFullChild' })}
+              {sections.communicationPreferences.completed ? t(($) => $.parentOrGuardian.editCommunicationPreferences) : t(($) => $.parentOrGuardian.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -267,10 +268,10 @@ export default function NewChildParentOrGuardian({ loaderData, params }: Route.C
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Continue click"
           >
-            {t(($) => $.parentOrGuardian.childrensApplication, { ns: 'applicationFullChild' })}
+            {t(($) => $.parentOrGuardian.childrensApplication)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back click">
-            {t(($) => $.parentOrGuardian.yourApplication, { ns: 'applicationFullChild' })}
+            {t(($) => $.parentOrGuardian.yourApplication)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-children/submit.tsx
+++ b/frontend/app/routes/public/application/full-children/submit.tsx
@@ -11,6 +11,7 @@ import { loadPublicApplicationFullChildStateForReview } from '~/.server/routes/h
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullChild.submit,
-  pageTitleI18nKey: 'applicationFullChild:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationFullChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -92,10 +92,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationFullChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationFullChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -132,77 +132,80 @@ export default function NewChildrenSubmit({ loaderData, params }: Route.Componen
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationFullChild' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationFullChild' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationFullChild' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationFullChild' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationFullChild' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationFullChild' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationFullChild' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationFullChild' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationFullChild' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationFullChild' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationFullChild' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/full-children/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'applicationFullChild' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/full-children/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Child:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/full-children/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/full-children/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationFullChild' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -12,6 +12,7 @@ import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/p
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -35,7 +36,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb', 'common'),
   pageIdentifier: pageIds.public.application.fullFamily.childApplication,
-  pageTitleI18nKey: 'applicationFullFamily:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -150,6 +150,7 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -166,7 +167,6 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'applicationFullFamily',
                 })}
               </h2>
               <div className="space-y-4">
@@ -185,7 +185,6 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'applicationFullFamily',
                       })}
                     </h2>
                   </CardTitle>
@@ -219,7 +218,6 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'applicationFullFamily',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -9,6 +9,7 @@ import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/p
 import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -28,7 +29,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.confirmation,
-  pageTitleI18nKey: 'applicationFullFamily:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -198,280 +198,281 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
           </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Confirmation survey button - Take the survey click"
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
             variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Print top - Application successfully submitted click"
           >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
-        {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.beginProcess[loaderData.context])}</p>
+          {loaderData.context === 'intake' && <p className="mt-4">{t(($) => $.confirm.proofOfCoverage)}</p>}
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.checkStatus)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.cdcpChecker} components={{ cdcpLink, noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.useCode)}</p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <p className="mt-4">{t(($) => $.confirm.getUpdatesInfo)}</p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.phoneNumber}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                <Address
-                  address={{
-                    address: mailingAddressInfo.address,
-                    city: mailingAddressInfo.city,
-                    provinceState: mailingAddressInfo.province,
-                    postalZipCode: mailingAddressInfo.postalCode,
-                    country: mailingAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                <Address
-                  address={{
-                    address: homeAddressInfo.address,
-                    city: homeAddressInfo.city,
-                    provinceState: homeAddressInfo.province,
-                    postalZipCode: homeAddressInfo.postalCode,
-                    country: homeAddressInfo.country,
-                  }}
-                />
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{t(($) => $.confirm.no)}</p>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'applicationFullFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'applicationFullFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <>{t(($) => $.confirm.no)}</>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.phoneNumber}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  <Address
+                    address={{
+                      address: mailingAddressInfo.address,
+                      city: mailingAddressInfo.city,
+                      provinceState: mailingAddressInfo.province,
+                      postalZipCode: mailingAddressInfo.postalCode,
+                      country: mailingAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  <Address
+                    address={{
+                      address: homeAddressInfo.address,
+                      city: homeAddressInfo.city,
+                      provinceState: homeAddressInfo.province,
+                      postalZipCode: homeAddressInfo.postalCode,
+                      country: homeAddressInfo.country,
+                    }}
+                  />
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{t(($) => $.confirm.no)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <>{t(($) => $.confirm.no)}</>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-family/contact-information.tsx
+++ b/frontend/app/routes/public/application/full-family/contact-information.tsx
@@ -10,6 +10,7 @@ import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, 
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -24,9 +25,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.contactInformation,
-  pageTitleI18nKey: 'applicationFullFamily:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -37,7 +37,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'applicationFullFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -89,27 +89,28 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="contactInformation" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
             </CardTitle>
             <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.phoneNumber?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'applicationFullFamily' })}>{state.phoneNumber.value.primary}</DefinitionListItem>
-                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'applicationFullFamily' })}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.value.primary}</DefinitionListItem>
+                {state.phoneNumber.value.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.value.alternate}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -123,7 +124,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit phone click"
             >
-              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'applicationFullFamily' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationFullFamily' })}
+              {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -131,16 +132,16 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
             </CardTitle>
             <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {mailingAddressInfo === undefined || homeAddressInfo === undefined ? (
-              <p>{t(($) => $.contactInformation.addressHelp, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.contactInformation.addressHelp)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'applicationFullFamily' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
                   <Address
                     address={{
                       address: mailingAddressInfo.address,
@@ -151,7 +152,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
                     }}
                   />
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'applicationFullFamily' })}>
+                <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                   <Address
                     address={{
                       address: homeAddressInfo.address,
@@ -176,7 +177,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit address click"
             >
-              {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'applicationFullFamily' }) : t(($) => $.contactInformation.addAddress, { ns: 'applicationFullFamily' })}
+              {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -184,20 +185,20 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
             </CardTitle>
             <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.communicationPreferences?.hasChanged ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'applicationFullFamily' })}>{preferredLanguage?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'applicationFullFamily' })}>{preferredMethod?.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod, { ns: 'applicationFullFamily' })}>{preferredNotificationMethod?.name}</DefinitionListItem>
-                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'applicationFullFamily' })}>{state.email}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{preferredLanguage?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{preferredMethod?.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod)}>{preferredNotificationMethod?.name}</DefinitionListItem>
+                {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email)}>{state.email}</DefinitionListItem>}
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -211,7 +212,7 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit comms click"
             >
-              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'applicationFullFamily' }) : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationFullFamily' })}
+              {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -225,10 +226,10 @@ export default function NewFamilyContactInformation({ loaderData, params }: Rout
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Continue click"
           >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'applicationFullFamily' })}
+            {t(($) => $.contactInformation.nextBtn)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/full-family/marital-status" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back click">
-            {t(($) => $.contactInformation.prevBtn, { ns: 'applicationFullFamily' })}
+            {t(($) => $.contactInformation.prevBtn)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-family/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/full-family/dental-insurance.tsx
@@ -8,6 +8,7 @@ import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/p
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -22,9 +23,8 @@ import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.dentalInsurance,
-  pageTitleI18nKey: 'applicationFullFamily:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -36,7 +36,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'applicationFullFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const selectedFederalGovernmentInsurancePlan = state.dentalBenefits?.value?.federalSocialProgram
@@ -80,27 +80,26 @@ export default function NewFamilyDentalInsurance({ loaderData, params }: Route.C
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalInsurance === undefined ? (
-              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'applicationFullFamily' })}>
-                  {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'applicationFullFamily' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'applicationFullFamily' })}
-                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
               </DefinitionList>
             )}
           </CardContent>
@@ -113,14 +112,10 @@ export default function NewFamilyDentalInsurance({ loaderData, params }: Route.C
               params={params}
               startIcon={sections.dentalInsurance.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalInsurance === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullFamily' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationFullFamily' })}`
-                  : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationFullFamily' })
-              }
+              aria-label={state.dentalInsurance === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}` : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit insurance click"
             >
-              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullFamily' }) : t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationFullFamily' })}
+              {state.dentalInsurance === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -128,29 +123,29 @@ export default function NewFamilyDentalInsurance({ loaderData, params }: Route.C
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
             </CardTitle>
             <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.dentalBenefits ? (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationFullFamily' })}>
+                <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
                   {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
                     <div className="space-y-3">
-                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationFullFamily' })}</p>
+                      <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                       <ul className="list-disc space-y-1 pl-7">
                         {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                         {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                       </ul>
                     </div>
                   ) : (
-                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationFullFamily' })}</p>
+                    <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
                   )}
                 </DefinitionListItem>
               </DefinitionList>
             ) : (
-              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
             )}
           </CardContent>
           <CardFooter className="border-t bg-zinc-100">
@@ -162,14 +157,10 @@ export default function NewFamilyDentalInsurance({ loaderData, params }: Route.C
               params={params}
               startIcon={sections.dentalBenefits.completed ? faPenToSquare : faCirclePlus}
               size="lg"
-              aria-label={
-                state.dentalBenefits === undefined
-                  ? `${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullFamily' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationFullFamily' })}`
-                  : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationFullFamily' })
-              }
+              aria-label={state.dentalBenefits === undefined ? `${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}` : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit benefits click"
             >
-              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationFullFamily' }) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationFullFamily' })}
+              {state.dentalBenefits === undefined ? t(($) => $.dentalInsurance.addAnswer) : t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -183,10 +174,10 @@ export default function NewFamilyDentalInsurance({ loaderData, params }: Route.C
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Continue click"
           >
-            {t(($) => $.dentalInsurance.childrensApplication, { ns: 'applicationFullFamily' })}
+            {t(($) => $.dentalInsurance.childrensApplication)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/full-family/contact-information" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back click">
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'applicationFullFamily' })}
+            {t(($) => $.dentalInsurance.contactInformation)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-family/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-family/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/public-application-full-family-route-helpers';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.exitApplication,
-  pageTitleI18nKey: 'applicationFullFamily:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function NewFamilyExitApplication({ loaderData, params }: Route.C
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/full-family/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/full-family/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/full-family/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-family/marital-status.tsx
@@ -8,6 +8,7 @@ import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/p
 import { isMaritalStatusSectionCompleted } from '~/.server/routes/helpers/public-application-full-section-checks';
 import { validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
@@ -23,9 +24,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.maritalStatus,
-  pageTitleI18nKey: 'applicationFullFamily:maritalStatus.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -36,7 +36,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'applicationFullFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const locale = getLocale(request);
   return {
@@ -59,30 +59,31 @@ export default function NewFamilyMaritalStatus({ loaderData, params }: Route.Com
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageHeading)}</AppPageTitle>
       <ProgressStepper activeStep="maritalStatus" className="mb-8" />
       <div className="max-w-prose space-y-8">
         <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
+          <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
           <p>{completedSectionsLabel}</p>
         </div>
         <Card>
           <CardHeader>
             <CardTitle asChild>
-              <h2>{t(($) => $.maritalStatus.maritalStatus, { ns: 'applicationFullFamily' })}</h2>
+              <h2>{t(($) => $.maritalStatus.maritalStatus)}</h2>
             </CardTitle>
             <CardAction>{sections.maritalStatus.completed && <StatusTag status="complete" />}</CardAction>
           </CardHeader>
           <CardContent>
             {state.maritalStatus === undefined ? (
-              <p>{t(($) => $.maritalStatus.selectYourStatus, { ns: 'applicationFullFamily' })}</p>
+              <p>{t(($) => $.maritalStatus.selectYourStatus)}</p>
             ) : (
               <DefinitionList layout="single-column">
-                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus, { ns: 'applicationFullFamily' })}>{state.maritalStatus.name}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.maritalStatus.maritalStatus)}>{state.maritalStatus.name}</DefinitionListItem>
                 {state.partnerInformation && (
                   <>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin, { ns: 'applicationFullFamily' })}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob, { ns: 'applicationFullFamily' })}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.maritalStatus.consent, { ns: 'applicationFullFamily' })}>{t(($) => $.maritalStatus.consentYes, { ns: 'applicationFullFamily' })}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseSin)}>{formatSin(state.partnerInformation.socialInsuranceNumber)}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.spouseYob)}>{state.partnerInformation.yearOfBirth}</DefinitionListItem>
+                    <DefinitionListItem term={t(($) => $.maritalStatus.consent)}>{t(($) => $.maritalStatus.consentYes)}</DefinitionListItem>
                   </>
                 )}
               </DefinitionList>
@@ -99,7 +100,7 @@ export default function NewFamilyMaritalStatus({ loaderData, params }: Route.Com
               size="lg"
               data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Edit marital click"
             >
-              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus, { ns: 'applicationFullFamily' }) : t(($) => $.maritalStatus.editMaritalStatus, { ns: 'applicationFullFamily' })}
+              {state.maritalStatus === undefined ? t(($) => $.maritalStatus.addMaritalStatus) : t(($) => $.maritalStatus.editMaritalStatus)}
             </ButtonLink>
           </CardFooter>
         </Card>
@@ -112,10 +113,10 @@ export default function NewFamilyMaritalStatus({ loaderData, params }: Route.Com
             params={params}
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Continue click"
           >
-            {t(($) => $.maritalStatus.contactInformation, { ns: 'applicationFullFamily' })}
+            {t(($) => $.maritalStatus.contactInformation)}
           </NavigationButtonLink>
           <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back click">
-            {t(($) => $.maritalStatus.yourApplication, { ns: 'applicationFullFamily' })}
+            {t(($) => $.maritalStatus.yourApplication)}
           </NavigationButtonLink>
         </div>
       </div>

--- a/frontend/app/routes/public/application/full-family/submit.tsx
+++ b/frontend/app/routes/public/application/full-family/submit.tsx
@@ -11,6 +11,7 @@ import { loadPublicApplicationFullFamilyStateForReview } from '~/.server/routes/
 import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationFullFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.fullFamily.submit,
-  pageTitleI18nKey: 'applicationFullFamily:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationFullFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -93,10 +93,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationFullFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationFullFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -133,78 +133,81 @@ export default function NewFamilySubmit({ loaderData, params }: Route.ComponentP
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationFullFamily' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationFullFamily' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationFullFamily' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationFullFamily' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationFullFamily' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationFullFamily' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationFullFamily' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationFullFamily' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationFullFamily' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationFullFamily' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationFullFamily' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/full-family/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back click"
-                >
-                  {t(($) => $.submit.childrenApplication, { ns: 'applicationFullFamily' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/full-family/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Full_Family:Back click"
+                  >
+                    {t(($) => $.submit.childrenApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/full-family/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/full-family/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationFullFamily' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/index.tsx
+++ b/frontend/app/routes/public/application/index.tsx
@@ -2,11 +2,14 @@ import { useEffect } from 'react';
 
 import { useNavigate, useNavigation } from 'react-router';
 
+import { useTranslation } from 'react-i18next';
+
 import type { Route } from './+types/index';
 
 import { TYPES } from '~/.server/constants';
 import { startApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
@@ -20,7 +23,6 @@ import { secondsToMilliseconds } from '~/utils/units.utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
   pageIdentifier: pageIds.public.application.index,
-  pageTitleI18nKey: 'application:eligibilityRequirements.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -45,6 +47,7 @@ const NAVIGATION_DELAY_MS = secondsToMilliseconds(1);
 export default function PublicApplicationIndex({ loaderData, params }: Route.ComponentProps) {
   const { id } = loaderData;
 
+  const { t } = useTranslation(handle.i18nNamespaces);
   const navigation = useNavigation();
   const navigate = useNavigate();
   const { set: setApplicationFlowStorageValue } = useApplicationFlowStorage();
@@ -75,57 +78,60 @@ export default function PublicApplicationIndex({ loaderData, params }: Route.Com
   }, [setApplicationFlowStorageValue, eligibilityRequirementsPath, isIdle, navigate]);
 
   return (
-    <div className="max-w-prose animate-pulse space-y-8">
-      {/* Intro text */}
-      <div className="space-y-4">
-        <div className="h-5 w-40 rounded bg-gray-200"></div>
-        <div className="h-5 w-56 rounded bg-gray-200"></div>
-      </div>
+    <>
+      <AppPageTitle>{t(($) => $.eligibilityRequirements.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose animate-pulse space-y-8">
+        {/* Intro text */}
+        <div className="space-y-4">
+          <div className="h-5 w-40 rounded bg-gray-200"></div>
+          <div className="h-5 w-56 rounded bg-gray-200"></div>
+        </div>
 
-      {/* Card 1 */}
-      <div className="rounded-lg border border-gray-300">
-        <div className="space-y-8 p-6">
-          <div className="h-6 w-3/4 rounded bg-gray-300"></div>
+        {/* Card 1 */}
+        <div className="rounded-lg border border-gray-300">
+          <div className="space-y-8 p-6">
+            <div className="h-6 w-3/4 rounded bg-gray-300"></div>
+            <div className="space-y-3">
+              <div className="h-5 w-full rounded bg-gray-200"></div>
+              <div className="h-5 w-5/6 rounded bg-gray-200"></div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+              <div className="h-5 w-2/3 rounded bg-gray-200"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Card 2 */}
+        <div className="rounded-lg border border-gray-300">
+          <div className="space-y-8 p-6">
+            <div className="h-6 w-40 rounded bg-gray-300"></div>
+            <div className="space-y-3">
+              <div className="h-5 w-full rounded bg-gray-200"></div>
+              <div className="h-5 w-5/6 rounded bg-gray-200"></div>
+            </div>
+          </div>
+
+          <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
+            <div className="flex items-center gap-3">
+              <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+              <div className="h-5 w-32 rounded bg-gray-200"></div>
+            </div>
+          </div>
+        </div>
+
+        {/* Next button */}
+        <div className="flex w-64 items-center justify-between rounded bg-gray-300 px-6 py-4">
           <div className="space-y-3">
-            <div className="h-5 w-full rounded bg-gray-200"></div>
-            <div className="h-5 w-5/6 rounded bg-gray-200"></div>
-          </div>
-        </div>
-
-        <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="h-6 w-6 rounded-full bg-gray-300"></div>
-            <div className="h-5 w-2/3 rounded bg-gray-200"></div>
-          </div>
-        </div>
-      </div>
-
-      {/* Card 2 */}
-      <div className="rounded-lg border border-gray-300">
-        <div className="space-y-8 p-6">
-          <div className="h-6 w-40 rounded bg-gray-300"></div>
-          <div className="space-y-3">
-            <div className="h-5 w-full rounded bg-gray-200"></div>
-            <div className="h-5 w-5/6 rounded bg-gray-200"></div>
-          </div>
-        </div>
-
-        <div className="border-t border-gray-300 bg-gray-50 px-6 py-4">
-          <div className="flex items-center gap-3">
-            <div className="h-6 w-6 rounded-full bg-gray-300"></div>
+            <div className="h-4 w-10 rounded bg-gray-200"></div>
             <div className="h-5 w-32 rounded bg-gray-200"></div>
           </div>
+          <div className="h-8 w-8 rounded-full bg-gray-200"></div>
         </div>
       </div>
-
-      {/* Next button */}
-      <div className="flex w-64 items-center justify-between rounded bg-gray-300 px-6 py-4">
-        <div className="space-y-3">
-          <div className="h-4 w-10 rounded bg-gray-200"></div>
-          <div className="h-5 w-32 rounded bg-gray-200"></div>
-        </div>
-        <div className="h-8 w-8 rounded-full bg-gray-200"></div>
-      </div>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
@@ -19,6 +19,7 @@ import {
 import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -39,7 +40,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedAdult.confirmation,
-  pageTitleI18nKey: 'applicationSimplifiedAdult:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -184,237 +184,240 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
   const cdcpLink = <InlineLink to={t(($) => $.confirm.mscaLinkChecker)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose space-y-10">
-      <section className="space-y-6">
-        <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-        <DefinitionList border>
-          <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
-            <Eligibility type={eligibility} />
-          </DefinitionListItem>
-        </DefinitionList>
-      </section>
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
-        <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
-          </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-        </p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="my-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <section className="space-y-6">
+          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
+          <DefinitionList border>
+            <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
+              <Eligibility type={eligibility} />
             </DefinitionListItem>
           </DefinitionList>
+        </section>
+        <div className="space-y-4">
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+          </h2>
+          <p>{t(($) => $.confirm.makeNote)}</p>
         </div>
-
-        <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+          </p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="my-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
               </DefinitionListItem>
             </DefinitionList>
-          </section>
+          </div>
 
-          {spouseInfo && (
+          <section className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
+              </section>
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                {mailingAddressInfo.hasMailingAddressChanged ? (
-                  <Address
-                    address={{
-                      address: mailingAddressInfo.address,
-                      city: mailingAddressInfo.city,
-                      provinceState: mailingAddressInfo.province,
-                      postalZipCode: mailingAddressInfo.postalCode,
-                      country: mailingAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
+                  </DefinitionListItem>
                 )}
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                {homeAddressInfo.hasHomeAddressChanged ? (
-                  <Address
-                    address={{
-                      address: homeAddressInfo.address,
-                      city: homeAddressInfo.city,
-                      provinceState: homeAddressInfo.province,
-                      postalZipCode: homeAddressInfo.postalCode,
-                      country: homeAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  {mailingAddressInfo.hasMailingAddressChanged ? (
+                    <Address
+                      address={{
+                        address: mailingAddressInfo.address,
+                        city: mailingAddressInfo.city,
+                        provinceState: mailingAddressInfo.province,
+                        postalZipCode: mailingAddressInfo.postalCode,
+                        country: mailingAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  {homeAddressInfo.hasHomeAddressChanged ? (
+                    <Address
+                      address={{
+                        address: homeAddressInfo.address,
+                        city: homeAddressInfo.city,
+                        provinceState: homeAddressInfo.province,
+                        postalZipCode: homeAddressInfo.postalCode,
+                        country: homeAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+              </DefinitionList>
+            </section>
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.hasDentalBenefitsChanged && (dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits) ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.hasDentalBenefitsChanged && (dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits) ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
           </section>
         </section>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </div>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-adult/contact-information.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/contact-information.tsx
@@ -15,6 +15,7 @@ import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/help
 import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -37,9 +38,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedAdult.contactInformation,
-  pageTitleI18nKey: 'applicationSimplifiedAdult:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'applicationSimplifiedAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -174,65 +174,68 @@ export default function RenewAdultContactInformation({ loaderData, params }: Rou
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="contactInformation" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.confirmInformation)}</p>
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="contactInformation" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.confirmInformation, { ns: 'application' })}</p>
+            <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
+              </CardTitle>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="public/application/$id/simplified-adult/dental-insurance"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Continue click"
+            >
+              {t(($) => $.contactInformation.nextBtn)}
+            </NavigationButtonLink>
+            <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click">
+              {t(($) => $.contactInformation.prevBtn)}
+            </NavigationButtonLink>
+          </div>
         </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'applicationSimplifiedAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'applicationSimplifiedAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'applicationSimplifiedAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="public/application/$id/simplified-adult/dental-insurance"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Continue click"
-          >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'applicationSimplifiedAdult' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click">
-            {t(($) => $.contactInformation.prevBtn, { ns: 'applicationSimplifiedAdult' })}
-          </NavigationButtonLink>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -260,11 +263,11 @@ function PhoneNumberCardContent(): JSX.Element {
   if (state.phoneNumber) {
     return (
       <CardContent>
-        {!state.phoneNumber.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedAdult' })}</p>}
+        {!state.phoneNumber.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.phoneNumber.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'applicationSimplifiedAdult' })}>{state.phoneNumber.primary}</DefinitionListItem>
-            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'applicationSimplifiedAdult' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+            <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
           </DefinitionList>
         )}
       </CardContent>
@@ -274,14 +277,14 @@ function PhoneNumberCardContent(): JSX.Element {
   if (clientApplication.hasPhoneNumber) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updatePhoneNumberHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+        <p>{t(($) => $.contactInformation.updatePhoneNumberHelp)}</p>
       </CardContent>
     );
   }
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+      <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -321,7 +324,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Edit phone click"
         >
-          {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'applicationSimplifiedAdult' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationSimplifiedAdult' })}
+          {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -341,7 +344,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Update phone click"
           >
-            {t(($) => $.contactInformation.updatePhoneNumber, { ns: 'applicationSimplifiedAdult' })}
+            {t(($) => $.contactInformation.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -355,7 +358,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged, { ns: 'applicationSimplifiedAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -374,7 +377,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Add phone click"
       >
-        {t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationSimplifiedAdult' })}
+        {t(($) => $.contactInformation.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -407,10 +410,10 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (state.mailingAddress && state.homeAddress) {
     return (
       <CardContent>
-        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedAdult' })}</p>}
+        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.mailingAddress.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'applicationSimplifiedAdult' })}>
+            <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
               <Address
                 address={{
                   address: state.mailingAddress.address ?? '',
@@ -423,7 +426,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
             </DefinitionListItem>
 
             {state.homeAddress.hasChanged && (
-              <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'applicationSimplifiedAdult' })}>
+              <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                 <Address
                   address={{
                     address: state.homeAddress.address ?? '',
@@ -445,7 +448,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (clientApplication.hasMailingAddress && clientApplication.hasHomeAddress) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updateAddressHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+        <p>{t(($) => $.contactInformation.updateAddressHelp)}</p>
       </CardContent>
     );
   }
@@ -453,7 +456,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.addressHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+      <p>{t(($) => $.contactInformation.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -494,7 +497,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Edit address click"
         >
-          {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'applicationSimplifiedAdult' }) : t(($) => $.contactInformation.addAddress, { ns: 'applicationSimplifiedAdult' })}
+          {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -514,7 +517,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Update address click"
           >
-            {t(($) => $.contactInformation.updateAddress, { ns: 'applicationSimplifiedAdult' })}
+            {t(($) => $.contactInformation.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -528,7 +531,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Complete address click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged, { ns: 'applicationSimplifiedAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -547,7 +550,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Add address click"
       >
-        {t(($) => $.contactInformation.addAddress, { ns: 'applicationSimplifiedAdult' })}
+        {t(($) => $.contactInformation.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -579,14 +582,14 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (state.communicationPreferences) {
     return (
       <CardContent>
-        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedAdult' })}</p>}
+        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.communicationPreferences.hasChanged && (
           <DefinitionList layout="single-column">
             <>
-              <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'applicationSimplifiedAdult' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'applicationSimplifiedAdult' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod, { ns: 'applicationSimplifiedAdult' })}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
-              {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'applicationSimplifiedAdult' })}>{state.email}</DefinitionListItem>}
+              <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+              <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+              <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod)}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
+              {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email)}>{state.email}</DefinitionListItem>}
             </>
           </DefinitionList>
         )}
@@ -598,7 +601,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (clientApplication.hasCommunicationPreferences) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updateCommunicationPreferencesHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+        <p>{t(($) => $.contactInformation.updateCommunicationPreferencesHelp)}</p>
       </CardContent>
     );
   }
@@ -606,7 +609,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'applicationSimplifiedAdult' })}</p>
+      <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -648,7 +651,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Edit comms click"
         >
-          {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'applicationSimplifiedAdult' }) : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationSimplifiedAdult' })}
+          {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -668,7 +671,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Update comms click"
           >
-            {t(($) => $.contactInformation.updateCommunicationPreferences, { ns: 'applicationSimplifiedAdult' })}
+            {t(($) => $.contactInformation.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -682,7 +685,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged, { ns: 'applicationSimplifiedAdult' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged)}</span>
           </LoadingButton>
         </div>
       </CardFooter>
@@ -701,7 +704,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Add comms click"
       >
-        {t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationSimplifiedAdult' })}
+        {t(($) => $.contactInformation.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
@@ -15,6 +15,7 @@ import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDent
 import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -34,9 +35,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedAdult.dentalInsurance,
-  pageTitleI18nKey: 'applicationSimplifiedAdult:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'applicationSimplifiedAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
@@ -143,59 +143,62 @@ export default function RenewAdultDentalInsurance({ loaderData, params }: Route.
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationSimplifiedAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalInsuranceCardContent />
-          <DentalInsuranceCardFooter />
-        </Card>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalInsuranceCardContent />
+            <DentalInsuranceCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationSimplifiedAdult' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalBenefitsCardContent />
-          <DentalBenefitsCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalBenefitsCardContent />
+            <DentalBenefitsCardFooter />
+          </Card>
 
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="public/application/$id/simplified-adult/submit"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Continue click"
-          >
-            {t(($) => $.dentalInsurance.submit, { ns: 'applicationSimplifiedAdult' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink
-            variant="secondary"
-            direction="previous"
-            routeId="public/application/$id/simplified-adult/contact-information"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click"
-          >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'applicationSimplifiedAdult' })}
-          </NavigationButtonLink>
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="public/application/$id/simplified-adult/submit"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Continue click"
+            >
+              {t(($) => $.dentalInsurance.submit)}
+            </NavigationButtonLink>
+            <NavigationButtonLink
+              variant="secondary"
+              direction="previous"
+              routeId="public/application/$id/simplified-adult/contact-information"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click"
+            >
+              {t(($) => $.dentalInsurance.contactInformation)}
+            </NavigationButtonLink>
+          </div>
         </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -219,9 +222,7 @@ function DentalInsuranceCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'applicationSimplifiedAdult' })}>
-            {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'applicationSimplifiedAdult' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'applicationSimplifiedAdult' })}
-          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -229,7 +230,7 @@ function DentalInsuranceCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'applicationSimplifiedAdult' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -262,7 +263,7 @@ function DentalInsuranceCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Edit button dental insurance click"
         >
-          {t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationSimplifiedAdult' })}
+          {t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
         </ButtonLink>
       </CardFooter>
     );
@@ -279,9 +280,9 @@ function DentalInsuranceCardFooter(): JSX.Element {
         startIcon={faCirclePlus}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Add button dental insurance click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedAdult' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationSimplifiedAdult' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedAdult' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );
@@ -308,17 +309,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationSimplifiedAdult' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationSimplifiedAdult' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                   {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationSimplifiedAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -330,17 +331,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationSimplifiedAdult' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {clientApplication.dentalBenefits.hasFederalBenefits || clientApplication.dentalBenefits.hasProvincialTerritorialBenefits ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationSimplifiedAdult' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {clientApplication.dentalBenefits.hasFederalBenefits && <li>{clientApplication.dentalBenefits.federalSocialProgram}</li>}
                   {clientApplication.dentalBenefits.hasProvincialTerritorialBenefits && <li>{clientApplication.dentalBenefits.provincialTerritorialSocialProgram}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationSimplifiedAdult' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -350,7 +351,7 @@ function DentalBenefitsCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'applicationSimplifiedAdult' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -385,7 +386,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Edit button government benefits click"
         >
-          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationSimplifiedAdult' })}
+          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
         </ButtonLink>
       </CardFooter>
     );
@@ -405,7 +406,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Update button government benefits click"
           >
-            {t(($) => $.dentalInsurance.updateMyAccess, { ns: 'applicationSimplifiedAdult' })}
+            {t(($) => $.dentalInsurance.updateMyAccess)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -419,7 +420,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Complete benefits click"
           >
-            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged, { ns: 'applicationSimplifiedAdult' })}</span>
+            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -437,9 +438,9 @@ function DentalBenefitsCardFooter(): JSX.Element {
         startIcon={faPenToSquare}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Adult:Add button dental benefits click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedAdult' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationSimplifiedAdult' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedAdult' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/public/application/simplified-adult/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedAdult.exitApplication,
-  pageTitleI18nKey: 'applicationSimplifiedAdult:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function RenewAdultExitApplication({ loaderData, params }: Route.
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/simplified-adult/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/simplified-adult/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Renewal Form-Adult:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-adult/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/submit.tsx
@@ -11,6 +11,7 @@ import { savePublicApplicationState, validateApplicationFlow } from '~/.server/r
 import { loadPublicApplicationSimplifiedAdultStateForReview } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedAdult', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedAdult.submit,
-  pageTitleI18nKey: 'applicationSimplifiedAdult:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationSimplifiedAdult' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const { ENABLED_FEATURES } = appContainer.get(TYPES.ClientConfig);
@@ -79,10 +79,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationSimplifiedAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationSimplifiedAdult' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -112,75 +112,78 @@ export default function RenewAdultSubmit({ loaderData, params }: Route.Component
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationSimplifiedAdult' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationSimplifiedAdult' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationSimplifiedAdult' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationSimplifiedAdult' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationSimplifiedAdult' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationSimplifiedAdult' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationSimplifiedAdult' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationSimplifiedAdult' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationSimplifiedAdult' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationSimplifiedAdult' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationSimplifiedAdult' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/simplified-adult/dental-insurance"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click"
-                >
-                  {t(($) => $.submit.dentalInsurance, { ns: 'applicationSimplifiedAdult' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/simplified-adult/dental-insurance"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Adult:Back click"
+                  >
+                    {t(($) => $.submit.dentalInsurance)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/simplified-adult/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/simplified-adult/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationSimplifiedAdult' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -13,6 +13,7 @@ import { savePublicApplicationState, validateApplicationFlow } from '~/.server/r
 import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -36,7 +37,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove', DENTAL_BENEFITS_NOT_CHANGED:
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb', 'common'),
   pageIdentifier: pageIds.public.application.simplifiedChild.childApplication,
-  pageTitleI18nKey: 'applicationSimplifiedChild:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -172,6 +172,7 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -187,7 +188,6 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'applicationSimplifiedChild',
                 })}
               </h2>
               <div className="space-y-4">
@@ -206,7 +206,6 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'applicationSimplifiedChild',
                       })}
                     </h2>
                   </CardTitle>
@@ -240,7 +239,6 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'applicationSimplifiedChild',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/public/application/simplified-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-children/confirmation.tsx
@@ -20,6 +20,7 @@ import {
 import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -40,7 +41,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedChild.confirmation,
-  pageTitleI18nKey: 'applicationSimplifiedChild:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -212,269 +212,270 @@ export default function RenewChildrenConfirmation({ loaderData, params }: Route.
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <section className="space-y-6">
-        <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-        {children.map((child) => (
-          <DefinitionList border key={child.id}>
-            <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
-              <Eligibility type={child.eligibility} />
-            </DefinitionListItem>
-          </DefinitionList>
-        ))}
-      </section>
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
-        <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
-          </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-        </p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="my-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
-        <section className="space-y-8">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
+        <section className="space-y-6">
+          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
+          {children.map((child) => (
+            <DefinitionList border key={child.id}>
+              <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
+                <Eligibility type={child.eligibility} />
               </DefinitionListItem>
             </DefinitionList>
-          </section>
+          ))}
+        </section>
+        <div className="space-y-4">
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+          </h2>
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+          </p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="my-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
-          {spouseInfo && (
+          <section className="space-y-8">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.parentOrGuardian)}</h2>
+
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.parentOrGuardianInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                {mailingAddressInfo.hasMailingAddressChanged ? (
-                  <Address
-                    address={{
-                      address: mailingAddressInfo.address,
-                      city: mailingAddressInfo.city,
-                      provinceState: mailingAddressInfo.province,
-                      postalZipCode: mailingAddressInfo.postalCode,
-                      country: mailingAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
-                )}
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                {homeAddressInfo.hasHomeAddressChanged ? (
-                  <Address
-                    address={{
-                      address: homeAddressInfo.address,
-                      city: homeAddressInfo.city,
-                      provinceState: homeAddressInfo.province,
-                      postalZipCode: homeAddressInfo.postalCode,
-                      country: homeAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'applicationSimplifiedChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'applicationSimplifiedChild',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.hasDentalBenefitsChanged && (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access) ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <p>{child.dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  {mailingAddressInfo.hasMailingAddressChanged ? (
+                    <Address
+                      address={{
+                        address: mailingAddressInfo.address,
+                        city: mailingAddressInfo.city,
+                        provinceState: mailingAddressInfo.province,
+                        postalZipCode: mailingAddressInfo.postalCode,
+                        country: mailingAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  {homeAddressInfo.hasHomeAddressChanged ? (
+                    <Address
+                      address={{
+                        address: homeAddressInfo.address,
+                        city: homeAddressInfo.city,
+                        provinceState: homeAddressInfo.province,
+                        postalZipCode: homeAddressInfo.postalCode,
+                        country: homeAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.hasDentalBenefitsChanged && (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access) ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <p>{child.dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-children/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedChild.exitApplication,
-  pageTitleI18nKey: 'applicationSimplifiedChild:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function RenewChildrenExitApplication({ loaderData, params }: Rou
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/simplified-children/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/simplified-children/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/simplified-children/parent-or-guardian.tsx
@@ -14,6 +14,7 @@ import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/help
 import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -35,9 +36,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedChild.parentOrGuardian,
-  pageTitleI18nKey: 'applicationSimplifiedChild:parentOrGuardian.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle, { ns: 'applicationSimplifiedChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.parentOrGuardian.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -174,65 +174,68 @@ export default function RenewChildParentOrGuardian({ loaderData, params }: Route
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.confirmInformation)}</p>
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="parentOrGuardian" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.confirmInformation, { ns: 'application' })}</p>
+            <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.phoneNumber)}</h2>
+              </CardTitle>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.parentOrGuardian.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="public/application/$id/simplified-children/childrens-application"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Continue click"
+            >
+              {t(($) => $.parentOrGuardian.childrensApplication)}
+            </NavigationButtonLink>
+            <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back click">
+              {t(($) => $.parentOrGuardian.yourApplication)}
+            </NavigationButtonLink>
+          </div>
         </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.phoneNumber, { ns: 'applicationSimplifiedChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.mailingAndHomeAddress, { ns: 'applicationSimplifiedChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.parentOrGuardian.communicationPreferences, { ns: 'applicationSimplifiedChild' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="public/application/$id/simplified-children/childrens-application"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Continue click"
-          >
-            {t(($) => $.parentOrGuardian.childrensApplication, { ns: 'applicationSimplifiedChild' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back click">
-            {t(($) => $.parentOrGuardian.yourApplication, { ns: 'applicationSimplifiedChild' })}
-          </NavigationButtonLink>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -260,11 +263,11 @@ function PhoneNumberCardContent(): JSX.Element {
   if (state.phoneNumber) {
     return (
       <CardContent>
-        {!state.phoneNumber.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange, { ns: 'applicationSimplifiedChild' })}</p>}
+        {!state.phoneNumber.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange)}</p>}
         {state.phoneNumber.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber, { ns: 'applicationSimplifiedChild' })}>{state.phoneNumber.primary}</DefinitionListItem>
-            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber, { ns: 'applicationSimplifiedChild' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+            <DefinitionListItem term={t(($) => $.parentOrGuardian.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.parentOrGuardian.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
           </DefinitionList>
         )}
       </CardContent>
@@ -274,14 +277,14 @@ function PhoneNumberCardContent(): JSX.Element {
   if (clientApplication.hasPhoneNumber) {
     return (
       <CardContent>
-        <p>{t(($) => $.parentOrGuardian.updatePhoneNumberHelp, { ns: 'applicationSimplifiedChild' })}</p>
+        <p>{t(($) => $.parentOrGuardian.updatePhoneNumberHelp)}</p>
       </CardContent>
     );
   }
 
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.phoneNumberHelp, { ns: 'applicationSimplifiedChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -321,7 +324,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Edit phone click"
         >
-          {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber, { ns: 'applicationSimplifiedChild' }) : t(($) => $.parentOrGuardian.addPhoneNumber, { ns: 'applicationSimplifiedChild' })}
+          {sections.phoneNumber.completed ? t(($) => $.parentOrGuardian.editPhoneNumber) : t(($) => $.parentOrGuardian.addPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -341,7 +344,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Update phone click"
           >
-            {t(($) => $.parentOrGuardian.updatePhoneNumber, { ns: 'applicationSimplifiedChild' })}
+            {t(($) => $.parentOrGuardian.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -355,7 +358,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.phoneNumberUnchanged, { ns: 'applicationSimplifiedChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -374,7 +377,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Add phone click"
       >
-        {t(($) => $.parentOrGuardian.addPhoneNumber, { ns: 'applicationSimplifiedChild' })}
+        {t(($) => $.parentOrGuardian.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -407,10 +410,10 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (state.mailingAddress && state.homeAddress) {
     return (
       <CardContent>
-        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange, { ns: 'applicationSimplifiedChild' })}</p>}
+        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange)}</p>}
         {state.mailingAddress.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress, { ns: 'applicationSimplifiedChild' })}>
+            <DefinitionListItem term={t(($) => $.parentOrGuardian.mailingAddress)}>
               <Address
                 address={{
                   address: state.mailingAddress.address ?? '',
@@ -423,7 +426,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
             </DefinitionListItem>
 
             {state.homeAddress.hasChanged && (
-              <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress, { ns: 'applicationSimplifiedChild' })}>
+              <DefinitionListItem term={t(($) => $.parentOrGuardian.homeAddress)}>
                 <Address
                   address={{
                     address: state.homeAddress.address ?? '',
@@ -445,7 +448,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (clientApplication.hasMailingAddress && clientApplication.hasHomeAddress) {
     return (
       <CardContent>
-        <p>{t(($) => $.parentOrGuardian.updateAddressHelp, { ns: 'applicationSimplifiedChild' })}</p>
+        <p>{t(($) => $.parentOrGuardian.updateAddressHelp)}</p>
       </CardContent>
     );
   }
@@ -453,7 +456,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.addressHelp, { ns: 'applicationSimplifiedChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -494,7 +497,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Edit address click"
         >
-          {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress, { ns: 'applicationSimplifiedChild' }) : t(($) => $.parentOrGuardian.addAddress, { ns: 'applicationSimplifiedChild' })}
+          {sections.address.completed ? t(($) => $.parentOrGuardian.editAddress) : t(($) => $.parentOrGuardian.addAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -514,7 +517,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Update address click"
           >
-            {t(($) => $.parentOrGuardian.updateAddress, { ns: 'applicationSimplifiedChild' })}
+            {t(($) => $.parentOrGuardian.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -528,7 +531,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Complete address click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.addressUnchanged, { ns: 'applicationSimplifiedChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -547,7 +550,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Add address click"
       >
-        {t(($) => $.parentOrGuardian.addAddress, { ns: 'applicationSimplifiedChild' })}
+        {t(($) => $.parentOrGuardian.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -579,13 +582,13 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (state.communicationPreferences) {
     return (
       <CardContent>
-        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange, { ns: 'applicationSimplifiedChild' })}</p>}
+        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.parentOrGuardian.noChange)}</p>}
         {state.communicationPreferences.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage, { ns: 'applicationSimplifiedChild' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod, { ns: 'applicationSimplifiedChild' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
-            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod, { ns: 'applicationSimplifiedChild' })}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
-            {state.email && <DefinitionListItem term={t(($) => $.parentOrGuardian.email, { ns: 'applicationSimplifiedChild' })}>{state.email}</DefinitionListItem>}
+            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.parentOrGuardian.preferredNotificationMethod)}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
+            {state.email && <DefinitionListItem term={t(($) => $.parentOrGuardian.email)}>{state.email}</DefinitionListItem>}
           </DefinitionList>
         )}
       </CardContent>
@@ -596,7 +599,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (clientApplication.hasCommunicationPreferences) {
     return (
       <CardContent>
-        <p>{t(($) => $.parentOrGuardian.updateCommunicationPreferencesHelp, { ns: 'applicationSimplifiedChild' })}</p>
+        <p>{t(($) => $.parentOrGuardian.updateCommunicationPreferencesHelp)}</p>
       </CardContent>
     );
   }
@@ -604,7 +607,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp, { ns: 'applicationSimplifiedChild' })}</p>
+      <p>{t(($) => $.parentOrGuardian.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -646,7 +649,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Edit comms click"
         >
-          {sections.communicationPreferences.completed ? t(($) => $.parentOrGuardian.editCommunicationPreferences, { ns: 'applicationSimplifiedChild' }) : t(($) => $.parentOrGuardian.addCommunicationPreferences, { ns: 'applicationSimplifiedChild' })}
+          {sections.communicationPreferences.completed ? t(($) => $.parentOrGuardian.editCommunicationPreferences) : t(($) => $.parentOrGuardian.addCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -666,7 +669,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Update comms click"
           >
-            {t(($) => $.parentOrGuardian.updateCommunicationPreferences, { ns: 'applicationSimplifiedChild' })}
+            {t(($) => $.parentOrGuardian.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -680,7 +683,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.parentOrGuardian.communicationPreferencesUnchanged, { ns: 'applicationSimplifiedChild' })}</span>
+            <span className="text-left">{t(($) => $.parentOrGuardian.communicationPreferencesUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -699,7 +702,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Add comms click"
       >
-        {t(($) => $.parentOrGuardian.addCommunicationPreferences, { ns: 'applicationSimplifiedChild' })}
+        {t(($) => $.parentOrGuardian.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/public/application/simplified-children/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-children/submit.tsx
@@ -11,6 +11,7 @@ import { savePublicApplicationState, validateApplicationFlow } from '~/.server/r
 import { loadPublicApplicationSimplifiedChildStateForReview } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedChild', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedChild.submit,
-  pageTitleI18nKey: 'applicationSimplifiedChild:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationSimplifiedChild' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -84,10 +84,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationSimplifiedChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationSimplifiedChild' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -117,77 +117,80 @@ export default function RenewChildrenSubmit({ loaderData, params }: Route.Compon
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationSimplifiedChild' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationSimplifiedChild' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationSimplifiedChild' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationSimplifiedChild' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationSimplifiedChild' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationSimplifiedChild' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationSimplifiedChild' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationSimplifiedChild' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationSimplifiedChild' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationSimplifiedChild' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationSimplifiedChild' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/simplified-children/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'applicationSimplifiedChild' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/simplified-children/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Child:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/simplified-children/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/simplified-children/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationSimplifiedChild' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -13,6 +13,7 @@ import { savePublicApplicationState, validateApplicationFlow } from '~/.server/r
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { isChildDentalBenefitsSectionCompleted, isChildDentalInsuranceSectionCompleted, isChildInformationSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -36,7 +37,6 @@ const FORM_ACTION = { add: 'add', remove: 'remove', DENTAL_BENEFITS_NOT_CHANGED:
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb', 'common'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.childApplication,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:childrensApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -171,6 +171,7 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.childrensApplication.pageTitle)}</AppPageTitle>
       <ProgressStepper activeStep="childrensApplication" className="mb-8" />
       <div className="max-w-prose space-y-8">
         {state.children.map((child, index) => {
@@ -186,7 +187,6 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
               <h2 className="font-lato mb-4 text-2xl font-bold">
                 {t(($) => $.childrensApplication.childTitle, {
                   childNumber: index + 1,
-                  ns: 'applicationSimplifiedFamily',
                 })}
               </h2>
               <div className="space-y-4">
@@ -205,7 +205,6 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
                     <h2>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
-                        ns: 'applicationSimplifiedFamily',
                       })}
                     </h2>
                   </CardTitle>
@@ -239,7 +238,6 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
                       ? t(($) => $.childrensApplication.addChildInformation)
                       : t(($) => $.childrensApplication.editChildInformation, {
                           childNumber: index + 1,
-                          ns: 'applicationSimplifiedFamily',
                         })}
                   </ButtonLink>
                 </CardFooter>

--- a/frontend/app/routes/public/application/simplified-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-family/confirmation.tsx
@@ -21,6 +21,7 @@ import {
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -41,7 +42,6 @@ import { formatSin } from '~/utils/sin-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.confirmation,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:confirm.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -230,296 +230,297 @@ export default function SimplifiedFamilyConfirmation({ loaderData, params }: Rou
   const { currentLanguage } = useCurrentLanguage();
 
   return (
-    <div className="max-w-prose space-y-10">
-      <section className="space-y-6">
-        <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
-        <DefinitionList border>
-          <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
-            <Eligibility type={eligibility} />
-          </DefinitionListItem>
-        </DefinitionList>
-        {children.map((child) => (
-          <DefinitionList key={child.id}>
-            <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
-              <Eligibility type={child.eligibility} />
-            </DefinitionListItem>
-          </DefinitionList>
-        ))}
-      </section>
-      <div className="space-y-4">
-        <h2 className="text-3xl">
-          <strong>{t(($) => $.confirm.appCodeIs)}</strong>
-          <br />
-          <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-        </h2>
-        <p>{t(($) => $.confirm.makeNote)}</p>
-      </div>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
-        <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
-        <Button
-          variant="primary"
-          size="lg"
-          className="mt-8 print:hidden"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Print top - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
-      </section>
-      <ContextualAlert type="comment">
-        <div className="space-y-4">
-          <h2 className="text-2xl">
-            <strong>{t(($) => $.confirm.survey.title)}</strong>
-          </h2>
-          <p>{t(($) => $.confirm.survey.info)}</p>
-          <ButtonLink
-            id="survey-button"
-            to={surveyLink}
-            className="external-link"
-            newTabIndicator
-            target="_blank"
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Confirmation survey button - Take the survey click"
-            variant="primary"
-          >
-            {t(($) => $.confirm.survey.button)}
-          </ButtonLink>
-        </div>
-      </ContextualAlert>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
-        <p className="mt-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
-        </p>
-      </section>
-      <section>
-        <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
-        <p className="my-4">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
-        </p>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>{t(($) => $.confirm.view)}</li>
-          <li>{t(($) => $.confirm.update)}</li>
-          <li>{t(($) => $.confirm.access)}</li>
-        </ul>
-      </section>
-      <section className="space-y-8">
-        <div className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
-          <DefinitionList border className="text-xl">
-            <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
-              <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
-            </DefinitionListItem>
-          </DefinitionList>
-        </div>
-
+    <>
+      <AppPageTitle>{t(($) => $.confirm.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-10">
         <section className="space-y-6">
-          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
+          <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.yourEligibility)}</h3>
+          <DefinitionList border>
+            <DefinitionListItem term={`${userInfo.firstName} ${userInfo.lastName}`}>
+              <Eligibility type={eligibility} />
+            </DefinitionListItem>
+          </DefinitionList>
+          {children.map((child) => (
+            <DefinitionList key={child.id}>
+              <DefinitionListItem term={`${child.firstName} ${child.lastName}`}>
+                <Eligibility type={child.eligibility} />
+              </DefinitionListItem>
+            </DefinitionList>
+          ))}
+        </section>
+        <div className="space-y-4">
+          <h2 className="text-3xl">
+            <strong>{t(($) => $.confirm.appCodeIs)}</strong>
+            <br />
+            <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+          </h2>
+          <p>{t(($) => $.confirm.makeNote)}</p>
+        </div>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.keepCopy)}</h2>
+          <p className="mt-4">{t(($) => $.confirm.printCopyImportant)}</p>
+          <Button
+            variant="primary"
+            size="lg"
+            className="mt-8 print:hidden"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Print top - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
+        </section>
+        <ContextualAlert type="comment">
+          <div className="space-y-4">
+            <h2 className="text-2xl">
+              <strong>{t(($) => $.confirm.survey.title)}</strong>
+            </h2>
+            <p>{t(($) => $.confirm.survey.info)}</p>
+            <ButtonLink
+              id="survey-button"
+              to={surveyLink}
+              className="external-link"
+              newTabIndicator
+              target="_blank"
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Confirmation survey button - Take the survey click"
+              variant="primary"
+            >
+              {t(($) => $.confirm.survey.button)}
+            </ButtonLink>
+          </div>
+        </ContextualAlert>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.whatsNext)}</h2>
+          <p className="mt-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.beginProcess} components={{ cdcpLink, mscaLinkAccount }} />
+          </p>
+        </section>
+        <section>
+          <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.getUpdatesTitle)}</h2>
+          <p className="my-4">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.confirm.getUpdatesText} components={{ mscaLinkAccount }} />
+          </p>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.confirm.view)}</li>
+            <li>{t(($) => $.confirm.update)}</li>
+            <li>{t(($) => $.confirm.access)}</li>
+          </ul>
+        </section>
+        <section className="space-y-8">
+          <div className="space-y-6">
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicationSumm)}</h2>
+            <DefinitionList border className="text-xl">
+              <DefinitionListItem term={t(($) => $.confirm.applicationCode)}>
+                <strong>{formatSubmissionApplicationCode(submissionInfo.confirmationCode)}</strong>
+              </DefinitionListItem>
+            </DefinitionList>
+          </div>
 
           <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
-            <DefinitionList border>
-              {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
-              <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
-            </DefinitionList>
-          </section>
+            <h2 className="font-lato text-3xl font-bold">{t(($) => $.confirm.applicant)}</h2>
 
-          {spouseInfo && (
             <section className="space-y-6">
-              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.applicantInfo)}</h3>
               <DefinitionList border>
-                <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                {userInfo.memberId && <DefinitionListItem term={t(($) => $.confirm.memberId)}>{formatClientNumber(userInfo.memberId)}</DefinitionListItem>}
+                <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${userInfo.firstName} ${userInfo.lastName}`}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dob)}>{userInfo.birthday}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sin)}>
-                  <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  <span className="text-nowrap">{formatSin(userInfo.sin)}</span>
                 </DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.maritalStatus)}>{userInfo.maritalStatus}</DefinitionListItem>
               </DefinitionList>
             </section>
-          )}
 
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
-              </DefinitionListItem>
-              {userInfo.contactInformationEmail && (
-                <DefinitionListItem term={t(($) => $.confirm.email)}>
-                  <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
-                </DefinitionListItem>
-              )}
-              <DefinitionListItem term={t(($) => $.confirm.mailing)}>
-                {mailingAddressInfo.hasMailingAddressChanged ? (
-                  <Address
-                    address={{
-                      address: mailingAddressInfo.address,
-                      city: mailingAddressInfo.city,
-                      provinceState: mailingAddressInfo.province,
-                      postalZipCode: mailingAddressInfo.postalCode,
-                      country: mailingAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
-                )}
-              </DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.home)}>
-                {homeAddressInfo.hasHomeAddressChanged ? (
-                  <Address
-                    address={{
-                      address: homeAddressInfo.address,
-                      city: homeAddressInfo.city,
-                      provinceState: homeAddressInfo.province,
-                      postalZipCode: homeAddressInfo.postalCode,
-                      country: homeAddressInfo.country,
-                    }}
-                  />
-                ) : (
-                  <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-            </DefinitionList>
-          </section>
-
-          <section className="space-y-6">
-            <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
-            <DefinitionList border>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-              <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                {dentalInsurance.hasDentalBenefitsChanged && (dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits) ? (
-                  <div className="space-y-3">
-                    <p>{t(($) => $.confirm.yes)}</p>
-                    <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                    <ul className="list-disc space-y-1 pl-7">
-                      {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
-                      {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
-                    </ul>
-                  </div>
-                ) : (
-                  <p>{dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
-                )}
-              </DefinitionListItem>
-            </DefinitionList>
-          </section>
-        </section>
-
-        <div className="mb-8 space-y-10">
-          {children.map((child) => {
-            const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
-            return (
-              <section key={child.id} className="space-y-10">
-                <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.pageSubTitle, {
-                      child: child.firstName,
-                      ns: 'applicationSimplifiedFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                  </DefinitionList>
-                </div>
-                <div>
-                  <h3 className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.confirm.dentalTitle, {
-                      child: child.firstName,
-                      ns: 'applicationSimplifiedFamily',
-                    })}
-                  </h3>
-                  <DefinitionList border>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
-                    <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
-                      {child.dentalInsurance.hasDentalBenefitsChanged && (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access) ? (
-                        <div className="space-y-3">
-                          <p>{t(($) => $.confirm.yes)}</p>
-                          <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
-                          <ul className="list-disc space-y-1 pl-7">
-                            {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
-                            {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
-                          </ul>
-                        </div>
-                      ) : (
-                        <p>{child.dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
-                      )}
-                    </DefinitionListItem>
-                  </DefinitionList>
-                </div>
+            {spouseInfo && (
+              <section className="space-y-6">
+                <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.spouseInfo)}</h3>
+                <DefinitionList border>
+                  <DefinitionListItem term={t(($) => $.confirm.yearBirth)}>{spouseInfo.yearOfBirth}</DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.sin)}>
+                    <span className="text-nowrap">{formatSin(spouseInfo.sin)}</span>
+                  </DefinitionListItem>
+                  <DefinitionListItem term={t(($) => $.confirm.consent)}>{t(($) => $.confirm.consentAnswer)}</DefinitionListItem>
+                </DefinitionList>
               </section>
-            );
-          })}
+            )}
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.contactInfo)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.phoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.phoneNumber : t(($) => $.confirm.noUpdate)}</span>
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
+                  <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
+                </DefinitionListItem>
+                {userInfo.contactInformationEmail && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
+                  </DefinitionListItem>
+                )}
+                <DefinitionListItem term={t(($) => $.confirm.mailing)}>
+                  {mailingAddressInfo.hasMailingAddressChanged ? (
+                    <Address
+                      address={{
+                        address: mailingAddressInfo.address,
+                        city: mailingAddressInfo.city,
+                        provinceState: mailingAddressInfo.province,
+                        postalZipCode: mailingAddressInfo.postalCode,
+                        country: mailingAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.home)}>
+                  {homeAddressInfo.hasHomeAddressChanged ? (
+                    <Address
+                      address={{
+                        address: homeAddressInfo.address,
+                        city: homeAddressInfo.city,
+                        provinceState: homeAddressInfo.province,
+                        postalZipCode: homeAddressInfo.postalCode,
+                        country: homeAddressInfo.country,
+                      }}
+                    />
+                  ) : (
+                    <span className="text-nowrap">{t(($) => $.confirm.noUpdate)}</span>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.commPref)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+              </DefinitionList>
+            </section>
+
+            <section className="space-y-6">
+              <h3 className="font-lato text-2xl font-bold">{t(($) => $.confirm.dentalInsurance)}</h3>
+              <DefinitionList border>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                  {dentalInsurance.hasDentalBenefitsChanged && (dentalInsurance.selectedFederalBenefits || dentalInsurance.selectedProvincialBenefits) ? (
+                    <div className="space-y-3">
+                      <p>{t(($) => $.confirm.yes)}</p>
+                      <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                      <ul className="list-disc space-y-1 pl-7">
+                        {dentalInsurance.selectedFederalBenefits && <li>{dentalInsurance.selectedFederalBenefits}</li>}
+                        {dentalInsurance.selectedProvincialBenefits && <li>{dentalInsurance.selectedProvincialBenefits}</li>}
+                      </ul>
+                    </div>
+                  ) : (
+                    <p>{dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
+                  )}
+                </DefinitionListItem>
+              </DefinitionList>
+            </section>
+          </section>
+
+          <div className="mb-8 space-y-10">
+            {children.map((child) => {
+              const dateOfBirth = toLocaleDateString(parseDateString(child.birthday ?? ''), currentLanguage);
+              return (
+                <section key={child.id} className="space-y-10">
+                  <h2 className="font-lato text-3xl font-bold">{child.firstName}</h2>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.pageSubTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.memberId)}>{child.memberId}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.fullName)}>{`${child.firstName} ${child.lastName}`}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dob)}>{dateOfBirth}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.sin)}>{child.sin && formatSin(child.sin)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.isParent)}>{child.isParent ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                  <div>
+                    <h3 className="font-lato mb-6 text-2xl font-bold">
+                      {t(($) => $.confirm.dentalTitle, {
+                        child: child.firstName,
+                      })}
+                    </h3>
+                    <DefinitionList border>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPrivate)}>{child.dentalInsurance.accessToDentalInsurance ? t(($) => $.confirm.yes) : t(($) => $.confirm.no)}</DefinitionListItem>
+                      <DefinitionListItem term={t(($) => $.confirm.dentalPublic)}>
+                        {child.dentalInsurance.hasDentalBenefitsChanged && (child.dentalInsurance.federalBenefit.access || child.dentalInsurance.provTerrBenefit.access) ? (
+                          <div className="space-y-3">
+                            <p>{t(($) => $.confirm.yes)}</p>
+                            <p>{t(($) => $.confirm.dentalBenefitHasAccess)}</p>
+                            <ul className="list-disc space-y-1 pl-7">
+                              {child.dentalInsurance.federalBenefit.access && <li>{child.dentalInsurance.federalBenefit.benefit}</li>}
+                              {child.dentalInsurance.provTerrBenefit.access && <li>{child.dentalInsurance.provTerrBenefit.benefit}</li>}
+                            </ul>
+                          </div>
+                        ) : (
+                          <p>{child.dentalInsurance.hasDentalBenefitsChanged ? t(($) => $.confirm.no) : t(($) => $.confirm.noUpdate)}</p>
+                        )}
+                      </DefinitionListItem>
+                    </DefinitionList>
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        </section>
+        <div className="my-6">
+          <Button
+            className="px-12 print:hidden"
+            size="lg"
+            variant="primary"
+            onClick={(event) => {
+              event.preventDefault();
+              window.print();
+            }}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Print bottom - Application successfully submitted click"
+          >
+            {t(($) => $.confirm.printBtn)}
+          </Button>
         </div>
-      </section>
-      <div className="my-6">
-        <Button
-          className="px-12 print:hidden"
-          size="lg"
-          variant="primary"
-          onClick={(event) => {
-            event.preventDefault();
-            window.print();
-          }}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Print bottom - Application successfully submitted click"
-        >
-          {t(($) => $.confirm.printBtn)}
-        </Button>
+        <Dialog>
+          <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Exit - Application successfully submitted click" asChild>
+            <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
+          </DialogTrigger>
+          <DialogContent aria-describedby={undefined} className="sm:max-w-md">
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
+            </DialogHeader>
+            <p>{t(($) => $.confirm.modal.info)}</p>
+            <p>{t(($) => $.confirm.modal.areYouSure)}</p>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back exit modal - Application successfully submitted click">
+                  {t(($) => $.confirm.modal.backBtn)}
+                </Button>
+              </DialogClose>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <Button
+                  id="confirm-modal-close"
+                  variant="primary"
+                  size="sm"
+                  onClick={() => removeApplicationFlowStorageValue()}
+                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Confirmation exit modal - Application successfully submitted click"
+                >
+                  {t(($) => $.confirm.modal.closeBtn)}
+                </Button>
+              </fetcher.Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
       </div>
-      <Dialog>
-        <DialogTrigger className="print:hidden" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Exit - Application successfully submitted click" asChild>
-          <Button variant="secondary">{t(($) => $.confirm.closeApplication)}</Button>
-        </DialogTrigger>
-        <DialogContent aria-describedby={undefined} className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.confirm.modal.header)}</DialogTitle>
-          </DialogHeader>
-          <p>{t(($) => $.confirm.modal.info)}</p>
-          <p>{t(($) => $.confirm.modal.areYouSure)}</p>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="confirm-modal-back" variant="secondary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back exit modal - Application successfully submitted click">
-                {t(($) => $.confirm.modal.backBtn)}
-              </Button>
-            </DialogClose>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <Button
-                id="confirm-modal-close"
-                variant="primary"
-                size="sm"
-                onClick={() => removeApplicationFlowStorageValue()}
-                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Confirmation exit modal - Application successfully submitted click"
-              >
-                {t(($) => $.confirm.modal.closeBtn)}
-              </Button>
-            </fetcher.Form>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-family/contact-information.tsx
+++ b/frontend/app/routes/public/application/simplified-family/contact-information.tsx
@@ -15,6 +15,7 @@ import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/hel
 import { isAddressSectionCompleted, isCommunicationPreferencesSectionCompleted, isPhoneNumberSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -37,9 +38,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.contactInformation,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:contactInformation.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -50,7 +50,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle, { ns: 'applicationSimplifiedFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.contactInformation.pageTitle) }),
   };
   const locale = getLocale(request);
 
@@ -174,65 +174,68 @@ export default function RenewFamilyContactInformation({ loaderData, params }: Ro
   const fetcher = useFetcher<typeof action>();
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="contactInformation" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.confirmInformation)}</p>
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
+    <>
+      <AppPageTitle>{t(($) => $.contactInformation.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="contactInformation" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.confirmInformation, { ns: 'application' })}</p>
+            <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.phoneNumber)}</h2>
+              </CardTitle>
+              <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <PhoneNumberCardContent />
+            <PhoneNumberCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.mailingAndHomeAddress)}</h2>
+              </CardTitle>
+              <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <MailingAndHomeAddressCardContent />
+            <MailingAndHomeAddressCardFooter />
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.contactInformation.communicationPreferences)}</h2>
+              </CardTitle>
+              <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <CommunicationPreferencesCardContent />
+            <CommunicationPreferencesCardFooter />
+          </Card>
+
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="public/application/$id/simplified-family/dental-insurance"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Continue click"
+            >
+              {t(($) => $.contactInformation.nextBtn)}
+            </NavigationButtonLink>
+            <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click">
+              {t(($) => $.contactInformation.prevBtn)}
+            </NavigationButtonLink>
+          </div>
         </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.phoneNumber, { ns: 'applicationSimplifiedFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.phoneNumber.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <PhoneNumberCardContent />
-          <PhoneNumberCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.mailingAndHomeAddress, { ns: 'applicationSimplifiedFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.address.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <MailingAndHomeAddressCardContent />
-          <MailingAndHomeAddressCardFooter />
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.contactInformation.communicationPreferences, { ns: 'applicationSimplifiedFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.communicationPreferences.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <CommunicationPreferencesCardContent />
-          <CommunicationPreferencesCardFooter />
-        </Card>
-
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="public/application/$id/simplified-family/dental-insurance"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Continue click"
-          >
-            {t(($) => $.contactInformation.nextBtn, { ns: 'applicationSimplifiedFamily' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink variant="secondary" direction="previous" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click">
-            {t(($) => $.contactInformation.prevBtn, { ns: 'applicationSimplifiedFamily' })}
-          </NavigationButtonLink>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -260,11 +263,11 @@ function PhoneNumberCardContent(): JSX.Element {
   if (state.phoneNumber) {
     return (
       <CardContent>
-        {!state.phoneNumber.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedFamily' })}</p>}
+        {!state.phoneNumber.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.phoneNumber.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber, { ns: 'applicationSimplifiedFamily' })}>{state.phoneNumber.primary}</DefinitionListItem>
-            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber, { ns: 'applicationSimplifiedFamily' })}>{state.phoneNumber.alternate}</DefinitionListItem>}
+            <DefinitionListItem term={t(($) => $.contactInformation.phoneNumber)}>{state.phoneNumber.primary}</DefinitionListItem>
+            {state.phoneNumber.alternate && <DefinitionListItem term={t(($) => $.contactInformation.altPhoneNumber)}>{state.phoneNumber.alternate}</DefinitionListItem>}
           </DefinitionList>
         )}
       </CardContent>
@@ -274,14 +277,14 @@ function PhoneNumberCardContent(): JSX.Element {
   if (clientApplication.hasPhoneNumber) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updatePhoneNumberHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+        <p>{t(($) => $.contactInformation.updatePhoneNumberHelp)}</p>
       </CardContent>
     );
   }
 
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.phoneNumberHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+      <p>{t(($) => $.contactInformation.phoneNumberHelp)}</p>
     </CardContent>
   );
 }
@@ -321,7 +324,7 @@ function PhoneNumberCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Edit phone click"
         >
-          {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber, { ns: 'applicationSimplifiedFamily' }) : t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationSimplifiedFamily' })}
+          {sections.phoneNumber.completed ? t(($) => $.contactInformation.editPhoneNumber) : t(($) => $.contactInformation.addPhoneNumber)}
         </ButtonLink>
       </CardFooter>
     );
@@ -341,7 +344,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Update phone click"
           >
-            {t(($) => $.contactInformation.updatePhoneNumber, { ns: 'applicationSimplifiedFamily' })}
+            {t(($) => $.contactInformation.updatePhoneNumber)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -355,7 +358,7 @@ function PhoneNumberCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Complete phone click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged, { ns: 'applicationSimplifiedFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.phoneNumberUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -374,7 +377,7 @@ function PhoneNumberCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Add phone click"
       >
-        {t(($) => $.contactInformation.addPhoneNumber, { ns: 'applicationSimplifiedFamily' })}
+        {t(($) => $.contactInformation.addPhoneNumber)}
       </ButtonLink>
     </CardFooter>
   );
@@ -407,10 +410,10 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (state.mailingAddress && state.homeAddress) {
     return (
       <CardContent>
-        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedFamily' })}</p>}
+        {!state.mailingAddress.hasChanged && !state.homeAddress.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.mailingAddress.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress, { ns: 'applicationSimplifiedFamily' })}>
+            <DefinitionListItem term={t(($) => $.contactInformation.mailingAddress)}>
               <Address
                 address={{
                   address: state.mailingAddress.address ?? '',
@@ -423,7 +426,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
             </DefinitionListItem>
 
             {state.homeAddress.hasChanged && (
-              <DefinitionListItem term={t(($) => $.contactInformation.homeAddress, { ns: 'applicationSimplifiedFamily' })}>
+              <DefinitionListItem term={t(($) => $.contactInformation.homeAddress)}>
                 <Address
                   address={{
                     address: state.homeAddress.address ?? '',
@@ -445,7 +448,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   if (clientApplication.hasMailingAddress && clientApplication.hasHomeAddress) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updateAddressHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+        <p>{t(($) => $.contactInformation.updateAddressHelp)}</p>
       </CardContent>
     );
   }
@@ -453,7 +456,7 @@ function MailingAndHomeAddressCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.addressHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+      <p>{t(($) => $.contactInformation.addressHelp)}</p>
     </CardContent>
   );
 }
@@ -494,7 +497,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Edit address click"
         >
-          {sections.address.completed ? t(($) => $.contactInformation.editAddress, { ns: 'applicationSimplifiedFamily' }) : t(($) => $.contactInformation.addAddress, { ns: 'applicationSimplifiedFamily' })}
+          {sections.address.completed ? t(($) => $.contactInformation.editAddress) : t(($) => $.contactInformation.addAddress)}
         </ButtonLink>
       </CardFooter>
     );
@@ -514,7 +517,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Update address click"
           >
-            {t(($) => $.contactInformation.updateAddress, { ns: 'applicationSimplifiedFamily' })}
+            {t(($) => $.contactInformation.updateAddress)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -528,7 +531,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Complete address click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged, { ns: 'applicationSimplifiedFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.addressUnchanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -547,7 +550,7 @@ function MailingAndHomeAddressCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Add address click"
       >
-        {t(($) => $.contactInformation.addAddress, { ns: 'applicationSimplifiedFamily' })}
+        {t(($) => $.contactInformation.addAddress)}
       </ButtonLink>
     </CardFooter>
   );
@@ -579,13 +582,13 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (state.communicationPreferences) {
     return (
       <CardContent>
-        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.contactInformation.noChange, { ns: 'applicationSimplifiedFamily' })}</p>}
+        {!state.communicationPreferences.hasChanged && <p>{t(($) => $.contactInformation.noChange)}</p>}
         {state.communicationPreferences.hasChanged && (
           <DefinitionList layout="single-column">
-            <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage, { ns: 'applicationSimplifiedFamily' })}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
-            <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod, { ns: 'applicationSimplifiedFamily' })}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
-            <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod, { ns: 'applicationSimplifiedFamily' })}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
-            {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email, { ns: 'applicationSimplifiedFamily' })}>{state.email}</DefinitionListItem>}
+            <DefinitionListItem term={t(($) => $.contactInformation.preferredLanguage)}>{state.communicationPreferences.preferredLanguage}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.contactInformation.preferredMethod)}>{state.communicationPreferences.preferredMethod}</DefinitionListItem>
+            <DefinitionListItem term={t(($) => $.contactInformation.preferredNotificationMethod)}>{state.communicationPreferences.preferredNotificationMethod}</DefinitionListItem>
+            {state.email && <DefinitionListItem term={t(($) => $.contactInformation.email)}>{state.email}</DefinitionListItem>}
           </DefinitionList>
         )}
       </CardContent>
@@ -596,7 +599,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   if (clientApplication.hasCommunicationPreferences) {
     return (
       <CardContent>
-        <p>{t(($) => $.contactInformation.updateCommunicationPreferencesHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+        <p>{t(($) => $.contactInformation.updateCommunicationPreferencesHelp)}</p>
       </CardContent>
     );
   }
@@ -604,7 +607,7 @@ function CommunicationPreferencesCardContent(): JSX.Element {
   // Case 3: No data at all
   return (
     <CardContent>
-      <p>{t(($) => $.contactInformation.communicationPreferencesHelp, { ns: 'applicationSimplifiedFamily' })}</p>
+      <p>{t(($) => $.contactInformation.communicationPreferencesHelp)}</p>
     </CardContent>
   );
 }
@@ -646,7 +649,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Edit comms click"
         >
-          {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences, { ns: 'applicationSimplifiedFamily' }) : t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationSimplifiedFamily' })}
+          {sections.communicationPreferences.completed ? t(($) => $.contactInformation.editCommunicationPreferences) : t(($) => $.contactInformation.addCommunicationPreferences)}
         </ButtonLink>
       </CardFooter>
     );
@@ -666,7 +669,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Update comms click"
           >
-            {t(($) => $.contactInformation.updateCommunicationPreferences, { ns: 'applicationSimplifiedFamily' })}
+            {t(($) => $.contactInformation.updateCommunicationPreferences)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -680,7 +683,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Complete comms click"
           >
-            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged, { ns: 'applicationSimplifiedFamily' })}</span>
+            <span className="text-left">{t(($) => $.contactInformation.communicationPreferencesUnchanged)}</span>
           </LoadingButton>
         </div>
       </CardFooter>
@@ -699,7 +702,7 @@ function CommunicationPreferencesCardFooter(): JSX.Element {
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Add comms click"
       >
-        {t(($) => $.contactInformation.addCommunicationPreferences, { ns: 'applicationSimplifiedFamily' })}
+        {t(($) => $.contactInformation.addCommunicationPreferences)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
@@ -15,6 +15,7 @@ import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDent
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { isDentalBenefitsSectionCompleted, isDentalInsuranceSectionCompleted } from '~/.server/routes/helpers/public-application-simplified-section-checks';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { Card, CardAction, CardContent, CardFooter, CardHeader, CardTitle } from '~/components/card';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -34,9 +35,8 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.dentalInsurance,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:dentalInsurance.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -48,7 +48,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle, { ns: 'applicationSimplifiedFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalInsurance.pageTitle) }),
   };
 
   const federalGovernmentInsurancePlanService = appContainer.get(TYPES.FederalGovernmentInsurancePlanService);
@@ -143,59 +143,62 @@ export default function RenewFamilyDentalInsurance({ loaderData, params }: Route
   const { completedSectionsLabel, allSectionsCompleted } = useSectionsStatus(sections);
 
   return (
-    <fetcher.Form method="post" noValidate>
-      <CsrfTokenInput />
-      <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <div className="space-y-4">
-          <p>{t(($) => $.completeAllSections)}</p>
-          <p>{completedSectionsLabel}</p>
-        </div>
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationSimplifiedFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalInsuranceCardContent />
-          <DentalInsuranceCardFooter />
-        </Card>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.pageHeading)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate>
+        <CsrfTokenInput />
+        <ProgressStepper activeStep="dentalInsurance" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <div className="space-y-4">
+            <p>{t(($) => $.completeAllSections, { ns: 'application' })}</p>
+            <p>{completedSectionsLabel}</p>
+          </div>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.accessToDentalInsurance)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalInsuranceCardContent />
+            <DentalInsuranceCardFooter />
+          </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle asChild>
-              <h2>{t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationSimplifiedFamily' })}</h2>
-            </CardTitle>
-            <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
-          </CardHeader>
-          <DentalBenefitsCardContent />
-          <DentalBenefitsCardFooter />
-        </Card>
+          <Card>
+            <CardHeader>
+              <CardTitle asChild>
+                <h2>{t(($) => $.dentalInsurance.otherBenefits)}</h2>
+              </CardTitle>
+              <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
+            </CardHeader>
+            <DentalBenefitsCardContent />
+            <DentalBenefitsCardFooter />
+          </Card>
 
-        <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-          <NavigationButtonLink
-            disabled={!allSectionsCompleted}
-            variant="primary"
-            direction="next"
-            routeId="public/application/$id/simplified-family/childrens-application"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Continue click"
-          >
-            {t(($) => $.dentalInsurance.childrensApplication, { ns: 'applicationSimplifiedFamily' })}
-          </NavigationButtonLink>
-          <NavigationButtonLink
-            variant="secondary"
-            direction="previous"
-            routeId="public/application/$id/simplified-family/contact-information"
-            params={params}
-            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click"
-          >
-            {t(($) => $.dentalInsurance.contactInformation, { ns: 'applicationSimplifiedFamily' })}
-          </NavigationButtonLink>
+          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+            <NavigationButtonLink
+              disabled={!allSectionsCompleted}
+              variant="primary"
+              direction="next"
+              routeId="public/application/$id/simplified-family/childrens-application"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Continue click"
+            >
+              {t(($) => $.dentalInsurance.childrensApplication)}
+            </NavigationButtonLink>
+            <NavigationButtonLink
+              variant="secondary"
+              direction="previous"
+              routeId="public/application/$id/simplified-family/contact-information"
+              params={params}
+              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click"
+            >
+              {t(($) => $.dentalInsurance.contactInformation)}
+            </NavigationButtonLink>
+          </div>
         </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 
@@ -219,9 +222,7 @@ function DentalInsuranceCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage, { ns: 'applicationSimplifiedFamily' })}>
-            {state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes, { ns: 'applicationSimplifiedFamily' }) : t(($) => $.dentalInsurance.dentalInsuranceNo, { ns: 'applicationSimplifiedFamily' })}
-          </DefinitionListItem>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToDentalInsuranceOrCoverage)}>{state.dentalInsurance ? t(($) => $.dentalInsurance.dentalInsuranceYes) : t(($) => $.dentalInsurance.dentalInsuranceNo)}</DefinitionListItem>
         </DefinitionList>
       </CardContent>
     );
@@ -229,7 +230,7 @@ function DentalInsuranceCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus, { ns: 'applicationSimplifiedFamily' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalInsuranceIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -262,7 +263,7 @@ function DentalInsuranceCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Edit button dental insurance click"
         >
-          {t(($) => $.dentalInsurance.editAccessToDentalInsurance, { ns: 'applicationSimplifiedFamily' })}
+          {t(($) => $.dentalInsurance.editAccessToDentalInsurance)}
         </ButtonLink>
       </CardFooter>
     );
@@ -279,9 +280,9 @@ function DentalInsuranceCardFooter(): JSX.Element {
         startIcon={faCirclePlus}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Add button dental insurance click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedFamily' })} - ${t(($) => $.dentalInsurance.accessToDentalInsurance, { ns: 'applicationSimplifiedFamily' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.accessToDentalInsurance)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedFamily' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );
@@ -308,17 +309,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationSimplifiedFamily' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {state.dentalBenefits.federalBenefit.access || state.dentalBenefits.provTerrBenefit.access ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationSimplifiedFamily' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {state.dentalBenefits.federalBenefit.access && <li>{state.dentalBenefits.federalBenefit.benefit}</li>}
                   {state.dentalBenefits.provTerrBenefit.access && <li>{state.dentalBenefits.provTerrBenefit.benefit}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationSimplifiedFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -330,17 +331,17 @@ function DentalBenefitsCardContent(): JSX.Element {
     return (
       <CardContent>
         <DefinitionList layout="single-column">
-          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits, { ns: 'applicationSimplifiedFamily' })}>
+          <DefinitionListItem term={t(($) => $.dentalInsurance.accessToGovernmentBenefits)}>
             {clientApplication.dentalBenefits.hasFederalBenefits || clientApplication.dentalBenefits.hasProvincialTerritorialBenefits ? (
               <div className="space-y-3">
-                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes, { ns: 'applicationSimplifiedFamily' })}</p>
+                <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsYes)}</p>
                 <ul className="list-disc space-y-1 pl-7">
                   {clientApplication.dentalBenefits.hasFederalBenefits && <li>{clientApplication.dentalBenefits.federalSocialProgram}</li>}
                   {clientApplication.dentalBenefits.hasProvincialTerritorialBenefits && <li>{clientApplication.dentalBenefits.provincialTerritorialSocialProgram}</li>}
                 </ul>
               </div>
             ) : (
-              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo, { ns: 'applicationSimplifiedFamily' })}</p>
+              <p>{t(($) => $.dentalInsurance.accessToGovernmentBenefitsNo)}</p>
             )}
           </DefinitionListItem>
         </DefinitionList>
@@ -350,7 +351,7 @@ function DentalBenefitsCardContent(): JSX.Element {
 
   return (
     <CardContent>
-      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus, { ns: 'applicationSimplifiedFamily' })}</p>
+      <p>{t(($) => $.dentalInsurance.dentalBenefitsIndicateStatus)}</p>
     </CardContent>
   );
 }
@@ -385,7 +386,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
           size="lg"
           data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Edit button government benefits click"
         >
-          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits, { ns: 'applicationSimplifiedFamily' })}
+          {t(($) => $.dentalInsurance.editAccessToGovernmentBenefits)}
         </ButtonLink>
       </CardFooter>
     );
@@ -405,7 +406,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Update button government benefits click"
           >
-            {t(($) => $.dentalInsurance.updateMyAccess, { ns: 'applicationSimplifiedFamily' })}
+            {t(($) => $.dentalInsurance.updateMyAccess)}
           </ButtonLink>
         </div>
         <div className="w-full px-6">
@@ -419,7 +420,7 @@ function DentalBenefitsCardFooter(): JSX.Element {
             size="lg"
             data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Complete benefits click"
           >
-            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged, { ns: 'applicationSimplifiedFamily' })}</span>
+            <span className="text-left">{t(($) => $.dentalInsurance.accessNotChanged)}</span>
           </Button>
         </div>
       </CardFooter>
@@ -437,9 +438,9 @@ function DentalBenefitsCardFooter(): JSX.Element {
         startIcon={faPenToSquare}
         size="lg"
         data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Public-Simplified_Family:Add button dental benefits click"
-        aria-label={`${t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedFamily' })} - ${t(($) => $.dentalInsurance.otherBenefits, { ns: 'applicationSimplifiedFamily' })}`}
+        aria-label={`${t(($) => $.dentalInsurance.addAnswer)} - ${t(($) => $.dentalInsurance.otherBenefits)}`}
       >
-        {t(($) => $.dentalInsurance.addAnswer, { ns: 'applicationSimplifiedFamily' })}
+        {t(($) => $.dentalInsurance.addAnswer)}
       </ButtonLink>
     </CardFooter>
   );

--- a/frontend/app/routes/public/application/simplified-family/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/exit-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.exitApplication,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:exitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -61,28 +61,31 @@ export default function SimplifiedFamilyExitApplication({ loaderData, params }: 
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.exitApplication.areYouSure)}</p>
-        <p>{t(($) => $.exitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.exitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.exitApplication.areYouSure)}</p>
+          <p>{t(($) => $.exitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/simplified-family/submit"
+            params={params}
+            disabled={isSubmitting}
+            startIcon={faChevronLeft}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back - Exiting the application click"
+          >
+            {t(($) => $.exitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Exit - Exiting the application click">
+            {t(($) => $.exitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/simplified-family/submit"
-          params={params}
-          disabled={isSubmitting}
-          startIcon={faChevronLeft}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back - Exiting the application click"
-        >
-          {t(($) => $.exitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Exit - Exiting the application click">
-          {t(($) => $.exitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/simplified-family/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-family/submit.tsx
@@ -11,6 +11,7 @@ import { savePublicApplicationState, validateApplicationFlow } from '~/.server/r
 import { loadPublicApplicationSimplifiedFamilyStateForReview } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { DebugPayload } from '~/components/debug-payload';
@@ -34,9 +35,8 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSimplifiedFamily', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.simplifiedFamily.submit,
-  pageTitleI18nKey: 'applicationSimplifiedFamily:submit.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -47,7 +47,7 @@ export async function loader({ context: { appContainer, session }, request, para
 
   const t = await getFixedT(request, handle.i18nNamespaces);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle, { ns: 'applicationSimplifiedFamily' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.submit.pageTitle) }),
   };
 
   const children = [];
@@ -85,10 +85,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired, { ns: 'applicationSimplifiedFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeInfoRequired),
     }),
     acknowledgeCriteria: z.literal(true, {
-      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired, { ns: 'applicationSimplifiedFamily' }),
+      error: t(($) => $.submit.errorMessage.acknowledgeCriteriaRequired),
     }),
   });
 
@@ -118,78 +118,81 @@ export default function SimplifiedFamilySubmit({ loaderData, params }: Route.Com
 
   const errors = fetcher.data?.errors;
 
-  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref, { ns: 'applicationSimplifiedFamily' })} className="external-link" newTabIndicator target="_blank" />;
+  const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <ProgressStepper activeStep="submit" className="mb-8" />
-      <div className="max-w-prose space-y-8">
-        <ErrorSummary />
-        <div className="space-y-8">
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview, { ns: 'applicationSimplifiedFamily' })}</h2>
-            <div className="space-y-4">
-              <p>{t(($) => $.submit.youAreSubmitting, { ns: 'applicationSimplifiedFamily' })}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{state.applicantName}</li>
-                {state.children.map((child, index) => (
-                  <li key={index}>{child}</li>
-                ))}
-              </ul>
-            </div>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication, { ns: 'applicationSimplifiedFamily' })}</h2>
-            <p>{t(($) => $.submit.pleaseReview, { ns: 'applicationSimplifiedFamily' })}</p>
-            <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Action click">
-              {t(($) => $.submit.reviewApplication, { ns: 'applicationSimplifiedFamily' })}
-            </ButtonLink>
-          </section>
-          <section className="space-y-4">
-            <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication, { ns: 'applicationSimplifiedFamily' })}</h2>
-            <p>{t(($) => $.submit.bySubmitting, { ns: 'applicationSimplifiedFamily' })}</p>
-            <p>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
-            </p>
-            <fetcher.Form method="post" noValidate>
-              <CsrfTokenInput />
-              <div className="space-y-2">
-                <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
-                  {t(($) => $.submit.infoIsCorrect, { ns: 'applicationSimplifiedFamily' })}
-                </InputCheckbox>
-                <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
-                  {t(($) => $.submit.iUnderstand, { ns: 'applicationSimplifiedFamily' })}
-                </InputCheckbox>
+    <>
+      <AppPageTitle>{t(($) => $.submit.pageHeading)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <ProgressStepper activeStep="submit" className="mb-8" />
+        <div className="max-w-prose space-y-8">
+          <ErrorSummary />
+          <div className="space-y-8">
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.overview)}</h2>
+              <div className="space-y-4">
+                <p>{t(($) => $.submit.youAreSubmitting)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{state.applicantName}</li>
+                  {state.children.map((child, index) => (
+                    <li key={index}>{child}</li>
+                  ))}
+                </ul>
               </div>
-              <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
-                <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Submit click">
-                  {t(($) => $.submit.submit, { ns: 'applicationSimplifiedFamily' })}
-                </LoadingButton>
-                <NavigationButtonLink
-                  disabled={isSubmitting}
-                  variant="secondary"
-                  direction="previous"
-                  routeId="public/application/$id/simplified-family/childrens-application"
-                  params={params}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click"
-                >
-                  {t(($) => $.submit.childrensApplication, { ns: 'applicationSimplifiedFamily' })}
-                </NavigationButtonLink>
-              </div>
-            </fetcher.Form>
-          </section>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.reviewYourApplication)}</h2>
+              <p>{t(($) => $.submit.pleaseReview)}</p>
+              <ButtonLink variant="primary" routeId="public/application/$id/your-application" params={params} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Action click">
+                {t(($) => $.submit.reviewApplication)}
+              </ButtonLink>
+            </section>
+            <section className="space-y-4">
+              <h2 className="font-lato text-3xl leading-none font-bold">{t(($) => $.submit.submitYourApplication)}</h2>
+              <p>{t(($) => $.submit.bySubmitting)}</p>
+              <p>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
+              </p>
+              <fetcher.Form method="post" noValidate>
+                <CsrfTokenInput />
+                <div className="space-y-2">
+                  <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
+                    {t(($) => $.submit.infoIsCorrect)}
+                  </InputCheckbox>
+                  <InputCheckbox id="acknowledge-criteria" name="acknowledgeCriteria" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeCriteria} required>
+                    {t(($) => $.submit.iUnderstand)}
+                  </InputCheckbox>
+                </div>
+                <div className="mt-8 grid gap-3 sm:grid-cols-[1fr_170px]">
+                  <LoadingButton loading={isSubmitting} variant="green" className="order-first h-full text-base sm:order-last sm:text-lg" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Submit click">
+                    {t(($) => $.submit.submit)}
+                  </LoadingButton>
+                  <NavigationButtonLink
+                    disabled={isSubmitting}
+                    variant="secondary"
+                    direction="previous"
+                    routeId="public/application/$id/simplified-family/childrens-application"
+                    params={params}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Simplified_Family:Back click"
+                  >
+                    {t(($) => $.submit.childrensApplication)}
+                  </NavigationButtonLink>
+                </div>
+              </fetcher.Form>
+            </section>
+          </div>
+          <div className="mt-8">
+            <InlineLink routeId="public/application/$id/simplified-family/exit-application" params={params}>
+              {t(($) => $.submit.exitApplication)}
+            </InlineLink>
+          </div>
         </div>
-        <div className="mt-8">
-          <InlineLink routeId="public/application/$id/simplified-family/exit-application" params={params}>
-            {t(($) => $.submit.exitApplication, { ns: 'applicationSimplifiedFamily' })}
-          </InlineLink>
-        </div>
-      </div>
-      {payload && (
-        <div className="mt-8">
-          <DebugPayload data={payload} enableCopy />
-        </div>
-      )}
-    </ErrorSummaryProvider>
+        {payload && (
+          <div className="mt-8">
+            <DebugPayload data={payload} enableCopy />
+          </div>
+        )}
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/application-delegate.tsx
+++ b/frontend/app/routes/public/application/spokes/application-delegate.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/application-delegate';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -21,7 +22,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.applicationDelegate,
-  pageTitleI18nKey: 'applicationSpokes:applicationDelegate.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -66,31 +66,34 @@ export default function ApplicationDelegate({ loaderData, params }: Route.Compon
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.contactRepresentative} components={{ contactServiceCanada, noWrap }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.prepareToApply} components={{ preparingToApply }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.applicationDelegate.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.contactRepresentative} components={{ contactServiceCanada, noWrap }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationDelegate.prepareToApply} components={{ preparingToApply }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            variant="secondary"
+            type="button"
+            routeId="public/application/$id/type-application"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Applying on behalf of someone click"
+          >
+            {t(($) => $.applicationDelegate.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Applying on behalf of someone click">
+            {t(($) => $.applicationDelegate.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          variant="secondary"
-          type="button"
-          routeId="public/application/$id/type-application"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Applying on behalf of someone click"
-        >
-          {t(($) => $.applicationDelegate.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Applying on behalf of someone click">
-          {t(($) => $.applicationDelegate.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/application/spokes/cannot-apply-child.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getAgeCategoryFromDateString } from '~/.server/routes/helpers/base-application-route-helpers';
 import { clearPublicApplicationState, getSingleChildState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.cannotApplyChild,
-  pageTitleI18nKey: 'applicationSpokes:children.cannotApplyChild.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -69,33 +69,36 @@ export default function ApplyForYourself({ loaderData, params }: Route.Component
   const noWrap = <span className="whitespace-nowrap" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-6 space-y-4">
-        <p>
-          {isChildrenOrYouth //
-            ? t(($) => $.children.cannotApplyChild.ineligibleToApply.cutoffApplication)
-            : t(($) => $.children.cannotApplyChild.ineligibleToApply.adultApplication)}
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.cannotApplyChild.eligibilityInfo} components={{ noWrap }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.children.cannotApplyChild.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-6 space-y-4">
+          <p>
+            {isChildrenOrYouth //
+              ? t(($) => $.children.cannotApplyChild.ineligibleToApply.cutoffApplication)
+              : t(($) => $.children.cannotApplyChild.ineligibleToApply.adultApplication)}
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.cannotApplyChild.eligibilityInfo} components={{ noWrap }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/children/$childId/information"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child apply for yourself click"
+          >
+            {t(($) => $.children.cannotApplyChild.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Child apply for yourself click">
+            {t(($) => $.children.cannotApplyChild.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/children/$childId/information"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child apply for yourself click"
-        >
-          {t(($) => $.children.cannotApplyChild.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Child apply for yourself click">
-          {t(($) => $.children.cannotApplyChild.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/child-dental-insurance.tsx
+++ b/frontend/app/routes/public/application/spokes/child-dental-insurance.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -38,7 +39,6 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.childDentalInsurance,
-  pageTitleI18nKey: 'applicationSpokes:children.dentalInsurance.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -54,7 +54,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'applicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -62,7 +61,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalInsurance.title, {
         childName: childName,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -70,14 +68,13 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalInsurance.title, {
         childName: childNumber,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
     }),
   };
 
-  return { meta, defaultState: childState.dentalInsurance, childName, i18nOptions: { childName }, applicationFlow: `${state.inputModel}-${state.typeOfApplication}` };
+  return { meta, defaultState: childState.dentalInsurance, childName, applicationFlow: `${state.inputModel}-${state.typeOfApplication}` };
 }
 
 export async function action({ context: { appContainer, session }, params, request }: Route.ActionArgs) {
@@ -166,81 +163,84 @@ export default function AccessToDentalInsuranceQuestion({ loaderData, params }: 
   );
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="my-6">
-            <InputRadios
-              id="has-dental-insurance"
-              name="hasDentalInsurance"
-              legend={t(($) => $.children.dentalInsurance.legend, {
-                childName: childName,
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionYes} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.yes,
-                  defaultChecked: defaultState?.hasDentalInsurance === true,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionNo} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.no,
-                  defaultChecked: defaultState?.hasDentalInsurance === false,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-              ]}
-              helpMessagePrimary={helpMessage}
-              helpMessagePrimaryClassName="text-black"
-              errorMessage={errors?.hasDentalInsurance}
-              required
-            />
-          </div>
-          {hasDentalInsurance && (
-            <div className="space-y-4">
-              <ContextualAlert type="info" id="child-dental-insurance-confirmation">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.children.dentalInsurance.alert.title)}</h2>
-                <p>
-                  {t(($) => $.children.dentalInsurance.alert.body, {
-                    childName: childName,
-                  })}
-                </p>
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation"
-                name="dentalInsuranceEligibilityConfirmation"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmation}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmation}
-                required
-                aria-describedby="child-dental-insurance-confirmation"
-              >
-                {t(($) => $.children.dentalInsurance.dentalInsuranceEligibilityConfirmation, {
+    <>
+      <AppPageTitle>{t(($) => $.children.dentalInsurance.title, { childName })}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="my-6">
+              <InputRadios
+                id="has-dental-insurance"
+                name="hasDentalInsurance"
+                legend={t(($) => $.children.dentalInsurance.legend, {
                   childName: childName,
                 })}
-              </InputCheckbox>
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionYes} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.yes,
+                    defaultChecked: defaultState?.hasDentalInsurance === true,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalInsurance.optionNo} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.no,
+                    defaultChecked: defaultState?.hasDentalInsurance === false,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                ]}
+                helpMessagePrimary={helpMessage}
+                helpMessagePrimaryClassName="text-black"
+                errorMessage={errors?.hasDentalInsurance}
+                required
+              />
             </div>
-          )}
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Child access to other dental insurance click">
-              {t(($) => $.children.dentalInsurance.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`public/application/$id/${applicationFlow}/childrens-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child access to other dental insurance click"
-            >
-              {t(($) => $.children.dentalInsurance.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            {hasDentalInsurance && (
+              <div className="space-y-4">
+                <ContextualAlert type="info" id="child-dental-insurance-confirmation">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.children.dentalInsurance.alert.title)}</h2>
+                  <p>
+                    {t(($) => $.children.dentalInsurance.alert.body, {
+                      childName: childName,
+                    })}
+                  </p>
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation"
+                  name="dentalInsuranceEligibilityConfirmation"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmation}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmation}
+                  required
+                  aria-describedby="child-dental-insurance-confirmation"
+                >
+                  {t(($) => $.children.dentalInsurance.dentalInsuranceEligibilityConfirmation, {
+                    childName: childName,
+                  })}
+                </InputCheckbox>
+              </div>
+            )}
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Child access to other dental insurance click">
+                {t(($) => $.children.dentalInsurance.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/${applicationFlow}/childrens-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child access to other dental insurance click"
+              >
+                {t(($) => $.children.dentalInsurance.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -13,6 +13,7 @@ import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDent
 import { getPublicApplicationState, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -40,7 +41,6 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.childFederalProvincialTerritorialBenefits,
-  pageTitleI18nKey: 'applicationSpokes:children.dentalBenefits.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
@@ -63,7 +63,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'applicationSpokes',
   });
   const childName = childState.information?.firstName ?? childNumber;
 
@@ -71,7 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalBenefits.title, {
         childName: childName,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -79,7 +77,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.dentalBenefits.title, {
         childName: childNumber,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -94,7 +91,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     regions,
     childName,
     applicationFlow: `${state.inputModel}-${state.typeOfApplication}` as const,
-    i18nOptions: { childName },
   };
 }
 
@@ -251,146 +247,146 @@ export default function SpokeChildAccessToDentalDentalBenefits({ loaderData, par
   }
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4">{t(($) => $.children.dentalBenefits.accessToDental)}</p>
-        <p className="mb-4">{t(($) => $.children.dentalBenefits.eligibilityCriteria)}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">
-              {t(($) => $.children.dentalBenefits.federalBenefits.title, {
-                childName: childName,
-                ns: 'applicationSpokes',
-              })}
-            </legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.children.dentalBenefits.federalBenefits.legend, {
-                childName: childName,
-                ns: 'applicationSpokes',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.children.dentalBenefits.federalBenefits.socialPrograms.legend)}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: defaultState?.federalSocialProgram === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.legend, {
-                childName: childName,
-                ns: 'applicationSpokes',
-              })}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.children.dentalBenefits.selectOne),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.children.dentalBenefits.title, { childName })}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4">{t(($) => $.children.dentalBenefits.accessToDental)}</p>
+          <p className="mb-4">{t(($) => $.children.dentalBenefits.eligibilityCriteria)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">
+                {t(($) => $.children.dentalBenefits.federalBenefits.title, {
+                  childName: childName,
+                })}
+              </legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.children.dentalBenefits.federalBenefits.legend, {
+                  childName: childName,
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.children.dentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: defaultState?.federalSocialProgram === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.legend, {
+                  childName: childName,
+                })}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.children.dentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...regions.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.children.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.children.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
 
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Child access to other federal, provincial or territorial dental benefits click">
-              {t(($) => $.children.dentalBenefits.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`public/application/$id/${applicationFlow}/childrens-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child access to other federal, provincial or territorial dental benefits click"
-            >
-              {t(($) => $.children.dentalBenefits.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Child access to other federal, provincial or territorial dental benefits click">
+                {t(($) => $.children.dentalBenefits.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/${applicationFlow}/childrens-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Child access to other federal, provincial or territorial dental benefits click"
+              >
+                {t(($) => $.children.dentalBenefits.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/child-information.tsx
+++ b/frontend/app/routes/public/application/spokes/child-information.tsx
@@ -15,6 +15,7 @@ import { getPublicApplicationState, getSingleChildState, savePublicApplicationSt
 import type { PublicApplicationChildInformationState, PublicApplicationChildSinState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -26,7 +27,6 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import type { InputRadiosProps } from '~/components/input-radios';
 import { InputRadios } from '~/components/input-radios';
 import { InputSanitizeField } from '~/components/input-sanitize-field';
-import { AppPageTitle } from '~/components/layouts/public-layout';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
@@ -63,7 +63,6 @@ export async function loader({ context: { appContainer, session }, params, reque
 
   const childNumber = t(($) => $.children.childNumber, {
     childNumber: childState.childNumber,
-    ns: 'applicationSpokes',
   });
   const childName = childState.isNew ? childNumber : (childState.information?.firstName ?? childNumber);
 
@@ -71,7 +70,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     title: t(($) => $.meta.title.template, {
       title: t(($) => $.children.information.pageTitle, {
         childName: childName,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -79,7 +77,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     dcTermsTitle: t(($) => $.meta.title.template, {
       title: t(($) => $.children.information.pageTitle, {
         childName: childNumber,
-        ns: 'applicationSpokes',
       }),
 
       ns: 'gcweb',
@@ -375,12 +372,7 @@ export default function ApplyFlowChildInformation({ loaderData, params }: Route.
 
   return (
     <ErrorSummaryProvider actionData={fetcher.data}>
-      <AppPageTitle>
-        {t(($) => $.children.information.pageTitle, {
-          childName: childName,
-          ns: 'applicationSpokes',
-        })}
-      </AppPageTitle>
+      <AppPageTitle>{t(($) => $.children.information.pageTitle, { childName: childName })}</AppPageTitle>
       <div className="max-w-prose">
         <ErrorAlert>
           <h2 className="mb-2 font-bold">{t(($) => $.children.information.errorMessage.alert.heading)}</h2>

--- a/frontend/app/routes/public/application/spokes/child-parent-guardian.tsx
+++ b/frontend/app/routes/public/application/spokes/child-parent-guardian.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/child-parent-guardian';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.childParentOrGuardian,
-  pageTitleI18nKey: 'applicationSpokes:children.parentOrGuardian.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -65,6 +65,7 @@ export default function ParentOrGuardian({ loaderData, params }: Route.Component
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.children.parentOrGuardian.pageTitle)}</AppPageTitle>
       <div className="mb-8 space-y-4">
         <p>{t(($) => $.children.parentOrGuardian.unableToApply)}</p>
       </div>

--- a/frontend/app/routes/public/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/public/application/spokes/communication-preferences.tsx
@@ -13,6 +13,7 @@ import { getPublicApplicationState, savePublicApplicationState, validateApplicat
 import type { ApplicationFlow, PublicApplicationCommunicationPreferencesState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -46,7 +47,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.communicationPreferences,
-  pageTitleI18nKey: 'applicationSpokes:communicationPreferences.pageTitle',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -247,50 +247,53 @@ export default function ApplicationSpokeCommunicationPreferences({ loaderData, p
   });
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.communicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
-            <InputRadios
-              id="preferred-method-sunlife"
-              legend={t(($) => $.communicationPreferences.preferredMethod)}
-              name="preferredMethod"
-              helpMessagePrimary={t(($) => $.communicationPreferences.preferredMethodHelpMessage)}
-              helpMessagePrimaryClassName="text-black"
-              options={sunLifeCommunicationMethodOptions}
-              errorMessage={errors?.preferredMethod}
-              required
-            />
-            <InputRadios
-              id="preferred-method-gc"
-              name="preferredNotificationMethod"
-              legend={t(($) => $.communicationPreferences.preferredNotificationMethod)}
-              options={gcCommunicationMethodOptions}
-              required
-              errorMessage={errors?.preferredNotificationMethod}
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Communication preferences click">
-              {preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || preferredNotification === COMMUNICATION_METHOD_GC_DIGITAL_ID ? t(($) => $.communicationPreferences.continue) : t(($) => $.communicationPreferences.save)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmittingOrSuccess}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Communication preferences click"
-            >
-              {t(($) => $.communicationPreferences.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+    <>
+      <AppPageTitle>{t(($) => $.communicationPreferences.pageTitle)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <InputRadios id="preferred-language" name="preferredLanguage" legend={t(($) => $.communicationPreferences.preferredLanguage)} options={preferredLanguageOptions} errorMessage={errors?.preferredLanguage} required />
+              <InputRadios
+                id="preferred-method-sunlife"
+                legend={t(($) => $.communicationPreferences.preferredMethod)}
+                name="preferredMethod"
+                helpMessagePrimary={t(($) => $.communicationPreferences.preferredMethodHelpMessage)}
+                helpMessagePrimaryClassName="text-black"
+                options={sunLifeCommunicationMethodOptions}
+                errorMessage={errors?.preferredMethod}
+                required
+              />
+              <InputRadios
+                id="preferred-method-gc"
+                name="preferredNotificationMethod"
+                legend={t(($) => $.communicationPreferences.preferredNotificationMethod)}
+                options={gcCommunicationMethodOptions}
+                required
+                errorMessage={errors?.preferredNotificationMethod}
+              />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmittingOrSuccess} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Communication preferences click">
+                {preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || preferredNotification === COMMUNICATION_METHOD_GC_DIGITAL_ID ? t(($) => $.communicationPreferences.continue) : t(($) => $.communicationPreferences.save)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmittingOrSuccess}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Communication preferences click"
+              >
+                {t(($) => $.communicationPreferences.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/dental-insurance-exit-application.tsx
+++ b/frontend/app/routes/public/application/spokes/dental-insurance-exit-application.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/dental-insurance-exit-application';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, getPublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -20,7 +21,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.dentalInsuranceExitApplication,
-  pageTitleI18nKey: 'applicationSpokes:dentalInsuranceExitApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -59,27 +59,30 @@ export default function ApplicationSpokeDentalInsuranceExitApplication({ loaderD
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.dentalInsuranceExitApplication.areYouSure)}</p>
-        <p>{t(($) => $.dentalInsuranceExitApplication.clickBack)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsuranceExitApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.dentalInsuranceExitApplication.areYouSure)}</p>
+          <p>{t(($) => $.dentalInsuranceExitApplication.clickBack)}</p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            id="back-button"
+            variant="secondary"
+            routeId="public/application/$id/dental-insurance"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Exiting the application click"
+          >
+            {t(($) => $.dentalInsuranceExitApplication.backBtn)}
+          </ButtonLink>
+          <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Exiting the application click">
+            {t(($) => $.dentalInsuranceExitApplication.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          id="back-button"
-          variant="secondary"
-          routeId="public/application/$id/dental-insurance"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Exiting the application click"
-        >
-          {t(($) => $.dentalInsuranceExitApplication.backBtn)}
-        </ButtonLink>
-        <LoadingButton variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Exiting the application click">
-          {t(($) => $.dentalInsuranceExitApplication.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/spokes/dental-insurance.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -39,7 +40,6 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.dentalInsurance,
-  pageTitleI18nKey: 'applicationSpokes:dentalInsurance.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -161,93 +161,96 @@ export default function ApplicationSpokeDentalInsurance({ loaderData, params }: 
   const t4aHref = <InlineLink to={t(($) => $.dentalInsurance.no.alertT4aHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <ErrorSummaryProvider actionData={fetcher.data}>
-      <div className="max-w-prose">
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="my-6">
-            <InputRadios
-              id="has-dental-insurance"
-              name="hasDentalInsurance"
-              legend={t(($) => $.dentalInsurance.legend)}
-              options={[
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionYes} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.yes,
-                  defaultChecked: defaultState?.hasDentalInsurance === true,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-                {
-                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionNo} />,
-                  value: HAS_DENTAL_INSURANCE_OPTION.no,
-                  defaultChecked: defaultState?.hasDentalInsurance === false,
-                  onChange: handleOnHasDentalInsuranceChanged,
-                },
-              ]}
-              helpMessagePrimary={helpMessage}
-              helpMessagePrimaryClassName="text-black"
-              errorMessage={errors?.hasDentalInsurance}
-              required
-            />
-          </div>
-          {hasDentalInsurance === true && (
-            <div className="mb-4 space-y-4">
-              <ContextualAlert type="info" id="dental-insurance-confirmation-yes">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.yes.alertTitle)}</h2>
-                <p>{t(($) => $.dentalInsurance.yes.alertBody)}</p>
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation-yes"
-                name="dentalInsuranceEligibilityConfirmationYes"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationYes}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmationYes}
+    <>
+      <AppPageTitle>{t(($) => $.dentalInsurance.title)}</AppPageTitle>
+      <ErrorSummaryProvider actionData={fetcher.data}>
+        <div className="max-w-prose">
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="my-6">
+              <InputRadios
+                id="has-dental-insurance"
+                name="hasDentalInsurance"
+                legend={t(($) => $.dentalInsurance.legend)}
+                options={[
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionYes} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.yes,
+                    defaultChecked: defaultState?.hasDentalInsurance === true,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                  {
+                    children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.optionNo} />,
+                    value: HAS_DENTAL_INSURANCE_OPTION.no,
+                    defaultChecked: defaultState?.hasDentalInsurance === false,
+                    onChange: handleOnHasDentalInsuranceChanged,
+                  },
+                ]}
+                helpMessagePrimary={helpMessage}
+                helpMessagePrimaryClassName="text-black"
+                errorMessage={errors?.hasDentalInsurance}
                 required
-                aria-describedby="dental-insurance-confirmation-yes"
-              >
-                {t(($) => $.dentalInsurance.yes.confirmation)}
-              </InputCheckbox>
+              />
             </div>
-          )}
-          {hasDentalInsurance === false && (
-            <div className="mb-4 space-y-4">
-              <ContextualAlert type="info" id="dental-insurance-confirmation-no">
-                <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.no.alertTitle)}</h2>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.no.alertBody} components={{ t4Href, t4aHref }} />
-              </ContextualAlert>
-              <InputCheckbox
-                id="dental-insurance-eligibility-confirmation-no"
-                name="dentalInsuranceEligibilityConfirmationNo"
-                value={CHECKBOX_VALUE.yes}
-                defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationNo}
-                errorMessage={errors?.dentalInsuranceEligibilityConfirmationNo}
-                required
-                aria-describedby="dental-insurance-confirmation-no"
-              >
-                {t(($) => $.dentalInsurance.no.confirmation)}
-              </InputCheckbox>
-            </div>
-          )}
+            {hasDentalInsurance === true && (
+              <div className="mb-4 space-y-4">
+                <ContextualAlert type="info" id="dental-insurance-confirmation-yes">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.yes.alertTitle)}</h2>
+                  <p>{t(($) => $.dentalInsurance.yes.alertBody)}</p>
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation-yes"
+                  name="dentalInsuranceEligibilityConfirmationYes"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationYes}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmationYes}
+                  required
+                  aria-describedby="dental-insurance-confirmation-yes"
+                >
+                  {t(($) => $.dentalInsurance.yes.confirmation)}
+                </InputCheckbox>
+              </div>
+            )}
+            {hasDentalInsurance === false && (
+              <div className="mb-4 space-y-4">
+                <ContextualAlert type="info" id="dental-insurance-confirmation-no">
+                  <h2 className="font-lato mb-2 text-xl font-semibold">{t(($) => $.dentalInsurance.no.alertTitle)}</h2>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.dentalInsurance.no.alertBody} components={{ t4Href, t4aHref }} />
+                </ContextualAlert>
+                <InputCheckbox
+                  id="dental-insurance-eligibility-confirmation-no"
+                  name="dentalInsuranceEligibilityConfirmationNo"
+                  value={CHECKBOX_VALUE.yes}
+                  defaultChecked={defaultState?.dentalInsuranceEligibilityConfirmationNo}
+                  errorMessage={errors?.dentalInsuranceEligibilityConfirmationNo}
+                  required
+                  aria-describedby="dental-insurance-confirmation-no"
+                >
+                  {t(($) => $.dentalInsurance.no.confirmation)}
+                </InputCheckbox>
+              </div>
+            )}
 
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Access to other dental insurance click">
-              {t(($) => $.dentalInsurance.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`public/application/$id/${applicationFlow}/dental-insurance`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Access to other dental insurance click"
-            >
-              {t(($) => $.dentalInsurance.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </div>
-    </ErrorSummaryProvider>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Access to other dental insurance click">
+                {t(($) => $.dentalInsurance.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/${applicationFlow}/dental-insurance`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Access to other dental insurance click"
+              >
+                {t(($) => $.dentalInsurance.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </div>
+      </ErrorSummaryProvider>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/email.tsx
+++ b/frontend/app/routes/public/application/spokes/email.tsx
@@ -11,6 +11,7 @@ import { getPublicApplicationState, savePublicApplicationState, validateApplicat
 import type { ApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -42,7 +43,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.email,
-  pageTitleI18nKey: 'applicationSpokes:email.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -143,27 +143,37 @@ export default function ApplicationEmail({ loaderData, params }: Route.Component
   const errors = typeof fetcher.data === 'object' && 'errors' in fetcher.data ? fetcher.data.errors : undefined;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
-          <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
-          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-          <div className="mb-6">
-            <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Email click">
-              {t(($) => $.email.continue)}
-            </LoadingButton>
-            <ButtonLink id="back-button" variant="secondary" routeId="public/application/$id/communication-preferences" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Email click">
-              {t(($) => $.email.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.email.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <p className="mb-4">{t(($) => $.email.provideEmail)}</p>
+            <p className="mb-8">{t(($) => $.email.verifyEmail)}</p>
+            <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+            <div className="mb-6">
+              <InputField id="email" name="email" type="email" inputMode="email" className="w-full" autoComplete="email" defaultValue={defaultState} errorMessage={errors?.email} label={t(($) => $.email.emailLegend)} maxLength={64} required />
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Email click">
+                {t(($) => $.email.continue)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="public/application/$id/communication-preferences"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Email click"
+              >
+                {t(($) => $.email.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -13,6 +13,7 @@ import type { PublicApplicationDentalFederalBenefitsState, PublicApplicationDent
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -38,9 +39,8 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.federalProvincialTerritorialBenefits,
-  pageTitleI18nKey: 'applicationSpokes:dentalBenefits.title',
 };
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialTerritorialSocialPrograms = await appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService).listAndSortLocalizedProvincialGovernmentInsurancePlans(locale);
 
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalBenefits.title, { ns: 'applicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.dentalBenefits.title) }),
   };
 
   return {
@@ -88,7 +88,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const federalBenefitsSchema = z
     .object({
       hasFederalBenefits: z.boolean({
-        error: t(($) => $.dentalBenefits.errorMessage.federalBenefitRequired, { ns: 'applicationSpokes' }),
+        error: t(($) => $.dentalBenefits.errorMessage.federalBenefitRequired),
       }),
       federalSocialProgram: z.string().trim().optional(),
     })
@@ -97,7 +97,7 @@ export async function action({ context: { appContainer, session }, params, reque
       if (val.hasFederalBenefits && (!val.federalSocialProgram || validator.isEmpty(val.federalSocialProgram))) {
         ctx.addIssue({
           code: 'custom',
-          message: t(($) => $.dentalBenefits.errorMessage.federalBenefitProgramRequired, { ns: 'applicationSpokes' }),
+          message: t(($) => $.dentalBenefits.errorMessage.federalBenefitProgramRequired),
           path: ['federalSocialProgram'],
         });
       }
@@ -112,7 +112,7 @@ export async function action({ context: { appContainer, session }, params, reque
   const provincialTerritorialBenefitsSchema = z
     .object({
       hasProvincialTerritorialBenefits: z.boolean({
-        error: t(($) => $.dentalBenefits.errorMessage.provincialBenefitRequired, { ns: 'applicationSpokes' }),
+        error: t(($) => $.dentalBenefits.errorMessage.provincialBenefitRequired),
       }),
       provincialTerritorialSocialProgram: z.string().trim().optional(),
       province: z.string().trim().optional(),
@@ -123,13 +123,13 @@ export async function action({ context: { appContainer, session }, params, reque
         if (!val.province || validator.isEmpty(val.province)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.dentalBenefits.errorMessage.provincialTerritorialRequired, { ns: 'applicationSpokes' }),
+            message: t(($) => $.dentalBenefits.errorMessage.provincialTerritorialRequired),
             path: ['province'],
           });
         } else if (!val.provincialTerritorialSocialProgram || validator.isEmpty(val.provincialTerritorialSocialProgram)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.dentalBenefits.errorMessage.provincialBenefitProgramRequired, { ns: 'applicationSpokes' }),
+            message: t(($) => $.dentalBenefits.errorMessage.provincialBenefitProgramRequired),
             path: ['provincialTerritorialSocialProgram'],
           });
         }
@@ -218,134 +218,137 @@ export default function ApplicationSpokeFederalProvincialTerritorialBenefits({ l
   }
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental, { ns: 'applicationSpokes' })}</p>
-        <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria, { ns: 'applicationSpokes' })}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.federalBenefits.title, { ns: 'applicationSpokes' })}</legend>
-            <InputRadios
-              id="has-federal-benefits"
-              name="hasFederalBenefits"
-              legend={t(($) => $.dentalBenefits.federalBenefits.legend, { ns: 'applicationSpokes' })}
-              options={[
-                {
-                  children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionYes} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.yes,
-                  defaultChecked: hasFederalBenefitValue === true,
-                  onChange: handleOnHasFederalBenefitChanged,
-                  append: hasFederalBenefitValue === true && (
-                    <InputRadios
-                      id="federal-social-programs"
-                      name="federalSocialProgram"
-                      legend={t(($) => $.dentalBenefits.federalBenefits.socialPrograms.legend, { ns: 'applicationSpokes' })}
-                      legendClassName="font-normal"
-                      options={federalSocialPrograms.map((option) => ({
-                        children: option.name,
-                        defaultChecked: defaultState?.federalSocialProgram === option.id,
-                        value: option.id,
-                      }))}
-                      errorMessage={errors?.federalSocialProgram}
-                      required
-                    />
-                  ),
-                },
-                {
-                  children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionNo} />,
-                  value: HAS_FEDERAL_BENEFITS_OPTION.no,
-                  defaultChecked: hasFederalBenefitValue === false,
-                  onChange: handleOnHasFederalBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasFederalBenefits}
-              required
-            />
-          </fieldset>
-          <fieldset className="mb-8">
-            <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.provincialTerritorialBenefits.title, { ns: 'applicationSpokes' })}</legend>
-            <InputRadios
-              id="has-provincial-territorial-benefits"
-              name="hasProvincialTerritorialBenefits"
-              legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.legend, { ns: 'applicationSpokes' })}
-              options={[
-                {
-                  children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                  append: hasProvincialTerritorialBenefitValue === true && (
-                    <div className="space-y-6">
-                      <InputSelect
-                        id="province"
-                        name="province"
-                        className="w-full sm:w-1/2"
-                        label={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend, { ns: 'applicationSpokes' })}
-                        onChange={handleOnRegionChanged}
-                        options={[
-                          {
-                            children: t(($) => $.dentalBenefits.selectOne, { ns: 'applicationSpokes' }),
-                            value: '',
-                            hidden: true,
-                          },
-                          ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
-                        ]}
-                        defaultValue={provinceValue}
-                        errorMessage={errors?.province}
+    <>
+      <AppPageTitle>{t(($) => $.dentalBenefits.title)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <p className="mb-4">{t(($) => $.dentalBenefits.accessToDental)}</p>
+          <p className="mb-4">{t(($) => $.dentalBenefits.eligibilityCriteria)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.federalBenefits.title)}</legend>
+              <InputRadios
+                id="has-federal-benefits"
+                name="hasFederalBenefits"
+                legend={t(($) => $.dentalBenefits.federalBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionYes} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.yes,
+                    defaultChecked: hasFederalBenefitValue === true,
+                    onChange: handleOnHasFederalBenefitChanged,
+                    append: hasFederalBenefitValue === true && (
+                      <InputRadios
+                        id="federal-social-programs"
+                        name="federalSocialProgram"
+                        legend={t(($) => $.dentalBenefits.federalBenefits.socialPrograms.legend)}
+                        legendClassName="font-normal"
+                        options={federalSocialPrograms.map((option) => ({
+                          children: option.name,
+                          defaultChecked: defaultState?.federalSocialProgram === option.id,
+                          value: option.id,
+                        }))}
+                        errorMessage={errors?.federalSocialProgram}
                         required
                       />
-                      {provinceValue && (
-                        <InputRadios
-                          id="provincial-territorial-social-programs"
-                          name="provincialTerritorialSocialProgram"
-                          legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend, { ns: 'applicationSpokes' })}
-                          legendClassName="font-normal"
-                          errorMessage={errors?.provincialTerritorialSocialProgram}
-                          options={provincialTerritorialSocialPrograms
-                            .filter((program) => program.provinceTerritoryStateId === provinceValue)
-                            .map((option) => ({
-                              children: option.name,
-                              value: option.id,
-                              checked: provincialTerritorialSocialProgramValue === option.id,
-                              onChange: handleOnProvincialTerritorialSocialProgramChanged,
-                            }))}
+                    ),
+                  },
+                  {
+                    children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.federalBenefits.optionNo} />,
+                    value: HAS_FEDERAL_BENEFITS_OPTION.no,
+                    defaultChecked: hasFederalBenefitValue === false,
+                    onChange: handleOnHasFederalBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasFederalBenefits}
+                required
+              />
+            </fieldset>
+            <fieldset className="mb-8">
+              <legend className="font-lato mb-4 text-2xl font-bold">{t(($) => $.dentalBenefits.provincialTerritorialBenefits.title)}</legend>
+              <InputRadios
+                id="has-provincial-territorial-benefits"
+                name="hasProvincialTerritorialBenefits"
+                legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.legend)}
+                options={[
+                  {
+                    children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionYes} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.yes,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === true,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                    append: hasProvincialTerritorialBenefitValue === true && (
+                      <div className="space-y-6">
+                        <InputSelect
+                          id="province"
+                          name="province"
+                          className="w-full sm:w-1/2"
+                          label={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.inputLegend)}
+                          onChange={handleOnRegionChanged}
+                          options={[
+                            {
+                              children: t(($) => $.dentalBenefits.selectOne),
+                              value: '',
+                              hidden: true,
+                            },
+                            ...provinceTerritoryStates.map((region) => ({ id: region.id, value: region.id, children: region.name })),
+                          ]}
+                          defaultValue={provinceValue}
+                          errorMessage={errors?.province}
                           required
                         />
-                      )}
-                    </div>
-                  ),
-                },
-                {
-                  children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
-                  value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
-                  defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
-                  onChange: handleOnHasProvincialTerritorialBenefitChanged,
-                },
-              ]}
-              errorMessage={errors?.hasProvincialTerritorialBenefits}
-              required
-            />
-          </fieldset>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Access to other dental benefits click">
-              {t(($) => $.dentalBenefits.saveBtn, { ns: 'applicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`public/application/$id/${applicationFlow}/dental-insurance`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Access to other dental benefits click"
-            >
-              {t(($) => $.dentalBenefits.backBtn, { ns: 'applicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+                        {provinceValue && (
+                          <InputRadios
+                            id="provincial-territorial-social-programs"
+                            name="provincialTerritorialSocialProgram"
+                            legend={t(($) => $.dentalBenefits.provincialTerritorialBenefits.socialPrograms.radioLegend)}
+                            legendClassName="font-normal"
+                            errorMessage={errors?.provincialTerritorialSocialProgram}
+                            options={provincialTerritorialSocialPrograms
+                              .filter((program) => program.provinceTerritoryStateId === provinceValue)
+                              .map((option) => ({
+                                children: option.name,
+                                value: option.id,
+                                checked: provincialTerritorialSocialProgramValue === option.id,
+                                onChange: handleOnProvincialTerritorialSocialProgramChanged,
+                              }))}
+                            required
+                          />
+                        )}
+                      </div>
+                    ),
+                  },
+                  {
+                    children: <Trans ns="applicationSpokes" i18nKey={($) => $.dentalBenefits.provincialTerritorialBenefits.optionNo} />,
+                    value: HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION.no,
+                    defaultChecked: defaultState?.hasProvincialTerritorialBenefits === false,
+                    onChange: handleOnHasProvincialTerritorialBenefitChanged,
+                  },
+                ]}
+                errorMessage={errors?.hasProvincialTerritorialBenefits}
+                required
+              />
+            </fieldset>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Access to other dental benefits click">
+                {t(($) => $.dentalBenefits.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/${applicationFlow}/dental-insurance`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Access to other dental benefits click"
+              >
+                {t(($) => $.dentalBenefits.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/file-taxes.tsx
+++ b/frontend/app/routes/public/application/spokes/file-taxes.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/file-taxes';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -18,7 +19,10 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
-export const handle = { i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'), pageIdentifier: pageIds.public.application.spokes.fileYourTaxes, pageTitleI18nKey: 'application:fileYourTaxes.pageTitle' } as const satisfies RouteHandleData;
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  pageIdentifier: pageIds.public.application.spokes.fileYourTaxes,
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 
@@ -62,32 +66,35 @@ export default function ApplicationFileYourTaxes({ loaderData, params }: Route.C
   }
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-8 space-y-4">
-        <p>{t(($) => $.fileYourTaxes.ineligibleToApply)}</p>
-        <p>
-          {t(($) => $.fileYourTaxes.taxNotFiled, {
-            taxYear: taxYear,
-            ns: 'application',
-          })}
-        </p>
-        <p>{t(($) => $.fileYourTaxes.unableToAssess)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.taxInfo} components={{ taxInfo }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.applyAfter} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.fileYourTaxes.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-8 space-y-4">
+          <p>{t(($) => $.fileYourTaxes.ineligibleToApply)}</p>
+          <p>
+            {t(($) => $.fileYourTaxes.taxNotFiled, {
+              taxYear: taxYear,
+              ns: 'application',
+            })}
+          </p>
+          <p>{t(($) => $.fileYourTaxes.unableToAssess)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.taxInfo} components={{ taxInfo }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.fileYourTaxes.applyAfter} />
+          </p>
+        </div>
+        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink id="back-button" variant="secondary" routeId="public/application/$id/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - File your taxes click">
+            {t(($) => $.fileYourTaxes.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - File your taxes click">
+            {t(($) => $.fileYourTaxes.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" onSubmit={handleSubmit} noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink id="back-button" variant="secondary" routeId="public/application/$id/tax-filing" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - File your taxes click">
-          {t(($) => $.fileYourTaxes.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - File your taxes click">
-          {t(($) => $.fileYourTaxes.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/home-address.tsx
+++ b/frontend/app/routes/public/application/spokes/home-address.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/public-applicatio
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -56,7 +57,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.homeAddress,
-  pageTitleI18nKey: 'applicationSpokes:address.homeAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -261,110 +261,120 @@ export default function HomeAddress({ loaderData, params }: Route.ComponentProps
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-8">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="homeAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.address.addressField.address)}
-                helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                maxLength={100}
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="home-apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.address.addressField.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue=""
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="home-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode ?? ''}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {homeRegions.length > 0 && (
-                <InputSelect
-                  id="home-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.address.addressField.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...homeRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.address.homeAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-8">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="homeAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.address)}
+                  helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  maxLength={100}
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="home-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country ?? ''}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={homeCountryChangeHandler}
-                required
-              />
+                <InputSanitizeField
+                  id="home-apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue=""
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="home-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="home-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode ?? ''}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {homeRegions.length > 0 && (
+                  <InputSelect
+                    id="home-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.address.addressField.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...homeRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="home-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.address.addressField.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country ?? ''}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={homeCountryChangeHandler}
+                  required
+                />
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Home address click"
+                  >
+                    {t(($) => $.address.saveBtn)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/mailing-address`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Home address click"
+              >
+                {t(($) => $.address.back)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Home address click"
-                >
-                  {t(($) => $.address.saveBtn)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && <AddressInvalidDialogContent addressContext="homeAddress" invalidAddress={addressDialogContent.invalidAddress} formAction={FORM_ACTION.useInvalidAddress} />}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink id="back-button" variant="secondary" routeId={`public/application/$id/mailing-address`} params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Home address click">
-              {t(($) => $.address.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/living-independently.tsx
+++ b/frontend/app/routes/public/application/spokes/living-independently.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -31,7 +32,6 @@ const LIVING_INDEPENDENTLY_OPTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.livingIndependently,
-  pageTitleI18nKey: 'applicationSpokes:livingIndependently.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -90,49 +90,52 @@ export default function ApplyFlowLivingIndependently({ loaderData, params }: Rou
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-6">{t(($) => $.livingIndependently.description)}</p>
-      <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="living-independently"
-            name="livingIndependently"
-            legend={t(($) => $.livingIndependently.formInstructions)}
-            options={[
-              {
-                value: LIVING_INDEPENDENTLY_OPTION.yes,
-                children: t(($) => $.livingIndependently.radioOptions.yes),
-                defaultChecked: defaultState === true,
-              },
-              {
-                value: LIVING_INDEPENDENTLY_OPTION.no,
-                children: t(($) => $.livingIndependently.radioOptions.no),
-                defaultChecked: defaultState === false,
-              },
-            ]}
-            required
-            errorMessage={errors?.livingIndependently}
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Living independently click">
-              {t(($) => $.livingIndependently.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="public/application/$id/personal-information"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Living independently click"
-            >
-              {t(($) => $.livingIndependently.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.livingIndependently.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-6">{t(($) => $.livingIndependently.description)}</p>
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="living-independently"
+              name="livingIndependently"
+              legend={t(($) => $.livingIndependently.formInstructions)}
+              options={[
+                {
+                  value: LIVING_INDEPENDENTLY_OPTION.yes,
+                  children: t(($) => $.livingIndependently.radioOptions.yes),
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  value: LIVING_INDEPENDENTLY_OPTION.no,
+                  children: t(($) => $.livingIndependently.radioOptions.no),
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              required
+              errorMessage={errors?.livingIndependently}
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Living independently click">
+                {t(($) => $.livingIndependently.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="public/application/$id/personal-information"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Living independently click"
+              >
+                {t(($) => $.livingIndependently.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/public/application/spokes/mailing-address.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/public-applicatio
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import type { AddressInvalidResponse, AddressResponse, AddressSuggestionResponse, CanadianAddress } from '~/components/address-validation-dialog';
 import { AddressInvalidDialogContent, AddressSuggestionDialogContent } from '~/components/address-validation-dialog';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogTrigger } from '~/components/dialog';
@@ -57,7 +58,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.mailingAddress,
-  pageTitleI18nKey: 'applicationSpokes:address.mailingAddress.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -296,122 +296,125 @@ export default function MailingAddress({ loaderData, params }: Route.ComponentPr
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <fieldset className="mb-6">
-            <div className="space-y-6">
-              <InputSanitizeField
-                id="mailingAddress"
-                name="address"
-                className="w-full"
-                label={t(($) => $.address.addressField.address)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line1"
-                defaultValue={defaultState.address}
-                errorMessage={errors?.address}
-                required
-              />
-              <InputSanitizeField
-                id="mailing-apartment"
-                name="apartment"
-                className="w-full"
-                label={t(($) => $.address.addressField.apartment)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
-                helpMessagePrimaryClassName="text-black"
-                autoComplete="address-line2"
-                defaultValue=""
-                errorMessage={errors?.apartment}
-              />
-              <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
-              <InputSanitizeField
-                id="mailing-postal-code"
-                name="postalZipCode"
-                className="w-full sm:w-1/2"
-                label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
-                maxLength={100}
-                autoComplete="postal-code"
-                defaultValue={defaultState.postalCode}
-                errorMessage={errors?.postalZipCode}
-                required={isPostalCodeRequired}
-                helpMessagePrimary={postalCodeHelpMessage}
-                helpMessagePrimaryClassName="text-black"
-              />
-              {mailingRegions.length > 0 && (
-                <InputSelect
-                  id="mailing-province"
-                  name="provinceStateId"
-                  className="w-full sm:w-1/2"
-                  label={t(($) => $.address.addressField.province)}
-                  defaultValue={defaultState.province}
-                  errorMessage={errors?.provinceStateId}
-                  options={[dummyOption, ...mailingRegions]}
+    <>
+      <AppPageTitle>{t(($) => $.address.mailingAddress.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <fieldset className="mb-6">
+              <div className="space-y-6">
+                <InputSanitizeField
+                  id="mailingAddress"
+                  name="address"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.address)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.addressHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line1"
+                  defaultValue={defaultState.address}
+                  errorMessage={errors?.address}
                   required
                 />
-              )}
-              <InputSelect
-                id="mailing-country"
-                name="countryId"
-                className="w-full sm:w-1/2"
-                label={t(($) => $.address.addressField.country)}
-                autoComplete="country"
-                defaultValue={defaultState.country}
-                errorMessage={errors?.countryId}
-                options={countries}
-                onChange={mailingCountryChangeHandler}
-                required
-              />
-              <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
-                {t(($) => $.address.homeAddress.useMailingAddress)}
-              </InputCheckbox>
+                <InputSanitizeField
+                  id="mailing-apartment"
+                  name="apartment"
+                  className="w-full"
+                  label={t(($) => $.address.addressField.apartment)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.address.addressField.apartmentHelp)}
+                  helpMessagePrimaryClassName="text-black"
+                  autoComplete="address-line2"
+                  defaultValue=""
+                  errorMessage={errors?.apartment}
+                />
+                <InputSanitizeField id="mailing-city" name="city" className="w-full" label={t(($) => $.address.addressField.city)} maxLength={100} autoComplete="address-level2" defaultValue={defaultState.city} errorMessage={errors?.city} required />
+                <InputSanitizeField
+                  id="mailing-postal-code"
+                  name="postalZipCode"
+                  className="w-full sm:w-1/2"
+                  label={isPostalCodeRequired ? t(($) => $.address.addressField.postalCode) : t(($) => $.address.addressField.postalCodeOptional)}
+                  maxLength={100}
+                  autoComplete="postal-code"
+                  defaultValue={defaultState.postalCode}
+                  errorMessage={errors?.postalZipCode}
+                  required={isPostalCodeRequired}
+                  helpMessagePrimary={postalCodeHelpMessage}
+                  helpMessagePrimaryClassName="text-black"
+                />
+                {mailingRegions.length > 0 && (
+                  <InputSelect
+                    id="mailing-province"
+                    name="provinceStateId"
+                    className="w-full sm:w-1/2"
+                    label={t(($) => $.address.addressField.province)}
+                    defaultValue={defaultState.province}
+                    errorMessage={errors?.provinceStateId}
+                    options={[dummyOption, ...mailingRegions]}
+                    required
+                  />
+                )}
+                <InputSelect
+                  id="mailing-country"
+                  name="countryId"
+                  className="w-full sm:w-1/2"
+                  label={t(($) => $.address.addressField.country)}
+                  autoComplete="country"
+                  defaultValue={defaultState.country}
+                  errorMessage={errors?.countryId}
+                  options={countries}
+                  onChange={mailingCountryChangeHandler}
+                  required
+                />
+                <InputCheckbox id="sync-addresses" name="syncAddresses" value="true" checked={copyAddressChecked} onChange={checkHandler}>
+                  {t(($) => $.address.homeAddress.useMailingAddress)}
+                </InputCheckbox>
+              </div>
+            </fieldset>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
+                <DialogTrigger asChild>
+                  <LoadingButton
+                    aria-expanded={undefined}
+                    variant="primary"
+                    id="continue-button"
+                    type="submit"
+                    name="_action"
+                    value={FORM_ACTION.submit}
+                    loading={isSubmitting}
+                    data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Mailing address click"
+                  >
+                    {copyAddressChecked ? t(($) => $.address.saveBtn) : t(($) => $.address.continue)}
+                  </LoadingButton>
+                </DialogTrigger>
+                {!isSubmitting && addressDialogContent && (
+                  <>
+                    {addressDialogContent.status === 'address-suggestion' && (
+                      <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
+                    )}
+                    {addressDialogContent.status === 'address-invalid' && (
+                      <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
+                    )}
+                  </>
+                )}
+              </Dialog>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Mailing address click"
+              >
+                {t(($) => $.address.back)}
+              </ButtonLink>
             </div>
-          </fieldset>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <Dialog open={addressDialogContent !== null} onOpenChange={onDialogOpenChangeHandler}>
-              <DialogTrigger asChild>
-                <LoadingButton
-                  aria-expanded={undefined}
-                  variant="primary"
-                  id="continue-button"
-                  type="submit"
-                  name="_action"
-                  value={FORM_ACTION.submit}
-                  loading={isSubmitting}
-                  data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Mailing address click"
-                >
-                  {copyAddressChecked ? t(($) => $.address.saveBtn) : t(($) => $.address.continue)}
-                </LoadingButton>
-              </DialogTrigger>
-              {!isSubmitting && addressDialogContent && (
-                <>
-                  {addressDialogContent.status === 'address-suggestion' && (
-                    <AddressSuggestionDialogContent enteredAddress={addressDialogContent.enteredAddress} suggestedAddress={addressDialogContent.suggestedAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useSelectedAddress} />
-                  )}
-                  {addressDialogContent.status === 'address-invalid' && (
-                    <AddressInvalidDialogContent addressContext="mailingAddress" invalidAddress={addressDialogContent.invalidAddress} syncAddresses={copyAddressChecked} formAction={FORM_ACTION.useInvalidAddress} />
-                  )}
-                </>
-              )}
-            </Dialog>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Mailing address click"
-            >
-              {t(($) => $.address.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -14,6 +14,7 @@ import type { ApplicationFlow, PublicApplicationPartnerInformationState } from '
 import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -45,9 +46,8 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.maritalStatus,
-  pageTitleI18nKey: 'applicationSpokes:maritalStatus.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -59,7 +59,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
   const locale = getLocale(request);
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle, { ns: 'applicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.maritalStatus.pageTitle) }),
   };
   const maritalStatuses = appContainer.get(TYPES.MaritalStatusService).listLocalizedMaritalStatuses(locale);
   return {
@@ -87,12 +87,12 @@ export async function action({ context: { appContainer, session }, params, reque
   const maritalStatusSchema = z.object({
     maritalStatus: z
       .string({
-        error: t(($) => $.maritalStatus.errorMessage.maritalStatusRequired, { ns: 'applicationSpokes' }),
+        error: t(($) => $.maritalStatus.errorMessage.maritalStatusRequired),
       })
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.maritalStatusRequired, { ns: 'applicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.maritalStatusRequired),
       ),
   });
 
@@ -100,36 +100,36 @@ export async function action({ context: { appContainer, session }, params, reque
   const partnerInformationSchema = z.object({
     consentToSharePersonalInformation: z.literal(
       true,
-      t(($) => $.maritalStatus.errorMessage.confirmRequired, { ns: 'applicationSpokes' }),
+      t(($) => $.maritalStatus.errorMessage.confirmRequired),
     ),
     yearOfBirth: z
       .string()
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.dateOfBirthYearRequired, { ns: 'applicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.dateOfBirthYearRequired),
       )
       .refine(
         (year) => Number.parseInt(year) > currentYear - 150,
-        t(($) => $.maritalStatus.errorMessage.yobIsPast, { ns: 'applicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.yobIsPast),
       )
       .refine(
         (year) => Number.parseInt(year) < currentYear,
-        t(($) => $.maritalStatus.errorMessage.yobIsFuture, { ns: 'applicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.yobIsFuture),
       ),
     socialInsuranceNumber: z
       .string()
       .trim()
       .min(
         1,
-        t(($) => $.maritalStatus.errorMessage.sinRequired, { ns: 'applicationSpokes' }),
+        t(($) => $.maritalStatus.errorMessage.sinRequired),
       )
 
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinValid, { ns: 'applicationSpokes' }),
+            message: t(($) => $.maritalStatus.errorMessage.sinValid),
           });
         } else if (
           [state.applicantInformation?.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
@@ -139,7 +139,7 @@ export async function action({ context: { appContainer, session }, params, reque
         ) {
           ctx.addIssue({
             code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinUnique, { ns: 'applicationSpokes' }),
+            message: t(($) => $.maritalStatus.errorMessage.sinUnique),
           });
         }
       }),
@@ -206,82 +206,85 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
   }, [defaultState, maritalStatuses]);
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            <InputRadios
-              id="maritalStatus"
-              name="maritalStatus"
-              legend={t(($) => $.maritalStatus.maritalStatus, { ns: 'applicationSpokes' })}
-              helpMessagePrimary={t(($) => $.maritalStatus.primaryHelpMessage, { ns: 'applicationSpokes' })}
-              options={maritalStatusOptions}
-              errorMessage={errors?.maritalStatus}
-              required
-            />
+    <>
+      <AppPageTitle>{t(($) => $.maritalStatus.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              <InputRadios
+                id="maritalStatus"
+                name="maritalStatus"
+                legend={t(($) => $.maritalStatus.maritalStatus)}
+                helpMessagePrimary={t(($) => $.maritalStatus.primaryHelpMessage)}
+                options={maritalStatusOptions}
+                errorMessage={errors?.maritalStatus}
+                required
+              />
 
-            {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-              <>
-                <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw, { ns: 'applicationSpokes' })}</h2>
-                <p className="mb-4">{t(($) => $.maritalStatus.provideSin, { ns: 'applicationSpokes' })}</p>
-                <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation, { ns: 'applicationSpokes' })}</p>
-                <InputPatternField
-                  id="social-insurance-number"
-                  name="socialInsuranceNumber"
-                  format={sinInputPatternFormat}
-                  label={t(($) => $.maritalStatus.sin, { ns: 'applicationSpokes' })}
-                  inputMode="numeric"
-                  helpMessagePrimary={t(($) => $.maritalStatus.sinHelp, { ns: 'applicationSpokes' })}
-                  helpMessagePrimaryClassName="text-black"
-                  defaultValue={defaultState.socialInsuranceNumber ?? ''}
-                  errorMessage={errors?.socialInsuranceNumber}
-                  required
-                />
-                <InputPatternField
-                  id="year-of-birth"
-                  name="yearOfBirth"
-                  inputMode="numeric"
-                  format="####"
-                  defaultValue={defaultState.yearOfBirth ?? ''}
-                  label={t(($) => $.maritalStatus.yearOfBirth, { ns: 'applicationSpokes' })}
-                  helpMessagePrimary={t(($) => $.maritalStatus.yearOfBirthHelp, { ns: 'applicationSpokes' })}
-                  helpMessagePrimaryClassName="text-black"
-                  errorMessage={errors?.yearOfBirth}
-                  required
-                />
-                <InputCheckbox
-                  id="consentToSharePersonalInformation"
-                  name="consentToSharePersonalInformation"
-                  value="yes"
-                  errorMessage={errors?.consentToSharePersonalInformation}
-                  defaultChecked={defaultState.consentToSharePersonalInformation === true}
-                  required
-                >
-                  {t(($) => $.maritalStatus.confirmCheckbox, { ns: 'applicationSpokes' })}
-                </InputCheckbox>
-              </>
-            )}
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Marital status click">
-              {t(($) => $.maritalStatus.saveBtn, { ns: 'applicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Marital status click"
-            >
-              {t(($) => $.maritalStatus.backBtn, { ns: 'applicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+              {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
+                <>
+                  <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</h2>
+                  <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
+                  <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
+                  <InputPatternField
+                    id="social-insurance-number"
+                    name="socialInsuranceNumber"
+                    format={sinInputPatternFormat}
+                    label={t(($) => $.maritalStatus.sin)}
+                    inputMode="numeric"
+                    helpMessagePrimary={t(($) => $.maritalStatus.sinHelp)}
+                    helpMessagePrimaryClassName="text-black"
+                    defaultValue={defaultState.socialInsuranceNumber ?? ''}
+                    errorMessage={errors?.socialInsuranceNumber}
+                    required
+                  />
+                  <InputPatternField
+                    id="year-of-birth"
+                    name="yearOfBirth"
+                    inputMode="numeric"
+                    format="####"
+                    defaultValue={defaultState.yearOfBirth ?? ''}
+                    label={t(($) => $.maritalStatus.yearOfBirth)}
+                    helpMessagePrimary={t(($) => $.maritalStatus.yearOfBirthHelp)}
+                    helpMessagePrimaryClassName="text-black"
+                    errorMessage={errors?.yearOfBirth}
+                    required
+                  />
+                  <InputCheckbox
+                    id="consentToSharePersonalInformation"
+                    name="consentToSharePersonalInformation"
+                    value="yes"
+                    errorMessage={errors?.consentToSharePersonalInformation}
+                    defaultChecked={defaultState.consentToSharePersonalInformation === true}
+                    required
+                  >
+                    {t(($) => $.maritalStatus.confirmCheckbox)}
+                  </InputCheckbox>
+                </>
+              )}
+            </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Marital status click">
+                {t(($) => $.maritalStatus.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Marital status click"
+              >
+                {t(($) => $.maritalStatus.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
@@ -14,6 +14,7 @@ import { TYPES } from '~/.server/constants';
 import { getContextualAgeCategoryFromDate, getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -36,7 +37,6 @@ const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.newOrReturningMember,
-  pageTitleI18nKey: 'applicationSpokes:newOrReturningMember.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -145,46 +145,49 @@ export default function ApplyFlowNewOrExistingMember({ loaderData, params }: Rou
   ];
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t(($) => $.newOrReturningMember.previouslyEnrolled)} options={options} errorMessage={errors?.newOrExistingMember} required />
-          {isNewOrReturningMember && (
-            <div className="my-8">
-              <InputPatternField
-                id="member-id"
-                name="memberId"
-                format={renewalCodeInputPatternFormat}
-                label={t(($) => $.newOrReturningMember.memberId)}
-                inputMode="numeric"
-                defaultValue={defaultState?.memberId ?? ''}
-                errorMessage={errors?.memberId}
-                helpMessagePrimary={t(($) => $.newOrReturningMember.memberIdDescription)}
-                required={isNewOrReturningMember}
-              />
+    <>
+      <AppPageTitle>{t(($) => $.newOrReturningMember.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios id="new-or-existing-member" name="newOrExistingMember" legend={t(($) => $.newOrReturningMember.previouslyEnrolled)} options={options} errorMessage={errors?.newOrExistingMember} required />
+            {isNewOrReturningMember && (
+              <div className="my-8">
+                <InputPatternField
+                  id="member-id"
+                  name="memberId"
+                  format={renewalCodeInputPatternFormat}
+                  label={t(($) => $.newOrReturningMember.memberId)}
+                  inputMode="numeric"
+                  defaultValue={defaultState?.memberId ?? ''}
+                  errorMessage={errors?.memberId}
+                  helpMessagePrimary={t(($) => $.newOrReturningMember.memberIdDescription)}
+                  required={isNewOrReturningMember}
+                />
+              </div>
+            )}
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
+                {t(($) => $.newOrReturningMember.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={userAgeCategory === 'youth' ? 'public/application/$id/living-independently' : 'public/application/$id/your-application'}
+                params={params}
+                disabled={isSubmitting}
+                startIcon={faChevronLeft}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
+              >
+                {t(($) => $.newOrReturningMember.backBtn)}
+              </ButtonLink>
             </div>
-          )}
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="continue-button" loading={isSubmitting} endIcon={faChevronRight} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Continue - New or existing member click">
-              {t(($) => $.newOrReturningMember.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={userAgeCategory === 'youth' ? 'public/application/$id/living-independently' : 'public/application/$id/your-application'}
-              params={params}
-              disabled={isSubmitting}
-              startIcon={faChevronLeft}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Adult:Back - New or existing member click"
-            >
-              {t(($) => $.newOrReturningMember.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/spokes/parent-or-guardian.tsx
@@ -8,6 +8,7 @@ import type { Route } from './+types/parent-or-guardian';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, getContextualAgeCategoryFromDate, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
@@ -22,7 +23,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.parentOrGuardian,
-  pageTitleI18nKey: 'applicationSpokes:parentOrGuardian.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -84,6 +84,7 @@ export default function ApplyFlowParentOrGuardian({ loaderData, params }: Route.
 
   return (
     <>
+      <AppPageTitle>{t(($) => $.parentOrGuardian.pageTitle)}</AppPageTitle>
       <div className="mb-8 max-w-prose space-y-4">
         <p className="mb-4">{t(($) => $.parentOrGuardian.unableToApply)}</p>
         <p>

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -13,6 +13,7 @@ import type { PublicApplicationApplicantInformationState, PublicApplicationInput
 import { getContextualAgeCategoryFromDate, getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -38,7 +39,6 @@ import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/str
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.personalInformation,
-  pageTitleI18nKey: 'applicationSpokes:personalInformation.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -278,107 +278,110 @@ export default function ApplicationPersonalInformation({ loaderData, params }: R
   const { ErrorAlert } = useErrorAlert(fetcherStatus === 'client-not-found');
 
   return (
-    <div className="max-w-prose">
-      <ErrorAlert>
-        <h2 className="mb-2 font-bold">{t(($) => $.personalInformation.errorMessage.alert.heading)}</h2>
-        <p className="mb-2">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.detail} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
-        </p>
-        <p className="mb-2">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.applyDate} values={{ startDate: fetcherEligibilityStartDate }} components={{ strong: <strong /> }} />
-        </p>
-      </ErrorAlert>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <p className="mb-4">{t(($) => $.personalInformation.formInstructionsSin)}</p>
-        <p className="mb-6">{t(($) => $.personalInformation.formInstructionsInfo)}</p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-8 space-y-6">
-            {isRenewalContext && (
+    <>
+      <AppPageTitle>{t(($) => $.personalInformation.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t(($) => $.personalInformation.errorMessage.alert.heading)}</h2>
+          <p className="mb-2">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.detail} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
+          </p>
+          <p className="mb-2">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.errorMessage.alert.applyDate} values={{ startDate: fetcherEligibilityStartDate }} components={{ strong: <strong /> }} />
+          </p>
+        </ErrorAlert>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <p className="mb-4">{t(($) => $.personalInformation.formInstructionsSin)}</p>
+          <p className="mb-6">{t(($) => $.personalInformation.formInstructionsInfo)}</p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-8 space-y-6">
+              {isRenewalContext && (
+                <InputPatternField
+                  id="member-id"
+                  name="memberId"
+                  label={t(($) => $.personalInformation.memberId)}
+                  inputMode="numeric"
+                  format={renewalCodeInputPatternFormat}
+                  helpMessagePrimary={t(($) => $.personalInformation.helpMessage.memberId)}
+                  helpMessagePrimaryClassName="text-black"
+                  defaultValue={state?.memberId ?? ''}
+                  errorMessage={errors?.memberId}
+                  required
+                />
+              )}
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputSanitizeField
+                  id="first-name"
+                  name="firstName"
+                  label={t(($) => $.personalInformation.firstName)}
+                  className="w-full"
+                  maxLength={100}
+                  aria-description={t(($) => $.personalInformation.nameInstructions)}
+                  autoComplete="given-name"
+                  defaultValue={state?.firstName ?? ''}
+                  errorMessage={errors?.firstName}
+                  required
+                />
+                <InputSanitizeField
+                  id="last-name"
+                  name="lastName"
+                  label={t(($) => $.personalInformation.lastName)}
+                  className="w-full"
+                  maxLength={100}
+                  aria-description={t(($) => $.personalInformation.nameInstructions)}
+                  autoComplete="family-name"
+                  defaultValue={state?.lastName ?? ''}
+                  errorMessage={errors?.lastName}
+                  required
+                />
+              </div>
+              <Collapsible id="name-instructions" summary={t(($) => $.personalInformation.singleLegalName)}>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.nameInstructions} />
+                </p>
+              </Collapsible>
+              <DatePickerField
+                id="date-of-birth"
+                names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
+                defaultValue={state?.dateOfBirth ?? ''}
+                legend={t(($) => $.personalInformation.dob)}
+                errorMessages={{ all: errors?.dateOfBirth, year: errors?.dateOfBirthYear, month: errors?.dateOfBirthMonth, day: errors?.dateOfBirthDay }}
+                required
+              />
               <InputPatternField
-                id="member-id"
-                name="memberId"
-                label={t(($) => $.personalInformation.memberId)}
+                id="social-insurance-number"
+                name="socialInsuranceNumber"
+                format={sinInputPatternFormat}
+                label={t(($) => $.personalInformation.sin)}
                 inputMode="numeric"
-                format={renewalCodeInputPatternFormat}
-                helpMessagePrimary={t(($) => $.personalInformation.helpMessage.memberId)}
+                helpMessagePrimary={t(($) => $.personalInformation.helpMessage.sin)}
                 helpMessagePrimaryClassName="text-black"
-                defaultValue={state?.memberId ?? ''}
-                errorMessage={errors?.memberId}
-                required
-              />
-            )}
-            <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputSanitizeField
-                id="first-name"
-                name="firstName"
-                label={t(($) => $.personalInformation.firstName)}
-                className="w-full"
-                maxLength={100}
-                aria-description={t(($) => $.personalInformation.nameInstructions)}
-                autoComplete="given-name"
-                defaultValue={state?.firstName ?? ''}
-                errorMessage={errors?.firstName}
-                required
-              />
-              <InputSanitizeField
-                id="last-name"
-                name="lastName"
-                label={t(($) => $.personalInformation.lastName)}
-                className="w-full"
-                maxLength={100}
-                aria-description={t(($) => $.personalInformation.nameInstructions)}
-                autoComplete="family-name"
-                defaultValue={state?.lastName ?? ''}
-                errorMessage={errors?.lastName}
+                defaultValue={state?.socialInsuranceNumber ?? ''}
+                errorMessage={errors?.socialInsuranceNumber}
                 required
               />
             </div>
-            <Collapsible id="name-instructions" summary={t(($) => $.personalInformation.singleLegalName)}>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.personalInformation.nameInstructions} />
-              </p>
-            </Collapsible>
-            <DatePickerField
-              id="date-of-birth"
-              names={{ day: 'dateOfBirthDay', month: 'dateOfBirthMonth', year: 'dateOfBirthYear' }}
-              defaultValue={state?.dateOfBirth ?? ''}
-              legend={t(($) => $.personalInformation.dob)}
-              errorMessages={{ all: errors?.dateOfBirth, year: errors?.dateOfBirthYear, month: errors?.dateOfBirthMonth, day: errors?.dateOfBirthDay }}
-              required
-            />
-            <InputPatternField
-              id="social-insurance-number"
-              name="socialInsuranceNumber"
-              format={sinInputPatternFormat}
-              label={t(($) => $.personalInformation.sin)}
-              inputMode="numeric"
-              helpMessagePrimary={t(($) => $.personalInformation.helpMessage.sin)}
-              helpMessagePrimaryClassName="text-black"
-              defaultValue={state?.socialInsuranceNumber ?? ''}
-              errorMessage={errors?.socialInsuranceNumber}
-              required
-            />
-          </div>
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Applicant information click">
-              {t(($) => $.personalInformation.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={`public/application/$id/your-application`}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Applicant information click"
-            >
-              {t(($) => $.personalInformation.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton id="save-button" variant="primary" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Applicant information click">
+                {t(($) => $.personalInformation.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={`public/application/$id/your-application`}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Applicant information click"
+              >
+                {t(($) => $.personalInformation.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/phone-number.tsx
+++ b/frontend/app/routes/public/application/spokes/phone-number.tsx
@@ -11,6 +11,7 @@ import type { ApplicationFlow } from '~/.server/routes/helpers/public-applicatio
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { phoneSchema } from '~/.server/validation/phone-schema';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -44,7 +45,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.phoneNumber,
-  pageTitleI18nKey: 'applicationSpokes:phoneNumber.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -131,76 +131,79 @@ export default function PhoneNumber({ loaderData, params }: Route.ComponentProps
   const findOffice = <InlineLink to={t(($) => $.phoneNumber.officeLink)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
-            <div className="grid items-end gap-6">
-              <InputPhoneField
-                id="phone-number"
-                name="phoneNumber"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumber ?? ''}
-                errorMessage={errors?.phoneNumber}
-                label={t(($) => $.phoneNumber.phoneNumber)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
-              <InputPhoneField
-                id="phone-number-alt"
-                name="phoneNumberAlt"
-                type="tel"
-                inputMode="tel"
-                className="w-full"
-                autoComplete="tel"
-                defaultValue={defaultState.phoneNumberAlt ?? ''}
-                errorMessage={errors?.phoneNumberAlt}
-                label={t(($) => $.phoneNumber.phoneNumberAlt)}
-                maxLength={100}
-                helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
-                helpMessagePrimaryClassName="text-gray-600"
-              />
+    <>
+      <AppPageTitle>{t(($) => $.phoneNumber.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-6">
+              <p className="mb-4 italic">{t(($) => $.optionalLabel, { ns: 'application' })}</p>
+              <div className="grid items-end gap-6">
+                <InputPhoneField
+                  id="phone-number"
+                  name="phoneNumber"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumber ?? ''}
+                  errorMessage={errors?.phoneNumber}
+                  label={t(($) => $.phoneNumber.phoneNumber)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessage)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+                <InputPhoneField
+                  id="phone-number-alt"
+                  name="phoneNumberAlt"
+                  type="tel"
+                  inputMode="tel"
+                  className="w-full"
+                  autoComplete="tel"
+                  defaultValue={defaultState.phoneNumberAlt ?? ''}
+                  errorMessage={errors?.phoneNumberAlt}
+                  label={t(($) => $.phoneNumber.phoneNumberAlt)}
+                  maxLength={100}
+                  helpMessagePrimary={t(($) => $.phoneNumber.helpMessageAlt)}
+                  helpMessagePrimaryClassName="text-gray-600"
+                />
+              </div>
             </div>
-          </div>
-          <Collapsible summary={t(($) => $.phoneNumber.dontHaveNumber)}>
-            <div className="space-y-6">
-              <section className="space-y-4">
-                <p>{t(($) => $.phoneNumber.needPhoneNumber)}</p>
-                <ul className="list-disc space-y-1 pl-7">
-                  <li>
-                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.serviceCanada} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
-                  </li>
-                  <li>
-                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.inPerson} components={{ findOffice }} />
-                  </li>
-                </ul>
-              </section>
+            <Collapsible summary={t(($) => $.phoneNumber.dontHaveNumber)}>
+              <div className="space-y-6">
+                <section className="space-y-4">
+                  <p>{t(($) => $.phoneNumber.needPhoneNumber)}</p>
+                  <ul className="list-disc space-y-1 pl-7">
+                    <li>
+                      <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.serviceCanada} components={{ noWrap: <span className="whitespace-nowrap" /> }} />
+                    </li>
+                    <li>
+                      <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.phoneNumber.inPerson} components={{ findOffice }} />
+                    </li>
+                  </ul>
+                </section>
+              </div>
+            </Collapsible>
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Phone number click">
+                {t(($) => $.phoneNumber.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId={getRouteFromApplicationFlow(applicationFlow)}
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Phone number click"
+              >
+                {t(($) => $.phoneNumber.backBtn)}
+              </ButtonLink>
             </div>
-          </Collapsible>
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Phone number click">
-              {t(($) => $.phoneNumber.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId={getRouteFromApplicationFlow(applicationFlow)}
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Phone number click"
-            >
-              {t(($) => $.phoneNumber.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/renewal-submitted.tsx
+++ b/frontend/app/routes/public/application/spokes/renewal-submitted.tsx
@@ -7,6 +7,7 @@ import type { Route } from './+types/renewal-submitted';
 import { TYPES } from '~/.server/constants';
 import { clearPublicApplicationState, getPublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { InlineLink } from '~/components/inline-link';
@@ -21,7 +22,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.protected.application.spokes.renewalSubmitted,
-  pageTitleI18nKey: 'applicationSpokes:renewalSubmitted.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -62,32 +62,35 @@ export default function RenewalApplicationSubmitted({ loaderData, params }: Rout
   const mscaLinkAccount = <InlineLink to={t(($) => $.renewalSubmitted.mscaLinkAccount)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <div className="mb-6 space-y-4">
-        <p>{t(($) => $.renewalSubmitted.recordsShowApplicationSubmitted)}</p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.statusCheckerInfo} components={{ statusCheckerLink }} />
-        </p>
-        <p>
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.updateProfileInfo} components={{ mscaLinkAccount, noWrap }} />
-        </p>
+    <>
+      <AppPageTitle>{t(($) => $.renewalSubmitted.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="mb-6 space-y-4">
+          <p>{t(($) => $.renewalSubmitted.recordsShowApplicationSubmitted)}</p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.statusCheckerInfo} components={{ statusCheckerLink }} />
+          </p>
+          <p>
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.renewalSubmitted.updateProfileInfo} components={{ mscaLinkAccount, noWrap }} />
+          </p>
+        </div>
+        <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
+          <CsrfTokenInput />
+          <ButtonLink
+            variant="secondary"
+            type="button"
+            routeId="public/application/$id/personal-information"
+            params={params}
+            disabled={isSubmitting}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Renewal application submitted click"
+          >
+            {t(($) => $.renewalSubmitted.backBtn)}
+          </ButtonLink>
+          <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Renewal application submitted click">
+            {t(($) => $.renewalSubmitted.exitBtn)}
+          </LoadingButton>
+        </fetcher.Form>
       </div>
-      <fetcher.Form method="post" noValidate className="flex flex-wrap items-center gap-3">
-        <CsrfTokenInput />
-        <ButtonLink
-          variant="secondary"
-          type="button"
-          routeId="public/application/$id/personal-information"
-          params={params}
-          disabled={isSubmitting}
-          data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Renewal application submitted click"
-        >
-          {t(($) => $.renewalSubmitted.backBtn)}
-        </ButtonLink>
-        <LoadingButton type="submit" variant="primary" id="proceed-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Exit - Renewal application submitted click">
-          {t(($) => $.renewalSubmitted.exitBtn)}
-        </LoadingButton>
-      </fetcher.Form>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/tax-filing.tsx
+++ b/frontend/app/routes/public/application/spokes/tax-filing.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -25,7 +26,10 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const TAX_FILING_OPTION = { no: 'no', yes: 'yes' } as const;
 
-export const handle = { i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'), pageIdentifier: pageIds.public.application.spokes.taxFiling, pageTitleI18nKey: 'application:taxFiling.pageTitle' } as const satisfies RouteHandleData;
+export const handle = {
+  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  pageIdentifier: pageIds.public.application.spokes.taxFiling,
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 
@@ -77,51 +81,54 @@ export default function ApplicationTaxFiling({ loaderData, params }: Route.Compo
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="tax-filing"
-            name="hasFiledTaxes"
-            legend={t(($) => $.taxFiling.formInstructions, {
-              taxYear: taxYear,
-              ns: 'application',
-            })}
-            options={[
-              {
-                value: TAX_FILING_OPTION.yes,
-                children: t(($) => $.taxFiling.radioOptions.yes),
-                defaultChecked: defaultState === true,
-              },
-              {
-                value: TAX_FILING_OPTION.no,
-                children: t(($) => $.taxFiling.radioOptions.no),
-                defaultChecked: defaultState === false,
-              },
-            ]}
-            errorMessage={errors?.hasFiledTaxes}
-            required
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Tax filing click">
-              {t(($) => $.taxFiling.saveBtn)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="public/application/$id/eligibility-requirements"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Tax filing click"
-            >
-              {t(($) => $.taxFiling.backBtn)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.taxFiling.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="tax-filing"
+              name="hasFiledTaxes"
+              legend={t(($) => $.taxFiling.formInstructions, {
+                taxYear: taxYear,
+                ns: 'application',
+              })}
+              options={[
+                {
+                  value: TAX_FILING_OPTION.yes,
+                  children: t(($) => $.taxFiling.radioOptions.yes),
+                  defaultChecked: defaultState === true,
+                },
+                {
+                  value: TAX_FILING_OPTION.no,
+                  children: t(($) => $.taxFiling.radioOptions.no),
+                  defaultChecked: defaultState === false,
+                },
+              ]}
+              errorMessage={errors?.hasFiledTaxes}
+              required
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Tax filing click">
+                {t(($) => $.taxFiling.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="public/application/$id/eligibility-requirements"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Tax filing click"
+              >
+                {t(($) => $.taxFiling.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/terms-conditions.tsx
+++ b/frontend/app/routes/public/application/spokes/terms-conditions.tsx
@@ -11,6 +11,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -45,7 +46,6 @@ const CONSENT_CHECKBOXES = [CHECKBOX_IDS.ACKNOWLEDGE_TERMS, CHECKBOX_IDS.ACKNOWL
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.termsConditions,
-  pageTitleI18nKey: 'applicationSpokes:termsConditions.pageHeading',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -189,182 +189,185 @@ export default function ApplyIndex({ loaderData, params }: Route.ComponentProps)
   const cite = <cite />;
 
   return (
-    <div className="max-w-prose">
-      <div className="space-y-6">
-        <h2 className="font-bold">{t(($) => $.termsConditions.beforeYouBegin)}</h2>
-        <ul className="list-disc space-y-1 pl-7">
-          <li>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.reviewConfirm} components={{ eligibilityRequirements }} />
-          </li>
-          <li>{t(($) => $.termsConditions.resolveActions)}</li>
-          <li>{t(($) => $.termsConditions.reviewStatements)}</li>
-        </ul>
-        <Collapsible summary={t(($) => $.termsConditions.termsAndConditionsOfUse.summary)}>
-          <div className="space-y-6">
-            <div className="space-y-4">
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplicationLegalTerms} components={{ canadaTermsConditions }} />
-              </p>
-              <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.esdcDefinitionClarification)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.termsConditions.pageHeading)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div className="space-y-6">
+          <h2 className="font-bold">{t(($) => $.termsConditions.beforeYouBegin)}</h2>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.reviewConfirm} components={{ eligibilityRequirements }} />
+            </li>
+            <li>{t(($) => $.termsConditions.resolveActions)}</li>
+            <li>{t(($) => $.termsConditions.reviewStatements)}</li>
+          </ul>
+          <Collapsible summary={t(($) => $.termsConditions.termsAndConditionsOfUse.summary)}>
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplicationLegalTerms} components={{ canadaTermsConditions }} />
+                </p>
+                <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.esdcDefinitionClarification)}</p>
+              </div>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.heading)}</h2>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.selfAgreement)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.timeout)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.incorrectInformation)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.onBehalfOfSomeoneElse)}</li>
+                  <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.atYourOwnRisk)}</li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.msdc} components={{ microsoftDataPrivacyPolicy }} />
+                  </li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.antibot} components={{ hcaptchaTermsOfService }} />
+                  </li>
+                </ul>
+              </section>
+              <section className="space-y-4">
+                <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
+              </section>
             </div>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.heading)}</h2>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.selfAgreement)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.timeout)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.incorrectInformation)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.onBehalfOfSomeoneElse)}</li>
-                <li>{t(($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.atYourOwnRisk)}</li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.msdc} components={{ microsoftDataPrivacyPolicy }} />
-                </li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.termsAndConditionsOfUse.onlineApplication.antibot} components={{ hcaptchaTermsOfService }} />
-                </li>
-              </ul>
-            </section>
-            <section className="space-y-4">
-              <p>{t(($) => $.termsConditions.termsAndConditionsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
-            </section>
-          </div>
-        </Collapsible>
+          </Collapsible>
 
-        <Collapsible summary={t(($) => $.termsConditions.privacyNoticeStatement.summary)}>
-          <div className="space-y-6">
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.heading)}</h2>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaApplicationAdministration)}</p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaInformationCollection)}</p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.participation} components={{ contactServiceCanada }} />
-              </p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.policyAnalysis)}</p>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.digitalCommunications)}</p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.collectionUse} components={{ cite }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.microsoftPolicy} components={{ microsoftDataPrivacyPolicy, cite }} />
-              </p>
-            </section>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.heading)}</h2>
-              <p>{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationRightsAndAccess)}</p>
-              <ul className="list-disc space-y-1 pl-7">
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.hcPpu440} components={{ hcPib }} />
-                </li>
-                <li>
-                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.esdcPpu712} components={{ esdcPib }} />
-                </li>
-              </ul>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.infoSourceAccess} components={{ infosource }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyContact} components={{ contactServiceCanada }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationHandlingComplaintProcess} components={{ fileacomplaint }} />
-              </p>
-              <p>
-                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyProtection} components={{ cdcpPrivacyPolicy }} />
-              </p>
-            </section>
-          </div>
-        </Collapsible>
-        <Collapsible summary={t(($) => $.termsConditions.sharingYourInformation.summary)}>
-          <div className="space-y-6">
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.heading)}</h2>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.shareInfo)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.policyAnalysis)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sendLetters)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.discloseInfo)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sunLifeAuthorization)}</p>
-            </section>
-            <section className="space-y-4">
-              <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.heading)}</h2>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.enrolConsent)}</p>
-              <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.consideredMinor)}</p>
-            </section>
-          </div>
-        </Collapsible>
+          <Collapsible summary={t(($) => $.termsConditions.privacyNoticeStatement.summary)}>
+            <div className="space-y-6">
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.heading)}</h2>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaApplicationAdministration)}</p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.serviceCanadaInformationCollection)}</p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.participation} components={{ contactServiceCanada }} />
+                </p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.policyAnalysis)}</p>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.personalInformation.digitalCommunications)}</p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.collectionUse} components={{ cite }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.personalInformation.microsoftPolicy} components={{ microsoftDataPrivacyPolicy, cite }} />
+                </p>
+              </section>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.heading)}</h2>
+                <p>{t(($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationRightsAndAccess)}</p>
+                <ul className="list-disc space-y-1 pl-7">
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.hcPpu440} components={{ hcPib }} />
+                  </li>
+                  <li>
+                    <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationBanks.esdcPpu712} components={{ esdcPib }} />
+                  </li>
+                </ul>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.infoSourceAccess} components={{ infosource }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyContact} components={{ contactServiceCanada }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.personalInformationHandlingComplaintProcess} components={{ fileacomplaint }} />
+                </p>
+                <p>
+                  <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.privacyNoticeStatement.howWeProtectYourPrivacy.privacyProtection} components={{ cdcpPrivacyPolicy }} />
+                </p>
+              </section>
+            </div>
+          </Collapsible>
+          <Collapsible summary={t(($) => $.termsConditions.sharingYourInformation.summary)}>
+            <div className="space-y-6">
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.heading)}</h2>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.shareInfo)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.policyAnalysis)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sendLetters)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.discloseInfo)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.governmentOfCanadaAndSunLife.sunLifeAuthorization)}</p>
+              </section>
+              <section className="space-y-4">
+                <h2 className="font-lato text-lg font-bold">{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.heading)}</h2>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.enrolConsent)}</p>
+                <p>{t(($) => $.termsConditions.sharingYourInformation.sharingOfInformationAndOralHealthProviders.consideredMinor)}</p>
+              </section>
+            </div>
+          </Collapsible>
+        </div>
+        <p className="my-8" id="application-consent">
+          {t(($) => $.termsConditions.apply.applicationConsent)}
+        </p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <ErrorSummary />
+            <div className="space-y-2">
+              <InputCheckbox
+                id="acknowledge-terms"
+                name={CHECKBOX_IDS.ACKNOWLEDGE_TERMS}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_TERMS]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_TERMS, e.target.checked)}
+                errorMessage={errors?.acknowledgeTerms}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.acknowledgeTerms)}
+              </InputCheckbox>
+
+              <InputCheckbox
+                id="acknowledge-privacy"
+                name={CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, e.target.checked)}
+                errorMessage={errors?.acknowledgePrivacy}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.acknowledgePrivacy)}
+              </InputCheckbox>
+
+              <InputCheckbox
+                id="share-data"
+                name={CHECKBOX_IDS.SHARE_DATA}
+                value={CHECKBOX_VALUE.yes}
+                checked={checkboxState[CHECKBOX_IDS.SHARE_DATA]}
+                onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.SHARE_DATA, e.target.checked)}
+                errorMessage={errors?.shareData}
+                required
+              >
+                {t(($) => $.termsConditions.checkboxes.shareData)}
+              </InputCheckbox>
+            </div>
+
+            <InputCheckbox
+              id="do-not-consent"
+              name={CHECKBOX_IDS.DO_NOT_CONSENT}
+              value={CHECKBOX_VALUE.yes}
+              className="my-8"
+              checked={checkboxState[CHECKBOX_IDS.DO_NOT_CONSENT]}
+              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.DO_NOT_CONSENT, e.target.checked)}
+              errorMessage={errors?.doNotConsent}
+            >
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.checkboxes.doNotConsent} />
+            </InputCheckbox>
+
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton aria-describedby="application-consent" variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Terms and Conditions click">
+                {t(($) => $.termsConditions.apply.continueButton)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="public/application/$id/eligibility-requirements"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Terms and Conditions click"
+              >
+                {t(($) => $.termsConditions.apply.backButton)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
       </div>
-      <p className="my-8" id="application-consent">
-        {t(($) => $.termsConditions.apply.applicationConsent)}
-      </p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <ErrorSummary />
-          <div className="space-y-2">
-            <InputCheckbox
-              id="acknowledge-terms"
-              name={CHECKBOX_IDS.ACKNOWLEDGE_TERMS}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_TERMS]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_TERMS, e.target.checked)}
-              errorMessage={errors?.acknowledgeTerms}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.acknowledgeTerms)}
-            </InputCheckbox>
-
-            <InputCheckbox
-              id="acknowledge-privacy"
-              name={CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, e.target.checked)}
-              errorMessage={errors?.acknowledgePrivacy}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.acknowledgePrivacy)}
-            </InputCheckbox>
-
-            <InputCheckbox
-              id="share-data"
-              name={CHECKBOX_IDS.SHARE_DATA}
-              value={CHECKBOX_VALUE.yes}
-              checked={checkboxState[CHECKBOX_IDS.SHARE_DATA]}
-              onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.SHARE_DATA, e.target.checked)}
-              errorMessage={errors?.shareData}
-              required
-            >
-              {t(($) => $.termsConditions.checkboxes.shareData)}
-            </InputCheckbox>
-          </div>
-
-          <InputCheckbox
-            id="do-not-consent"
-            name={CHECKBOX_IDS.DO_NOT_CONSENT}
-            value={CHECKBOX_VALUE.yes}
-            className="my-8"
-            checked={checkboxState[CHECKBOX_IDS.DO_NOT_CONSENT]}
-            onChange={(e) => handleCheckboxChange(CHECKBOX_IDS.DO_NOT_CONSENT, e.target.checked)}
-            errorMessage={errors?.doNotConsent}
-          >
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsConditions.checkboxes.doNotConsent} />
-          </InputCheckbox>
-
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton aria-describedby="application-consent" variant="primary" id="continue-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Terms and Conditions click">
-              {t(($) => $.termsConditions.apply.continueButton)}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="public/application/$id/eligibility-requirements"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Terms and Conditions click"
-            >
-              {t(($) => $.termsConditions.apply.backButton)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/type-application.tsx
+++ b/frontend/app/routes/public/application/spokes/type-application.tsx
@@ -9,6 +9,7 @@ import { TYPES } from '~/.server/constants';
 import { getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -26,9 +27,8 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children', delegate: 'delegate' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'applicationSpokes', 'gcweb'),
+  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.typeOfApplication,
-  pageTitleI18nKey: 'applicationSpokes:typeOfApplication.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -38,7 +38,7 @@ export async function loader({ context: { appContainer, session }, params, reque
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   const meta = {
-    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.typeOfApplication.pageTitle, { ns: 'applicationSpokes' }) }),
+    title: t(($) => $.meta.title.template, { ns: 'gcweb', title: t(($) => $.typeOfApplication.pageTitle) }),
   };
 
   return { meta, defaultState: state.typeOfApplication };
@@ -57,7 +57,7 @@ export async function action({ context: { appContainer, session }, params, reque
    */
   const typeOfApplicationSchema = z.object({
     typeOfApplication: z.enum(APPLICANT_TYPE, {
-      error: t(($) => $.typeOfApplication.errorMessage.typeOfApplicationRequired, { ns: 'applicationSpokes' }),
+      error: t(($) => $.typeOfApplication.errorMessage.typeOfApplicationRequired),
     }),
   });
 
@@ -86,42 +86,45 @@ export default function ApplicationTypeOfApplication({ loaderData, params }: Rou
   const errors = fetcher.data?.errors;
 
   return (
-    <div className="max-w-prose">
-      <p className="mt-8 mb-4 italic">{t(($) => $.requiredLabel)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <InputRadios
-            id="type-of-application"
-            name="typeOfApplication"
-            legend={t(($) => $.typeOfApplication.formInstructions, { ns: 'applicationSpokes' })}
-            options={[
-              { value: APPLICANT_TYPE.adult, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personal} />, defaultChecked: defaultState === APPLICANT_TYPE.adult },
-              { value: APPLICANT_TYPE.children, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.child} />, defaultChecked: defaultState === APPLICANT_TYPE.children },
-              { value: APPLICANT_TYPE.family, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personalAndChild} />, defaultChecked: defaultState === APPLICANT_TYPE.family },
-              { value: APPLICANT_TYPE.delegate, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.delegate} />, defaultChecked: defaultState === APPLICANT_TYPE.delegate },
-            ]}
-            required
-            errorMessage={errors?.typeOfApplication}
-          />
-          <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Type of application click">
-              {t(($) => $.typeOfApplication.saveBtn, { ns: 'applicationSpokes' })}
-            </LoadingButton>
-            <ButtonLink
-              id="back-button"
-              variant="secondary"
-              routeId="public/application/$id/your-application"
-              params={params}
-              disabled={isSubmitting}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Type of application click"
-            >
-              {t(($) => $.typeOfApplication.backBtn, { ns: 'applicationSpokes' })}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.typeOfApplication.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mt-8 mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <InputRadios
+              id="type-of-application"
+              name="typeOfApplication"
+              legend={t(($) => $.typeOfApplication.formInstructions)}
+              options={[
+                { value: APPLICANT_TYPE.adult, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personal} />, defaultChecked: defaultState === APPLICANT_TYPE.adult },
+                { value: APPLICANT_TYPE.children, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.child} />, defaultChecked: defaultState === APPLICANT_TYPE.children },
+                { value: APPLICANT_TYPE.family, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.personalAndChild} />, defaultChecked: defaultState === APPLICANT_TYPE.family },
+                { value: APPLICANT_TYPE.delegate, children: <Trans ns="applicationSpokes" i18nKey={($) => $.typeOfApplication.radioOptions.delegate} />, defaultChecked: defaultState === APPLICANT_TYPE.delegate },
+              ]}
+              required
+              errorMessage={errors?.typeOfApplication}
+            />
+            <div className="mt-8 flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton variant="primary" id="save-button" loading={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Save - Type of application click">
+                {t(($) => $.typeOfApplication.saveBtn)}
+              </LoadingButton>
+              <ButtonLink
+                id="back-button"
+                variant="secondary"
+                routeId="public/application/$id/your-application"
+                params={params}
+                disabled={isSubmitting}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Type of application click"
+              >
+                {t(($) => $.typeOfApplication.backBtn)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/application/spokes/verify-email.tsx
+++ b/frontend/app/routes/public/application/spokes/verify-email.tsx
@@ -12,6 +12,7 @@ import { getPublicApplicationState, savePublicApplicationState, validateApplicat
 import type { ApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button, ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { Dialog, DialogClose, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
@@ -53,7 +54,6 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
   pageIdentifier: pageIds.public.application.spokes.verifyEmail,
-  pageTitleI18nKey: 'applicationSpokes:verifyEmail.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -228,92 +228,93 @@ export default function ApplicationVerifyEmail({ loaderData, params }: Route.Com
   );
 
   return (
-    <div className="max-w-prose">
-      <ErrorAlert>
-        <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
-        <p className="-mb-3">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.verificationCodeAlert.detail} components={{ requestLink }} />
-        </p>
-      </ErrorAlert>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <p className="mb-4">
-          {t(($) => $.verifyEmail.verificationCode, {
-            email: defaultState,
-            ns: 'applicationSpokes',
-          })}
-        </p>
-        <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
-        <p className="mb-8">
-          <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
-        </p>
-        <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
-        <ErrorSummary />
-        <fetcher.Form method="post" noValidate>
-          <CsrfTokenInput />
-          <div className="mb-6">
-            <div className="grid items-end gap-6 md:grid-cols-2">
-              <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
-            </div>
-            <LoadingButton
-              id="request-button"
-              type="button"
-              name="_action"
-              variant="link"
-              className="no-underline hover:underline"
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.request}
-              value={FORM_ACTION.request}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Request new verification code - Verify email click"
-              onClick={async () => {
-                const formData = new FormData();
-                formData.append('_action', FORM_ACTION.request);
-                formData.append('_csrf', csrfToken);
-
-                await fetcher.submit(formData, { method: 'post' });
-              }}
-            >
-              {t(($) => $.verifyEmail.requestNewCode)}
-            </LoadingButton>
-          </div>
-
-          <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
-            <LoadingButton
-              variant="primary"
-              id="continue-button"
-              name="_action"
-              value={FORM_ACTION.submit}
-              disabled={isSubmitting}
-              loading={isSubmitting && submittedAction === FORM_ACTION.submit}
-              data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Verify email click"
-            >
-              {t(($) => $.verifyEmail.continue)}
-            </LoadingButton>
-            <ButtonLink id="back-button" variant="secondary" routeId="public/application/$id/email" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Verify email click">
-              {t(($) => $.verifyEmail.back)}
-            </ButtonLink>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-      <Dialog open={showDialog} onOpenChange={setShowDialog}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
-          </DialogHeader>
-          <DialogDescription>
-            {t(($) => $.verifyEmail.codeSent.detail, {
+    <>
+      <AppPageTitle>{t(($) => $.verifyEmail.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <ErrorAlert>
+          <h2 className="mb-2 font-bold">{t(($) => $.verifyEmail.verificationCodeAlert.heading)}</h2>
+          <p className="-mb-3">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.verificationCodeAlert.detail} components={{ requestLink }} />
+          </p>
+        </ErrorAlert>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <p className="mb-4">
+            {t(($) => $.verifyEmail.verificationCode, {
               email: defaultState,
-              ns: 'applicationSpokes',
             })}
-          </DialogDescription>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Modal Continue - Verify email click">
+          </p>
+          <p className="mb-4">{t(($) => $.verifyEmail.requestNew)}</p>
+          <p className="mb-8">
+            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.verifyEmail.unableToVerify} components={{ communicationLink }} />
+          </p>
+          <p className="mb-4 italic">{t(($) => $.requiredLabel, { ns: 'application' })}</p>
+          <ErrorSummary />
+          <fetcher.Form method="post" noValidate>
+            <CsrfTokenInput />
+            <div className="mb-6">
+              <div className="grid items-end gap-6 md:grid-cols-2">
+                <InputField id="verification-code" name="verificationCode" className="w-full" errorMessage={errors?.verificationCode} label={t(($) => $.verifyEmail.verificationCodeLabel)} inputMode="numeric" required />
+              </div>
+              <LoadingButton
+                id="request-button"
+                type="button"
+                name="_action"
+                variant="link"
+                className="no-underline hover:underline"
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.request}
+                value={FORM_ACTION.request}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Request new verification code - Verify email click"
+                onClick={async () => {
+                  const formData = new FormData();
+                  formData.append('_action', FORM_ACTION.request);
+                  formData.append('_csrf', csrfToken);
+
+                  await fetcher.submit(formData, { method: 'post' });
+                }}
+              >
+                {t(($) => $.verifyEmail.requestNewCode)}
+              </LoadingButton>
+            </div>
+
+            <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">
+              <LoadingButton
+                variant="primary"
+                id="continue-button"
+                name="_action"
+                value={FORM_ACTION.submit}
+                disabled={isSubmitting}
+                loading={isSubmitting && submittedAction === FORM_ACTION.submit}
+                data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Continue - Verify email click"
+              >
                 {t(($) => $.verifyEmail.continue)}
-              </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+              </LoadingButton>
+              <ButtonLink id="back-button" variant="secondary" routeId="public/application/$id/email" params={params} disabled={isSubmitting} data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Back - Verify email click">
+                {t(($) => $.verifyEmail.back)}
+              </ButtonLink>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+        <Dialog open={showDialog} onOpenChange={setShowDialog}>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>{t(($) => $.verifyEmail.codeSent.heading)}</DialogTitle>
+            </DialogHeader>
+            <DialogDescription>
+              {t(($) => $.verifyEmail.codeSent.detail, {
+                email: defaultState,
+              })}
+            </DialogDescription>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button id="modal-continue" disabled={isSubmitting} variant="primary" size="sm" data-gc-analytics-customclick="ESDC-EDSC:CDCP Online Application Form-Spoke:Modal Continue - Verify email click">
+                  {t(($) => $.verifyEmail.continue)}
+                </Button>
+              </DialogClose>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -15,6 +15,7 @@ import { TYPES } from '~/.server/constants';
 import { getStatusResultUrl, saveStatusState, startStatusState } from '~/.server/routes/helpers/status-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
@@ -47,7 +48,6 @@ const CHILD_HAS_SIN = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
   pageIdentifier: pageIds.public.status.child,
-  pageTitleI18nKey: 'status:child.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -281,88 +281,91 @@ export default function StatusCheckerChild({ loaderData, params }: Route.Compone
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.child.form.completeFields)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
-          <CsrfTokenInput />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
-          <div className="mb-8 space-y-6">
-            <InputPatternField
-              id="code"
-              name="code"
-              format={applicationCodeInputPatternFormat}
-              label={t(($) => $.child.form.applicationCodeLabel)}
-              inputMode="numeric"
-              helpMessagePrimary={t(($) => $.child.form.applicationCodeDescription)}
-              required
-              errorMessage={errors?.code}
-              defaultValue=""
-            />
-            <InputRadios
-              id="child-has-sin"
-              name="childHasSin"
-              legend={t(($) => $.child.form.radioLegend)}
-              options={[
-                {
-                  value: CHILD_HAS_SIN.yes,
-                  children: <Trans ns="status" i18nKey={($) => $.child.form.optionYes} />,
-                  onChange: handleOnChildHasSinChanged,
-                },
-                {
-                  value: CHILD_HAS_SIN.no,
-                  children: <Trans ns="status" i18nKey={($) => $.child.form.optionNo} />,
-                  onChange: handleOnChildHasSinChanged,
-                },
-              ]}
-              errorMessage={errors?.childHasSin}
-              required
-            />
-            {childHasSinState === true && (
-              <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.child.form.sinLabel)} helpMessagePrimary={t(($) => $.child.form.sinDescription)} required errorMessage={errors?.sin} defaultValue="" />
-            )}
-            {childHasSinState === false && (
-              <>
-                <Collapsible summary={t(($) => $.child.form.ifChildSummary)} className="mt-8">
-                  <div className="space-y-4">
-                    <p>{t(($) => $.child.form.ifChildDesc)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.child.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.child.form.completeFields)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+            <CsrfTokenInput />
+            {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
+            <div className="mb-8 space-y-6">
+              <InputPatternField
+                id="code"
+                name="code"
+                format={applicationCodeInputPatternFormat}
+                label={t(($) => $.child.form.applicationCodeLabel)}
+                inputMode="numeric"
+                helpMessagePrimary={t(($) => $.child.form.applicationCodeDescription)}
+                required
+                errorMessage={errors?.code}
+                defaultValue=""
+              />
+              <InputRadios
+                id="child-has-sin"
+                name="childHasSin"
+                legend={t(($) => $.child.form.radioLegend)}
+                options={[
+                  {
+                    value: CHILD_HAS_SIN.yes,
+                    children: <Trans ns="status" i18nKey={($) => $.child.form.optionYes} />,
+                    onChange: handleOnChildHasSinChanged,
+                  },
+                  {
+                    value: CHILD_HAS_SIN.no,
+                    children: <Trans ns="status" i18nKey={($) => $.child.form.optionNo} />,
+                    onChange: handleOnChildHasSinChanged,
+                  },
+                ]}
+                errorMessage={errors?.childHasSin}
+                required
+              />
+              {childHasSinState === true && (
+                <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.child.form.sinLabel)} helpMessagePrimary={t(($) => $.child.form.sinDescription)} required errorMessage={errors?.sin} defaultValue="" />
+              )}
+              {childHasSinState === false && (
+                <>
+                  <Collapsible summary={t(($) => $.child.form.ifChildSummary)} className="mt-8">
+                    <div className="space-y-4">
+                      <p>{t(($) => $.child.form.ifChildDesc)}</p>
+                    </div>
+                  </Collapsible>
+                  <div className="grid items-end gap-6 md:grid-cols-2">
+                    <InputSanitizeField id="first-name" name="firstName" label={t(($) => $.child.form.firstName)} className="w-full" maxLength={100} aria-describedby="name-instructions" required errorMessage={errors?.firstName} defaultValue="" />
+                    <InputSanitizeField id="last-name" name="lastName" label={t(($) => $.child.form.lastName)} className="w-full" maxLength={100} aria-describedby="name-instructions" required errorMessage={errors?.lastName} defaultValue="" />
                   </div>
-                </Collapsible>
-                <div className="grid items-end gap-6 md:grid-cols-2">
-                  <InputSanitizeField id="first-name" name="firstName" label={t(($) => $.child.form.firstName)} className="w-full" maxLength={100} aria-describedby="name-instructions" required errorMessage={errors?.firstName} defaultValue="" />
-                  <InputSanitizeField id="last-name" name="lastName" label={t(($) => $.child.form.lastName)} className="w-full" maxLength={100} aria-describedby="name-instructions" required errorMessage={errors?.lastName} defaultValue="" />
-                </div>
-                <DatePickerField
-                  id="date-of-birth"
-                  names={{
-                    day: 'dateOfBirthDay',
-                    month: 'dateOfBirthMonth',
-                    year: 'dateOfBirthYear',
-                  }}
-                  defaultValue=""
-                  legend={t(($) => $.child.form.dateOfBirthLabel)}
-                  required
-                  errorMessages={{
-                    all: errors?.dateOfBirth,
-                    year: errors?.dateOfBirthYear,
-                    month: errors?.dateOfBirthMonth,
-                    day: errors?.dateOfBirthDay,
-                  }}
-                />
-              </>
-            )}
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" variant="secondary" routeId="public/status/index" params={params} startIcon={faChevronLeft} disabled={isSubmitting}>
-              {t(($) => $.child.form.backBtn)}
-            </ButtonLink>
-            <LoadingButton variant="primary" id="submit" loading={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
-              {t(($) => $.child.form.submit)}
-            </LoadingButton>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+                  <DatePickerField
+                    id="date-of-birth"
+                    names={{
+                      day: 'dateOfBirthDay',
+                      month: 'dateOfBirthMonth',
+                      year: 'dateOfBirthYear',
+                    }}
+                    defaultValue=""
+                    legend={t(($) => $.child.form.dateOfBirthLabel)}
+                    required
+                    errorMessages={{
+                      all: errors?.dateOfBirth,
+                      year: errors?.dateOfBirthYear,
+                      month: errors?.dateOfBirthMonth,
+                      day: errors?.dateOfBirthDay,
+                    }}
+                  />
+                </>
+              )}
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <ButtonLink id="back-button" variant="secondary" routeId="public/status/index" params={params} startIcon={faChevronLeft} disabled={isSubmitting}>
+                {t(($) => $.child.form.backBtn)}
+              </ButtonLink>
+              <LoadingButton variant="primary" id="submit" loading={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
+                {t(($) => $.child.form.submit)}
+              </LoadingButton>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -10,6 +10,7 @@ import type { Route } from './+types/index';
 import { TYPES } from '~/.server/constants';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Collapsible } from '~/components/collapsible';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -35,7 +36,6 @@ const CHECK_FOR = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
   pageIdentifier: pageIds.public.status.index,
-  pageTitleI18nKey: 'status:pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -118,89 +118,92 @@ export default function StatusChecker({ loaderData, params }: Route.ComponentPro
   const canadaTermsConditions = <InlineLink to={t(($) => $.links.canadaTermsConditions)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
-    <div className="max-w-prose">
-      <div>
-        <h2 className="font-bold">{t(($) => $.statusCheckerHeading)}</h2>
-        <p className="mb-4">{t(($) => $.statusCheckerContent)}</p>
-        <h2 className="font-bold">{t(($) => $.onlineStatusHeading)}</h2>
-        <p className="mb-4">{t(($) => $.onlineStatusContent)}</p>
-        <p className="mb-4">{t(($) => $.termsConditions)}</p>
-      </div>
-      <Collapsible summary={t(($) => $.termsOfUse.summary)} className="mt-8">
-        <div className="space-y-4">
-          <h2 className="mb-4 font-bold">{t(($) => $.termsOfUse.heading)}</h2>
-          <p>{t(($) => $.termsOfUse.thankYou)}</p>
-          <p>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.legalTerms} components={{ canadaTermsConditions }} />
-          </p>
-          <p>{t(($) => $.termsOfUse.accessTerms)}</p>
-          <p>{t(($) => $.termsOfUse.maintenance)}</p>
-          <p>{t(($) => $.termsOfUse.inactive)}</p>
-          <p>{t(($) => $.termsOfUse.termsRejectionPolicy)}</p>
+    <>
+      <AppPageTitle>{t(($) => $.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <div>
+          <h2 className="font-bold">{t(($) => $.statusCheckerHeading)}</h2>
+          <p className="mb-4">{t(($) => $.statusCheckerContent)}</p>
+          <h2 className="font-bold">{t(($) => $.onlineStatusHeading)}</h2>
+          <p className="mb-4">{t(($) => $.onlineStatusContent)}</p>
+          <p className="mb-4">{t(($) => $.termsConditions)}</p>
+        </div>
+        <Collapsible summary={t(($) => $.termsOfUse.summary)} className="mt-8">
+          <div className="space-y-4">
+            <h2 className="mb-4 font-bold">{t(($) => $.termsOfUse.heading)}</h2>
+            <p>{t(($) => $.termsOfUse.thankYou)}</p>
+            <p>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.legalTerms} components={{ canadaTermsConditions }} />
+            </p>
+            <p>{t(($) => $.termsOfUse.accessTerms)}</p>
+            <p>{t(($) => $.termsOfUse.maintenance)}</p>
+            <p>{t(($) => $.termsOfUse.inactive)}</p>
+            <p>{t(($) => $.termsOfUse.termsRejectionPolicy)}</p>
 
-          <p>{t(($) => $.termsOfUse.esdcDefinitionClarification)}</p>
-          <p className="font-bold">{t(($) => $.termsOfUse.statusChecker.heading)}</p>
-          <ul className="list-disc space-y-1 pl-7">
-            <li>{t(($) => $.termsOfUse.statusChecker.selfAgreement)}</li>
-            <li>{t(($) => $.termsOfUse.statusChecker.onBehalfOfSomeoneElse)}</li>
-            <li>{t(($) => $.termsOfUse.statusChecker.atYourOwnRisk)}</li>
-            <li>{t(($) => $.termsOfUse.statusChecker.onlyUse)}</li>
-            <li>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.statusChecker.msdc} components={{ microsoftServiceAgreement }} />
-            </li>
-            <li>
-              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.statusChecker.antibot} components={{ hcaptchaTermsOfService }} />
-            </li>
-          </ul>
-          <h2 className="font-bold">{t(($) => $.termsOfUse.changesToTheseTermsOfUse.heading)}</h2>
-          <p>{t(($) => $.termsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
-        </div>
-      </Collapsible>
-      <Collapsible summary={t(($) => $.privacyNoticeStatement.summary)} className="my-8">
-        <div className="space-y-4">
-          <p>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.collectionOfUse} components={{ cite: <cite /> }} />
-          </p>
-          <p>{t(($) => $.privacyNoticeStatement.providedInformation)}</p>
-          <p>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.thirdPartyProvider} components={{ microsoftDataPrivacyPolicy }} />
-          </p>
-          <p>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.personalInformation} components={{ cite: <cite /> }} />
-          </p>
-          <p>
-            <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.reportAConcern} components={{ fileacomplaint }} />
-          </p>
-        </div>
-      </Collapsible>
-      <p className="mb-4 italic">{t(($) => $.form.completeFields)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
-          <CsrfTokenInput />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
-          <InputRadios
-            id="status-check-for"
-            name="statusCheckFor"
-            legend={t(($) => $.form.radioLegend)}
-            options={[
-              {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.form.radioText.myself} />,
-                value: CHECK_FOR.myself,
-              },
-              {
-                children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.form.radioText.child} />,
-                value: CHECK_FOR.child,
-              },
-            ]}
-            required
-            errorMessage={errors?.checkFor}
-          />
-          <LoadingButton variant="primary" id="submit" loading={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
-            {t(($) => $.form.continue)}
-          </LoadingButton>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+            <p>{t(($) => $.termsOfUse.esdcDefinitionClarification)}</p>
+            <p className="font-bold">{t(($) => $.termsOfUse.statusChecker.heading)}</p>
+            <ul className="list-disc space-y-1 pl-7">
+              <li>{t(($) => $.termsOfUse.statusChecker.selfAgreement)}</li>
+              <li>{t(($) => $.termsOfUse.statusChecker.onBehalfOfSomeoneElse)}</li>
+              <li>{t(($) => $.termsOfUse.statusChecker.atYourOwnRisk)}</li>
+              <li>{t(($) => $.termsOfUse.statusChecker.onlyUse)}</li>
+              <li>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.statusChecker.msdc} components={{ microsoftServiceAgreement }} />
+              </li>
+              <li>
+                <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.termsOfUse.statusChecker.antibot} components={{ hcaptchaTermsOfService }} />
+              </li>
+            </ul>
+            <h2 className="font-bold">{t(($) => $.termsOfUse.changesToTheseTermsOfUse.heading)}</h2>
+            <p>{t(($) => $.termsOfUse.changesToTheseTermsOfUse.esdcTermsAmendmentPolicy)}</p>
+          </div>
+        </Collapsible>
+        <Collapsible summary={t(($) => $.privacyNoticeStatement.summary)} className="my-8">
+          <div className="space-y-4">
+            <p>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.collectionOfUse} components={{ cite: <cite /> }} />
+            </p>
+            <p>{t(($) => $.privacyNoticeStatement.providedInformation)}</p>
+            <p>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.thirdPartyProvider} components={{ microsoftDataPrivacyPolicy }} />
+            </p>
+            <p>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.personalInformation} components={{ cite: <cite /> }} />
+            </p>
+            <p>
+              <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.privacyNoticeStatement.reportAConcern} components={{ fileacomplaint }} />
+            </p>
+          </div>
+        </Collapsible>
+        <p className="mb-4 italic">{t(($) => $.form.completeFields)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+            <CsrfTokenInput />
+            {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
+            <InputRadios
+              id="status-check-for"
+              name="statusCheckFor"
+              legend={t(($) => $.form.radioLegend)}
+              options={[
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.form.radioText.myself} />,
+                  value: CHECK_FOR.myself,
+                },
+                {
+                  children: <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.form.radioText.child} />,
+                  value: CHECK_FOR.child,
+                },
+              ]}
+              required
+              errorMessage={errors?.checkFor}
+            />
+            <LoadingButton variant="primary" id="submit" loading={isSubmitting} className="my-8" data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
+              {t(($) => $.form.continue)}
+            </LoadingButton>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/status/myself.tsx
+++ b/frontend/app/routes/public/status/myself.tsx
@@ -12,6 +12,7 @@ import { TYPES } from '~/.server/constants';
 import { getStatusResultUrl, saveStatusState, startStatusState } from '~/.server/routes/helpers/status-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { ErrorSummary } from '~/components/error-summary';
@@ -34,7 +35,6 @@ import { extractDigits } from '~/utils/string-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
   pageIdentifier: pageIds.public.status.myself,
-  pageTitleI18nKey: 'status:myself.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -148,37 +148,40 @@ export default function StatusCheckerMyself({ loaderData, params }: Route.Compon
   }
 
   return (
-    <div className="max-w-prose">
-      <p className="mb-4 italic">{t(($) => $.myself.form.completeFields)}</p>
-      <ErrorSummaryProvider actionData={fetcher.data}>
-        <ErrorSummary />
-        <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
-          <CsrfTokenInput />
-          {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
-          <div className="mb-8 space-y-6">
-            <InputPatternField
-              id="code"
-              name="code"
-              format={applicationCodeInputPatternFormat}
-              label={t(($) => $.myself.form.applicationCodeLabel)}
-              inputMode="numeric"
-              helpMessagePrimary={t(($) => $.myself.form.applicationCodeDescription)}
-              required
-              errorMessage={errors?.code}
-              defaultValue=""
-            />
-            <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.myself.form.sinLabel)} helpMessagePrimary={t(($) => $.myself.form.sinDescription)} required errorMessage={errors?.sin} defaultValue="" />
-          </div>
-          <div className="flex flex-wrap items-center gap-3">
-            <ButtonLink id="back-button" variant="secondary" routeId="public/status/index" params={params} startIcon={faChevronLeft} disabled={isSubmitting}>
-              {t(($) => $.myself.form.backBtn)}
-            </ButtonLink>
-            <LoadingButton variant="primary" id="submit" loading={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
-              {t(($) => $.myself.form.submit)}
-            </LoadingButton>
-          </div>
-        </fetcher.Form>
-      </ErrorSummaryProvider>
-    </div>
+    <>
+      <AppPageTitle>{t(($) => $.myself.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose">
+        <p className="mb-4 italic">{t(($) => $.myself.form.completeFields)}</p>
+        <ErrorSummaryProvider actionData={fetcher.data}>
+          <ErrorSummary />
+          <fetcher.Form method="post" onSubmit={handleSubmit} noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+            <CsrfTokenInput />
+            {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={HCAPTCHA_SITE_KEY} ref={captchaRef} />}
+            <div className="mb-8 space-y-6">
+              <InputPatternField
+                id="code"
+                name="code"
+                format={applicationCodeInputPatternFormat}
+                label={t(($) => $.myself.form.applicationCodeLabel)}
+                inputMode="numeric"
+                helpMessagePrimary={t(($) => $.myself.form.applicationCodeDescription)}
+                required
+                errorMessage={errors?.code}
+                defaultValue=""
+              />
+              <InputPatternField id="sin" name="sin" format={sinInputPatternFormat} label={t(($) => $.myself.form.sinLabel)} helpMessagePrimary={t(($) => $.myself.form.sinDescription)} required errorMessage={errors?.sin} defaultValue="" />
+            </div>
+            <div className="flex flex-wrap items-center gap-3">
+              <ButtonLink id="back-button" variant="secondary" routeId="public/status/index" params={params} startIcon={faChevronLeft} disabled={isSubmitting}>
+                {t(($) => $.myself.form.backBtn)}
+              </ButtonLink>
+              <LoadingButton variant="primary" id="submit" loading={isSubmitting} data-gc-analytics-formsubmit="submit" endIcon={faChevronRight}>
+                {t(($) => $.myself.form.submit)}
+              </LoadingButton>
+            </div>
+          </fetcher.Form>
+        </ErrorSummaryProvider>
+      </div>
+    </>
   );
 }

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -10,6 +10,7 @@ import { TYPES } from '~/.server/constants';
 import { clearStatusState, getStatusStateIdFromUrl, loadStatusState } from '~/.server/routes/helpers/status-route-helpers';
 import { getContextualAlertType } from '~/.server/utils/application-code.utils';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { Button } from '~/components/buttons';
 import { ClientFriendlyStatusMarkdown } from '~/components/client-friendly-status-markdown';
 import { ContextualAlert } from '~/components/contextual-alert';
@@ -30,7 +31,6 @@ const FORM_ACTION = {
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
   pageIdentifier: pageIds.public.status.result,
-  pageTitleI18nKey: 'status:result.pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -88,29 +88,32 @@ export default function StatusCheckerResult({ loaderData, params }: Route.Compon
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
 
   return (
-    <fetcher.Form method="post" noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
-      <CsrfTokenInput />
-      <div className="max-w-prose">
-        {statusResult.clientFriendlyStatus ? (
-          <ContextualAlert type={statusResult.alertType}>
-            <h2 className="mb-2 font-bold">{t(($) => $.result.statusHeading)}</h2>
-            <ClientFriendlyStatusMarkdown content={statusResult.clientFriendlyStatus.name} />
-          </ContextualAlert>
-        ) : (
-          <StatusNotFound />
-        )}
-        <div className="mt-12">
-          <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} variant="primary" endIcon={faChevronRight}>
-            {t(($) => $.result.checkAnother)}
-          </Button>
+    <>
+      <AppPageTitle>{t(($) => $.result.pageTitle)}</AppPageTitle>
+      <fetcher.Form method="post" noValidate autoComplete="off" data-gc-analytics-formname="ESDC-EDSC: Canadian Dental Care Plan Status Checker">
+        <CsrfTokenInput />
+        <div className="max-w-prose">
+          {statusResult.clientFriendlyStatus ? (
+            <ContextualAlert type={statusResult.alertType}>
+              <h2 className="mb-2 font-bold">{t(($) => $.result.statusHeading)}</h2>
+              <ClientFriendlyStatusMarkdown content={statusResult.clientFriendlyStatus.name} />
+            </ContextualAlert>
+          ) : (
+            <StatusNotFound />
+          )}
+          <div className="mt-12">
+            <Button id="cancel-button" name="_action" value={FORM_ACTION.cancel} disabled={isSubmitting} variant="primary" endIcon={faChevronRight}>
+              {t(($) => $.result.checkAnother)}
+            </Button>
+          </div>
+          <div className="mt-6">
+            <Button id="exit-button" name="_action" value={FORM_ACTION.exit} disabled={isSubmitting} className="mt-6" variant="secondary">
+              {t(($) => $.result.exitBtn)}
+            </Button>
+          </div>
         </div>
-        <div className="mt-6">
-          <Button id="exit-button" name="_action" value={FORM_ACTION.exit} disabled={isSubmitting} className="mt-6" variant="secondary">
-            {t(($) => $.result.exitBtn)}
-          </Button>
-        </div>
-      </div>
-    </fetcher.Form>
+      </fetcher.Form>
+    </>
   );
 }
 

--- a/frontend/app/routes/public/unable-to-process-request.tsx
+++ b/frontend/app/routes/public/unable-to-process-request.tsx
@@ -3,6 +3,7 @@ import { Trans, useTranslation } from 'react-i18next';
 import type { Route } from './+types/unable-to-process-request';
 
 import { getFixedT } from '~/.server/utils/locale.utils';
+import { AppPageTitle } from '~/components/app-page-title';
 import { InlineLink } from '~/components/inline-link';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { pageIds } from '~/page-ids';
@@ -14,7 +15,6 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 export const handle = {
   i18nNamespaces: getTypedI18nNamespaces('unableToProcessRequest', 'gcweb'),
   pageIdentifier: pageIds.public.unableToProcessRequest,
-  pageTitleI18nKey: 'unableToProcessRequest:pageTitle',
 } as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
@@ -37,6 +37,7 @@ export default function UnableToProcessRequest({ loaderData, params }: Route.Com
 
   return (
     <PublicLayout>
+      <AppPageTitle>{t(($) => $.pageTitle)}</AppPageTitle>
       <div className="max-w-prose">
         <div className="space-y-4">
           <p>{t(($) => $.unableToProcess)}</p>

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -38,11 +38,6 @@ const buildInfoSchema = z
   })
   .readonly();
 
-const i18nKeySchema = z
-  .custom<ParsedKeysByNamespaces>()
-  .refine((val) => typeof val === 'string' && !validator.isEmpty(val))
-  .readonly();
-
 export const i18nNamespacesSchema = z
   .array(z.custom<FlatNamespace>())
   .refine((arr) => Array.isArray(arr) && arr.every((val) => typeof val === 'string' && !validator.isEmpty(val)))
@@ -60,8 +55,6 @@ export type TransformAdobeAnalyticsUrl = (url: string | URL) => URL;
 
 export type PageIdentifier = z.infer<typeof pageIdentifierSchema>;
 
-export type PageTitleI18nKey = z.infer<typeof i18nKeySchema>;
-
 /**
  * Common data returned from a route's handle object.
  */
@@ -70,7 +63,6 @@ export interface RouteHandleData extends Record<string, unknown | undefined> {
   i18nNamespaces?: I18nNamespaces;
   transformAdobeAnalyticsUrl?: TransformAdobeAnalyticsUrl;
   pageIdentifier?: PageIdentifier;
-  pageTitleI18nKey?: PageTitleI18nKey;
 }
 
 export function useBreadcrumbs() {
@@ -112,21 +104,6 @@ export function usePageIdentifier() {
     .map(({ handle }) => handle as RouteHandleData | undefined)
     .map((handle) => pageIdentifierSchema.safeParse(handle?.pageIdentifier))
     .map((result) => (result.success ? result.data : undefined))
-    .reduce(coalesce);
-}
-
-export function usePageTitleI18nKey() {
-  return useMatches()
-    .map(({ handle }) => handle as RouteHandleData | undefined)
-    .map((handle) => i18nKeySchema.safeParse(handle?.pageTitleI18nKey))
-    .map((result) => (result.success ? result.data : undefined))
-    .reduce(coalesce);
-}
-
-export function usePageTitleI18nOptions() {
-  return useMatches()
-    .map(({ loaderData }) => loaderData as { i18nOptions?: { [key: string]: string } } | undefined)
-    .map((data) => data?.i18nOptions)
     .reduce(coalesce);
 }
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors how page titles are rendered in the application, focusing on improving maintainability and consistency. The main change is to move the `AppPageTitle` component into its own file and update all usage to render page titles explicitly within each page component, rather than as part of the layout. This also removes the logic for determining the page title from route handles and layouts, simplifying the overall approach.

**Component extraction and usage update:**

- Extracted the `AppPageTitle` component into its own file (`app-page-title.tsx`) and updated its implementation to use translation and accessible focus management. All usages of `AppPageTitle` are now explicit in each page component, rather than being handled by the layout. [[1]](diffhunk://#diff-97eb942f2597bfd53a7a438562b6a113360e4ca46a90fd40d79b4891970fa6d6R1-R21) [[2]](diffhunk://#diff-a628df9607ad6d11ff72e139427c9955e9b040984202c3da3eaef61d620f2ffbR67-R68) [[3]](diffhunk://#diff-042f722662be794845600f58d85669f8e8e66f56a86d7b9ab73c7a9fac224113R86-R87) [[4]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67R102-R103) [[5]](diffhunk://#diff-6799521ec868d6d18271aa28a6c11841dfd25432879ea4ef47b3f766a38a3fe9R15)

**Layout and route handle simplification:**

- Removed the `AppPageTitle` rendering and related page title logic from both `ProtectedLayout` and `PublicLayout`. This includes deleting the use of `usePageTitleI18nKey`, `usePageTitleI18nOptions`, and translation logic from these layouts. [[1]](diffhunk://#diff-4c8d307678c68d2a637cf2de0702dc4e2c04b8da9dc995ce0f0b2baa4da59294L21-R26) [[2]](diffhunk://#diff-4c8d307678c68d2a637cf2de0702dc4e2c04b8da9dc995ce0f0b2baa4da59294L35-L45) [[3]](diffhunk://#diff-4c8d307678c68d2a637cf2de0702dc4e2c04b8da9dc995ce0f0b2baa4da59294L54-L66) [[4]](diffhunk://#diff-dc68400e3602636b16a9e075383d33edee5c06ddbfedeffefb0abdf2e74cf931L16-R20) [[5]](diffhunk://#diff-dc68400e3602636b16a9e075383d33edee5c06ddbfedeffefb0abdf2e74cf931L30-L40) [[6]](diffhunk://#diff-dc68400e3602636b16a9e075383d33edee5c06ddbfedeffefb0abdf2e74cf931L49-L61)
- Removed `pageTitleI18nKey` from the `handle` objects in relevant route files, since page titles are now rendered directly in the component. [[1]](diffhunk://#diff-a628df9607ad6d11ff72e139427c9955e9b040984202c3da3eaef61d620f2ffbL26) [[2]](diffhunk://#diff-042f722662be794845600f58d85669f8e8e66f56a86d7b9ab73c7a9fac224113L28) [[3]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67L31)

**Test updates:**

- Added new tests and snapshots for the `AppPageTitle` component to ensure correct rendering and maintain test coverage. [[1]](diffhunk://#diff-5cb9ceff26957c0e0905b6c992d7481169b359e738180da743f26c24dea277a6R1-R16) [[2]](diffhunk://#diff-fa0959433b0660b49255e10186de3b202f33dd96c76786a23850e56feabd53e1R1-R23)
- Removed obsolete tests related to the old page title logic in `route-utils.test.tsx`.
- Cleaned up unused imports in test and layout files. [[1]](diffhunk://#diff-f850b298a17fb735579667572f5d4355e81a355123cf564af605fb3b52abea2fL8-R8) [[2]](diffhunk://#diff-4c8d307678c68d2a637cf2de0702dc4e2c04b8da9dc995ce0f0b2baa4da59294L1-R1) [[3]](diffhunk://#diff-dc68400e3602636b16a9e075383d33edee5c06ddbfedeffefb0abdf2e74cf931L2-R2)

**Page component updates:**

- Updated all affected page components to render the `AppPageTitle` directly with the appropriate translated title, ensuring consistency and explicitness in page structure. [[1]](diffhunk://#diff-a628df9607ad6d11ff72e139427c9955e9b040984202c3da3eaef61d620f2ffbR67-R68) [[2]](diffhunk://#diff-a628df9607ad6d11ff72e139427c9955e9b040984202c3da3eaef61d620f2ffbR171) [[3]](diffhunk://#diff-042f722662be794845600f58d85669f8e8e66f56a86d7b9ab73c7a9fac224113R86-R87) [[4]](diffhunk://#diff-042f722662be794845600f58d85669f8e8e66f56a86d7b9ab73c7a9fac224113R140) [[5]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67R102-R103) [[6]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67R205)

These changes make the handling of page titles more explicit and maintainable, reducing coupling between routing, layouts, and content components.