### PR TITLE
refactor(frontend): i18n namespace route handle

### DIFF
--- a/frontend/__tests__/utils/locale-utils.test.ts
+++ b/frontend/__tests__/utils/locale-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { APP_LOCALES, getAltLanguage, getLanguage, getNamespaces, getTypedI18nNamespaces, isAppLocale, removeLanguageFromPath, useAppLocale } from '~/utils/locale-utils';
+import { APP_LOCALES, getAltLanguage, getLanguage, getNamespaces, isAppLocale, removeLanguageFromPath, useAppLocale } from '~/utils/locale-utils';
 
 /*
  * @vitest-environment jsdom
@@ -79,27 +79,6 @@ describe('locale-utils', () => {
     it('should return a unique array of namespaces from route handles', () => {
       const routes = [{ handle: { i18nNamespaces: ['namespace1', 'namespace2'] } }, { handle: { i18nNamespaces: ['namespace2', 'namespace3'] } }];
       expect(getNamespaces(routes)).toEqual(['namespace1', 'namespace2', 'namespace3']);
-    });
-
-    it('should handle undefined or invalid i18nNamespaces', () => {
-      const routes: Array<{ handle?: unknown }> = [
-        { handle: { i18nNamespaces: undefined } },
-        { handle: { i18nNamespaces: 'invalid' } }, // Invalid type
-        { handle: { i18nNamespaces: ['namespace1'] } },
-      ];
-
-      expect(getNamespaces(routes)).toEqual(['namespace1']);
-    });
-  });
-
-  describe('getTypedI18nNamespaces', () => {
-    it('should return a typed tuple of namespaces', () => {
-      const result = getTypedI18nNamespaces('common', 'gcweb', 'unableToProcessRequest');
-      expect(result).toEqual(['common', 'gcweb', 'unableToProcessRequest']);
-
-      type ExpectedType = readonly ['common', 'gcweb', 'unableToProcessRequest'];
-      const typedResult: ExpectedType = result; // No TypeScript error
-      expect(typedResult).toEqual(['common', 'gcweb', 'unableToProcessRequest']);
     });
   });
 

--- a/frontend/app/components/layouts/protected-layout.tsx
+++ b/frontend/app/components/layouts/protected-layout.tsx
@@ -22,10 +22,11 @@ import { useBrowserCompatiblityBanner } from '~/hooks';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
-import { getTypedI18nNamespaces, translateFromKey } from '~/utils/locale-utils';
+import { translateFromKey } from '~/utils/locale-utils';
 import { useBreadcrumbs } from '~/utils/route-utils';
+import type { I18nNamespaces } from '~/utils/route-utils';
 
-export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
+export const i18nNamespaces = ['gcweb'] satisfies I18nNamespaces;
 
 /**
  * GCWeb Application page template.

--- a/frontend/app/components/layouts/public-layout.tsx
+++ b/frontend/app/components/layouts/public-layout.tsx
@@ -17,9 +17,9 @@ import { useBrowserCompatiblityBanner, useCurrentLanguage } from '~/hooks';
 import { useFeature } from '~/root';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
 import { getClientEnv } from '~/utils/env-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import type { I18nNamespaces } from '~/utils/route-utils';
 
-export const i18nNamespaces = getTypedI18nNamespaces('gcweb');
+export const i18nNamespaces = ['gcweb'] satisfies I18nNamespaces;
 
 /**
  * GCWeb Application page template.

--- a/frontend/app/components/session-timeout.tsx
+++ b/frontend/app/components/session-timeout.tsx
@@ -8,9 +8,9 @@ import { useIdleTimer } from 'react-idle-timer';
 
 import { Button } from '~/components/buttons';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '~/components/dialog';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
+import type { I18nNamespaces } from '~/utils/route-utils';
 
-const i18nNamespaces = getTypedI18nNamespaces('gcweb');
+const i18nNamespaces = ['gcweb'] satisfies I18nNamespaces;
 
 export interface SessionTimeoutProps extends Required<Pick<IIdleTimerProps, 'promptBeforeIdle' | 'timeout'>> {
   /**

--- a/frontend/app/routes/language-chooser.tsx
+++ b/frontend/app/routes/language-chooser.tsx
@@ -1,13 +1,12 @@
 import type { Route } from './+types/language-chooser';
 
 import { ButtonLink } from '~/components/buttons';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getDescriptionMetaTags, getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('gcweb'),
+  i18nNamespaces: ['gcweb'],
 } as const satisfies RouteHandleData;
 
 // Meta tags are constructed for a bilingual page.

--- a/frontend/app/routes/protected/application/entry/eligibility-requirements.tsx
+++ b/frontend/app/routes/protected/application/entry/eligibility-requirements.tsx
@@ -16,13 +16,12 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.eligibilityRequirements,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/entry/renew.tsx
+++ b/frontend/app/routes/protected/application/entry/renew.tsx
@@ -18,13 +18,12 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.typeOfApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/entry/your-application.tsx
+++ b/frontend/app/routes/protected/application/entry/your-application.tsx
@@ -18,7 +18,6 @@ import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -27,7 +26,7 @@ import { formatSin } from '~/utils/sin-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.typeOfApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/index.tsx
+++ b/frontend/app/routes/protected/application/index.tsx
@@ -16,7 +16,6 @@ import { AppPageTitle } from '~/components/app-page-title';
 import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -24,7 +23,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { secondsToMilliseconds } from '~/utils/units.utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.index,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/contact-information.tsx
@@ -19,13 +19,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/dental-insurance.tsx
@@ -17,13 +17,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/marital-status.tsx
@@ -17,14 +17,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeAdult.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -24,7 +24,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-children/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb', 'common'),
+  i18nNamespaces: ['protectedApplicationIntakeChild', 'protectedApplication', 'gcweb', 'common'],
   pageIdentifier: pageIds.protected.application.intakeChild.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-children/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeChild.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-children/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeChild.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/intake-children/parent-or-guardian.tsx
@@ -18,14 +18,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeChild.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-children/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-children/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeChild.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -24,7 +24,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb', 'common'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb', 'common'],
   pageIdentifier: pageIds.protected.application.intakeFamily.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-family/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/intake-family/contact-information.tsx
@@ -19,13 +19,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/intake-family/dental-insurance.tsx
@@ -17,13 +17,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/exit-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/intake-family/marital-status.tsx
@@ -17,14 +17,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/intake-family/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-family/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationIntakeFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.intakeFamily.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/layout.tsx
+++ b/frontend/app/routes/protected/application/layout.tsx
@@ -19,7 +19,6 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/adobe-analytics-route-helpers';
 import { useApiProtectedApplicationState } from '~/utils/api-protected-application-state.utils';
 import { useApiSession } from '~/utils/api-session-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { removeTrailingSlash } from '~/utils/url-utils';
@@ -27,7 +26,7 @@ import { removeTrailingSlash } from '~/utils/url-utils';
 export const handle = {
   // Declare all i18n namespaces required by this route and its descendants.
   // Preloading them upfront ensures translations are available on initial render.
-  i18nNamespaces: getTypedI18nNamespaces(
+  i18nNamespaces: [
     ...layoutI18nNamespaces,
     'common',
     'protectedApplication',
@@ -38,7 +37,7 @@ export const handle = {
     'protectedApplicationRenewalChild',
     'protectedApplicationRenewalFamily',
     'protectedApplicationSpokes',
-  ),
+  ],
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -31,14 +31,13 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/contact-information.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/contact-information.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +36,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/dental-insurance.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +34,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/marital-status.tsx
@@ -19,7 +19,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalAdult', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalAdult.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ type ClientDentalBenefits = {
 const FORM_ACTION = { DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb', 'common'),
+  i18nNamespaces: ['protectedApplicationRenewalChild', 'protectedApplication', 'gcweb', 'common'],
   pageIdentifier: pageIds.protected.application.renewalChild.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -32,14 +32,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalChild.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-children/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalChild.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/parent-or-guardian.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,7 +37,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalChild.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-children/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalChild', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalChild.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ type ClientDentalBenefits = {
 const FORM_ACTION = { DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb', 'common'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb', 'common'],
   pageIdentifier: pageIds.protected.application.renewalFamily.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -33,14 +33,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/contact-information.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/contact-information.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -37,7 +36,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/dental-insurance.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +34,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/exit-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/marital-status.tsx
@@ -19,7 +19,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-family/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationRenewalFamily', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalFamily.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/renewal-submitted.tsx
+++ b/frontend/app/routes/protected/application/renewal-submitted.tsx
@@ -12,13 +12,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.renewalSubmitted,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/application-delegate.tsx
+++ b/frontend/app/routes/protected/application/spokes/application-delegate.tsx
@@ -14,13 +14,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.applicationDelegate,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/cannot-apply-child.tsx
+++ b/frontend/app/routes/protected/application/spokes/cannot-apply-child.tsx
@@ -13,13 +13,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.cannotApplyChild,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/child-dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-dental-insurance.tsx
@@ -22,9 +22,9 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const CHECKBOX_VALUE = {
@@ -37,9 +37,9 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.childDentalInsurance,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
   return getTitleMetaTags(loaderData.meta.title, loaderData.meta.dcTermsTitle);

--- a/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -23,9 +23,9 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const HAS_FEDERAL_BENEFITS_OPTION = {
@@ -39,9 +39,9 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.childFederalProvincialTerritorialBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
   return getTitleMetaTags(loaderData.meta.title, loaderData.meta.dcTermsTitle);

--- a/frontend/app/routes/protected/application/spokes/child-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-information.tsx
@@ -30,7 +30,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -44,7 +43,7 @@ const YES_NO_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.childInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/child-parent-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-parent-guardian.tsx
@@ -13,13 +13,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.childParentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
@@ -19,7 +19,6 @@ import { InputPatternField } from '~/components/input-pattern-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.childSocialInsuranceNumber,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/protected/application/spokes/communication-preferences.tsx
@@ -24,9 +24,9 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
@@ -44,9 +44,9 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.communicationPreferences,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/application/spokes/dental-insurance-exit-application.tsx
+++ b/frontend/app/routes/protected/application/spokes/dental-insurance-exit-application.tsx
@@ -13,13 +13,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.dentalInsuranceExitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/dental-insurance.tsx
+++ b/frontend/app/routes/protected/application/spokes/dental-insurance.tsx
@@ -23,9 +23,9 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const CHECKBOX_VALUE = {
@@ -38,9 +38,9 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.dentalInsurance,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/application/spokes/email.tsx
+++ b/frontend/app/routes/protected/application/spokes/email.tsx
@@ -20,7 +20,6 @@ import { InputField } from '~/components/input-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -41,7 +40,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.email,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/protected/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -23,9 +23,9 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const HAS_FEDERAL_BENEFITS_OPTION = {
@@ -39,9 +39,9 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.federalProvincialTerritorialBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/application/spokes/file-taxes.tsx
+++ b/frontend/app/routes/protected/application/spokes/file-taxes.tsx
@@ -14,13 +14,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.fileYourTaxes,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/home-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/home-address.tsx
@@ -27,7 +27,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -55,7 +54,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.homeAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/living-independently.tsx
+++ b/frontend/app/routes/protected/application/spokes/living-independently.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -30,7 +29,7 @@ const LIVING_INDEPENDENTLY_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.livingIndependently,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/protected/application/spokes/mailing-address.tsx
@@ -28,7 +28,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -56,7 +55,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.mailingAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -27,7 +27,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -49,7 +48,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/protected/application/spokes/new-or-returning-member.tsx
@@ -25,7 +25,6 @@ import type { InputRadiosProps } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ import { extractDigits } from '~/utils/string-utils';
 const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.newOrReturningMember,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/parent-guardian.tsx
@@ -17,7 +17,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -29,7 +28,7 @@ const YES_NO_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.parentGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/parent-or-guardian.tsx
+++ b/frontend/app/routes/protected/application/spokes/parent-or-guardian.tsx
@@ -14,14 +14,13 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -24,7 +24,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -33,7 +32,7 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.personalInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/phone-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/phone-number.tsx
@@ -22,7 +22,6 @@ import { InputPhoneField } from '~/components/input-phone-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -43,7 +42,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.phoneNumber,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
+++ b/frontend/app/routes/protected/application/spokes/renewal-selection.tsx
@@ -26,14 +26,13 @@ import { InputCheckboxes } from '~/components/input-checkboxes';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.renewalSelection,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/tax-filing.tsx
+++ b/frontend/app/routes/protected/application/spokes/tax-filing.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const TAX_FILING_OPTION = { no: 'no', yes: 'yes' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.taxFiling,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/terms-conditions.tsx
+++ b/frontend/app/routes/protected/application/spokes/terms-conditions.tsx
@@ -22,7 +22,6 @@ import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -44,7 +43,7 @@ type CheckboxId = (typeof CHECKBOX_IDS)[keyof typeof CHECKBOX_IDS];
 const CONSENT_CHECKBOXES = [CHECKBOX_IDS.ACKNOWLEDGE_TERMS, CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, CHECKBOX_IDS.SHARE_DATA] as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.termsConditions,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/type-application.tsx
+++ b/frontend/app/routes/protected/application/spokes/type-application.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children', delegate: 'delegate' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.typeOfApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/application/spokes/verify-email.tsx
+++ b/frontend/app/routes/protected/application/spokes/verify-email.tsx
@@ -25,7 +25,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useCsrfToken } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -52,7 +51,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedApplicationSpokes', 'protectedApplication', 'gcweb'),
+  i18nNamespaces: ['protectedApplicationSpokes', 'protectedApplication', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.verifyEmail,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/data-unavailable.tsx
+++ b/frontend/app/routes/protected/data-unavailable.tsx
@@ -9,13 +9,12 @@ import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('dataUnavailable', 'gcweb'),
+  i18nNamespaces: ['dataUnavailable', 'gcweb'],
   pageIdentifier: pageIds.protected.dataUnavailable,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/documents/index.tsx
+++ b/frontend/app/routes/protected/documents/index.tsx
@@ -11,13 +11,12 @@ import { ButtonLink } from '~/components/buttons';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '~/components/table';
 import { pageIds } from '~/page-ids';
 import { parseDateTimeString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
+  i18nNamespaces: ['documents', 'gcweb'],
   pageIdentifier: pageIds.protected.documents.index,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/documents/not-required.tsx
+++ b/frontend/app/routes/protected/documents/not-required.tsx
@@ -8,14 +8,13 @@ import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'documents:index.pageTitle', routeId: 'protected/documents/index' }],
-  i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
+  i18nNamespaces: ['documents', 'gcweb'],
   pageIdentifier: pageIds.protected.documents.notRequired,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -33,7 +33,7 @@ import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import { getClientEnv } from '~/utils/env-utils';
 import { arrayBufferToBase64, getFileExtension, getMimeType } from '~/utils/file.utils';
-import { getLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getLanguage } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -49,7 +49,7 @@ type DocumentUploadSchemaErrorTree = z.core.$ZodErrorTree<DocumentUploadSchemaOu
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'documents:index.pageTitle', routeId: 'protected/documents/index' }],
-  i18nNamespaces: getTypedI18nNamespaces('documents', 'gcweb'),
+  i18nNamespaces: ['documents', 'gcweb'],
   pageIdentifier: pageIds.protected.documents.upload,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/letters/index.tsx
+++ b/frontend/app/routes/protected/letters/index.tsx
@@ -18,14 +18,14 @@ import { InlineLink } from '~/components/inline-link';
 import { InputSelect } from '~/components/input-select';
 import { useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getNameByLanguage, getTypedI18nNamespaces } from '~/utils/locale-utils';
+import { getNameByLanguage } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'letters:index.pageTitle' }],
-  i18nNamespaces: getTypedI18nNamespaces('letters', 'gcweb'),
+  i18nNamespaces: ['letters', 'gcweb'],
   pageIdentifier: pageIds.protected.letters.index,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/applicant-information.tsx
+++ b/frontend/app/routes/protected/profile/applicant-information.tsx
@@ -8,14 +8,13 @@ import { AppPageTitle } from '~/components/app-page-title';
 import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.applicantInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/communication-preferences.tsx
@@ -9,14 +9,14 @@ import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.communicationPreferences,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/profile/contact-information.tsx
+++ b/frontend/app/routes/protected/profile/contact-information.tsx
@@ -14,14 +14,14 @@ import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.contactInformation,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/profile/dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/dental-benefits.tsx
@@ -9,14 +9,14 @@ import { ButtonLink } from '~/components/buttons';
 import { DefinitionList, DefinitionListItem } from '~/components/definition-list';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.dentalBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-child-dental-benefits.tsx
@@ -22,7 +22,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/adobe-analytics-route-helpers';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:editChildDentalBenefits.breadcrumb', routeId: 'protected/profile/dental-benefits' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   transformAdobeAnalyticsUrl,
   pageIdentifier: pageIds.protected.profile.editChildDentalBenefits,
 } as const satisfies RouteHandleData;

--- a/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
+++ b/frontend/app/routes/protected/profile/edit-communication-preferences.tsx
@@ -26,7 +26,6 @@ import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
 import type { ProfileEmailContext } from '~/routes/protected/profile/email';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:communicationPreferences.pageTitle', routeId: 'protected/profile/communication-preferences' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.editCommunicationPreferences,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
+++ b/frontend/app/routes/protected/profile/edit-dental-benefits.tsx
@@ -21,9 +21,9 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const FORM_ACTION = {
@@ -44,9 +44,9 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:editDentalBenefits.breadcrumb', routeId: 'protected/profile/dental-benefits' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.editDentalBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
   return getTitleMetaTags(loaderData.meta.title, loaderData.meta.dcTermsTitle);

--- a/frontend/app/routes/protected/profile/eligibility.tsx
+++ b/frontend/app/routes/protected/profile/eligibility.tsx
@@ -15,13 +15,12 @@ import { DefinitionList, DefinitionListItem } from '~/components/definition-list
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.eligibility,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/email.tsx
+++ b/frontend/app/routes/protected/profile/email.tsx
@@ -18,7 +18,6 @@ import { InputField } from '~/components/input-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -60,7 +59,7 @@ function requireProfileEmailContext({ request, params }: Pick<Route.LoaderArgs |
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.email,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/home-address.tsx
+++ b/frontend/app/routes/protected/profile/home-address.tsx
@@ -25,7 +25,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -41,7 +40,7 @@ const FORM_ACTION = {
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.editHomeAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/mailing-address.tsx
+++ b/frontend/app/routes/protected/profile/mailing-address.tsx
@@ -26,7 +26,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -42,7 +41,7 @@ const FORM_ACTION = {
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.editMailingAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/phone-number.tsx
+++ b/frontend/app/routes/protected/profile/phone-number.tsx
@@ -18,7 +18,6 @@ import { InputPhoneField } from '~/components/input-phone-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -26,7 +25,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
   breadcrumbs: [{ labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' }],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.phoneNumber,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/profile/verify-email.tsx
+++ b/frontend/app/routes/protected/profile/verify-email.tsx
@@ -24,7 +24,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import type { ProfileEmailContext } from '~/routes/protected/profile/email';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -50,7 +49,7 @@ export const handle = {
     { labelI18nKey: 'protectedProfile:contactInformation.pageTitle', routeId: 'protected/profile/contact-information' },
     { labelI18nKey: 'protectedProfile:email.pageTitle', routeId: 'protected/profile/contact/email-address' },
   ],
-  i18nNamespaces: getTypedI18nNamespaces('protectedProfile', 'gcweb'),
+  i18nNamespaces: ['protectedProfile', 'gcweb'],
   pageIdentifier: pageIds.protected.profile.verifyEmail,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/stub-login.tsx
+++ b/frontend/app/routes/protected/stub-login.tsx
@@ -17,7 +17,6 @@ import { ErrorSummaryProvider } from '~/components/error-summary-context';
 import { InputField } from '~/components/input-field';
 import { InputPatternField } from '~/components/input-pattern-field';
 import { InputSelect } from '~/components/input-select';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -25,7 +24,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('stubLogin', 'gcweb'),
+  i18nNamespaces: ['stubLogin', 'gcweb'],
   pageIdentifier: 'CDCP-00XX',
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/protected/unable-to-process-request.tsx
+++ b/frontend/app/routes/protected/unable-to-process-request.tsx
@@ -8,13 +8,12 @@ import type { IdToken } from '~/.server/utils/raoidc.utils';
 import { AppPageTitle } from '~/components/app-page-title';
 import { InlineLink } from '~/components/inline-link';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('unableToProcessRequest', 'gcweb'),
+  i18nNamespaces: ['unableToProcessRequest', 'gcweb'],
   pageIdentifier: pageIds.protected.unableToProcessRequest,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/entry/eligibility-requirements.tsx
+++ b/frontend/app/routes/public/application/entry/eligibility-requirements.tsx
@@ -13,13 +13,12 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  i18nNamespaces: ['application', 'gcweb'],
   pageIdentifier: pageIds.public.application.eligibilityRequirements,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/entry/your-application.tsx
+++ b/frontend/app/routes/public/application/entry/your-application.tsx
@@ -18,7 +18,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber } from '~/utils/application-code-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -28,7 +27,7 @@ import { cn } from '~/utils/tw-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  i18nNamespaces: ['application', 'gcweb'],
   pageIdentifier: pageIds.public.application.typeOfApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/contact-information.tsx
+++ b/frontend/app/routes/public/application/full-adult/contact-information.tsx
@@ -19,13 +19,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/full-adult/dental-insurance.tsx
@@ -17,13 +17,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-adult/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-adult/marital-status.tsx
@@ -17,14 +17,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-adult/submit.tsx
+++ b/frontend/app/routes/public/application/full-adult/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullAdult.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -24,7 +24,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-children/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb', 'common'),
+  i18nNamespaces: ['applicationFullChild', 'application', 'gcweb', 'common'],
   pageIdentifier: pageIds.public.application.fullChild.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullChild.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-children/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-children/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullChild.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/full-children/parent-or-guardian.tsx
@@ -18,14 +18,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullChild.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-children/submit.tsx
+++ b/frontend/app/routes/public/application/full-children/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullChild.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -24,7 +24,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb', 'common'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb', 'common'],
   pageIdentifier: pageIds.public.application.fullFamily.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -20,14 +20,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/contact-information.tsx
+++ b/frontend/app/routes/public/application/full-family/contact-information.tsx
@@ -19,13 +19,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/full-family/dental-insurance.tsx
@@ -17,13 +17,12 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/exit-application.tsx
+++ b/frontend/app/routes/public/application/full-family/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/marital-status.tsx
+++ b/frontend/app/routes/public/application/full-family/marital-status.tsx
@@ -17,14 +17,13 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/full-family/submit.tsx
+++ b/frontend/app/routes/public/application/full-family/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationFullFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationFullFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.fullFamily.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/index.tsx
+++ b/frontend/app/routes/public/application/index.tsx
@@ -13,7 +13,6 @@ import { AppPageTitle } from '~/components/app-page-title';
 import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { getCurrentDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -21,7 +20,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 import { secondsToMilliseconds } from '~/utils/units.utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  i18nNamespaces: ['application', 'gcweb'],
   pageIdentifier: pageIds.public.application.index,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/layout.tsx
+++ b/frontend/app/routes/public/application/layout.tsx
@@ -18,7 +18,6 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { transformAdobeAnalyticsUrl } from '~/route-helpers/adobe-analytics-route-helpers';
 import { useApiApplicationState } from '~/utils/api-application-state-utils';
 import { useApiSession } from '~/utils/api-session-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { removeTrailingSlash } from '~/utils/url-utils';
@@ -26,8 +25,8 @@ import { removeTrailingSlash } from '~/utils/url-utils';
 export const handle = {
   // Declare all i18n namespaces required by this route and its descendants.
   // Preloading them upfront ensures translations are available on initial render.
-  i18nNamespaces: getTypedI18nNamespaces(
-    ...layoutI18nNamespaces,
+  i18nNamespaces: [
+    ...layoutI18nNamespaces, //
     'common',
     'application',
     'applicationFullAdult',
@@ -37,7 +36,7 @@ export const handle = {
     'applicationSimplifiedChild',
     'applicationSimplifiedFamily',
     'applicationSpokes',
-  ),
+  ],
   transformAdobeAnalyticsUrl,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
@@ -31,14 +31,13 @@ import { useApplicationFlowStorage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedAdult.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-adult/contact-information.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/contact-information.tsx
@@ -26,7 +26,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,7 +37,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedAdult.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/dental-insurance.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +34,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedAdult.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-adult/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedAdult.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-adult/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-adult/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedAdult', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedAdult', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedAdult.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -25,7 +25,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-children/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove', DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb', 'common'),
+  i18nNamespaces: ['applicationSimplifiedChild', 'application', 'gcweb', 'common'],
   pageIdentifier: pageIds.public.application.simplifiedChild.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-children/confirmation.tsx
@@ -32,14 +32,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedChild.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-children/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedChild.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-children/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/simplified-children/parent-or-guardian.tsx
@@ -24,7 +24,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -36,7 +35,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedChild.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-children/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-children/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-children/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedChild', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedChild', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedChild.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -25,7 +25,6 @@ import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-family/progress-stepper';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
 import { generateId } from '~/utils/id.utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ import { formatSin } from '~/utils/sin-utils';
 const FORM_ACTION = { add: 'add', remove: 'remove', DENTAL_BENEFITS_NOT_CHANGED: 'dental-benefits-not-changed' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb', 'common'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb', 'common'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.childApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-family/confirmation.tsx
@@ -33,14 +33,13 @@ import { useApplicationFlowStorage, useCurrentLanguage } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { formatClientNumber, formatSubmissionApplicationCode } from '~/utils/application-code-utils';
 import { parseDateString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 import { formatSin } from '~/utils/sin-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.confirmation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/contact-information.tsx
+++ b/frontend/app/routes/public/application/simplified-family/contact-information.tsx
@@ -26,7 +26,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -38,7 +37,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.contactInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/simplified-family/dental-insurance.tsx
@@ -25,7 +25,6 @@ import { StatusTag } from '~/components/status-tag';
 import { useSectionsStatus } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
@@ -35,7 +34,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.dentalInsurance,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/exit-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/exit-application.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.exitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/simplified-family/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-family/submit.tsx
@@ -24,7 +24,6 @@ import { NavigationButtonLink } from '~/components/navigation-buttons';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { ProgressStepper } from '~/routes/public/application/simplified-family/progress-stepper';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ const CHECKBOX_VALUE = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSimplifiedFamily', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSimplifiedFamily', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.simplifiedFamily.submit,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/application-delegate.tsx
+++ b/frontend/app/routes/public/application/spokes/application-delegate.tsx
@@ -14,13 +14,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.applicationDelegate,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/cannot-apply-child.tsx
+++ b/frontend/app/routes/public/application/spokes/cannot-apply-child.tsx
@@ -15,13 +15,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.cannotApplyChild,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/child-dental-insurance.tsx
+++ b/frontend/app/routes/public/application/spokes/child-dental-insurance.tsx
@@ -22,9 +22,9 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const CHECKBOX_VALUE = {
@@ -37,9 +37,9 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.childDentalInsurance,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
   return getTitleMetaTags(loaderData.meta.title, loaderData.meta.dcTermsTitle);

--- a/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/child-federal-provincial-territorial-benefits.tsx
@@ -23,9 +23,9 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const HAS_FEDERAL_BENEFITS_OPTION = {
@@ -39,9 +39,9 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.childFederalProvincialTerritorialBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => {
   return getTitleMetaTags(loaderData.meta.title, loaderData.meta.dcTermsTitle);

--- a/frontend/app/routes/public/application/spokes/child-information.tsx
+++ b/frontend/app/routes/public/application/spokes/child-information.tsx
@@ -32,7 +32,6 @@ import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ const YES_NO_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.childInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/child-parent-guardian.tsx
+++ b/frontend/app/routes/public/application/spokes/child-parent-guardian.tsx
@@ -13,13 +13,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.childParentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/communication-preferences.tsx
+++ b/frontend/app/routes/public/application/spokes/communication-preferences.tsx
@@ -25,9 +25,9 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import * as adobeAnalytics from '~/utils/adobe-analytics.client';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
@@ -45,9 +45,9 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.communicationPreferences,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/public/application/spokes/dental-insurance-exit-application.tsx
+++ b/frontend/app/routes/public/application/spokes/dental-insurance-exit-application.tsx
@@ -13,13 +13,12 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.dentalInsuranceExitApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/dental-insurance.tsx
+++ b/frontend/app/routes/public/application/spokes/dental-insurance.tsx
@@ -23,9 +23,9 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const CHECKBOX_VALUE = {
@@ -38,9 +38,9 @@ const HAS_DENTAL_INSURANCE_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.dentalInsurance,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/public/application/spokes/email.tsx
+++ b/frontend/app/routes/public/application/spokes/email.tsx
@@ -20,7 +20,6 @@ import { InputField } from '~/components/input-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -41,7 +40,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.email,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
+++ b/frontend/app/routes/public/application/spokes/federal-provincial-territorial-benefits.tsx
@@ -23,9 +23,9 @@ import { InputSelect } from '~/components/input-select';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 const HAS_FEDERAL_BENEFITS_OPTION = {
@@ -39,9 +39,9 @@ const HAS_PROVINCIAL_TERRITORIAL_BENEFITS_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.federalProvincialTerritorialBenefits,
-};
+} as const satisfies RouteHandleData;
 
 export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
 

--- a/frontend/app/routes/public/application/spokes/file-taxes.tsx
+++ b/frontend/app/routes/public/application/spokes/file-taxes.tsx
@@ -14,13 +14,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  i18nNamespaces: ['application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.fileYourTaxes,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/home-address.tsx
+++ b/frontend/app/routes/public/application/spokes/home-address.tsx
@@ -27,7 +27,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -55,7 +54,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.homeAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/living-independently.tsx
+++ b/frontend/app/routes/public/application/spokes/living-independently.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -30,7 +29,7 @@ const LIVING_INDEPENDENTLY_OPTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.livingIndependently,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/mailing-address.tsx
+++ b/frontend/app/routes/public/application/spokes/mailing-address.tsx
@@ -28,7 +28,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -56,7 +55,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.mailingAddress,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -27,7 +27,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.maritalStatus,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
+++ b/frontend/app/routes/public/application/spokes/new-or-returning-member.tsx
@@ -25,7 +25,6 @@ import type { InputRadiosProps } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -35,7 +34,7 @@ import { extractDigits } from '~/utils/string-utils';
 const NEW_OR_EXISTING_MEMBER_OPTION = { no: 'no', yes: 'yes' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.newOrReturningMember,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/parent-or-guardian.tsx
+++ b/frontend/app/routes/public/application/spokes/parent-or-guardian.tsx
@@ -14,14 +14,13 @@ import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { LoadingButton } from '~/components/loading-button';
 import { useApplicationFlowStorage, useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.parentOrGuardian,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -28,7 +28,6 @@ import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { isValidClientNumberRenewal, renewalCodeInputPatternFormat } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString, parseDateTimeString, toLocaleDateString } from '~/utils/date-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -37,7 +36,7 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.personalInformation,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/phone-number.tsx
+++ b/frontend/app/routes/public/application/spokes/phone-number.tsx
@@ -22,7 +22,6 @@ import { InputPhoneField } from '~/components/input-phone-field';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -43,7 +42,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.phoneNumber,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/renewal-submitted.tsx
+++ b/frontend/app/routes/public/application/spokes/renewal-submitted.tsx
@@ -14,13 +14,12 @@ import { InlineLink } from '~/components/inline-link';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.protected.application.spokes.renewalSubmitted,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/tax-filing.tsx
+++ b/frontend/app/routes/public/application/spokes/tax-filing.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const TAX_FILING_OPTION = { no: 'no', yes: 'yes' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('application', 'gcweb'),
+  i18nNamespaces: ['application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.taxFiling,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/terms-conditions.tsx
+++ b/frontend/app/routes/public/application/spokes/terms-conditions.tsx
@@ -22,7 +22,6 @@ import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -44,7 +43,7 @@ type CheckboxId = (typeof CHECKBOX_IDS)[keyof typeof CHECKBOX_IDS];
 const CONSENT_CHECKBOXES = [CHECKBOX_IDS.ACKNOWLEDGE_TERMS, CHECKBOX_IDS.ACKNOWLEDGE_PRIVACY, CHECKBOX_IDS.SHARE_DATA] as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.termsConditions,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/type-application.tsx
+++ b/frontend/app/routes/public/application/spokes/type-application.tsx
@@ -18,7 +18,6 @@ import { InputRadios } from '~/components/input-radios';
 import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -27,7 +26,7 @@ import { getTitleMetaTags } from '~/utils/seo-utils';
 const APPLICANT_TYPE = { adult: 'adult', family: 'family', children: 'children', delegate: 'delegate' } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.typeOfApplication,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/application/spokes/verify-email.tsx
+++ b/frontend/app/routes/public/application/spokes/verify-email.tsx
@@ -25,7 +25,6 @@ import { LoadingButton } from '~/components/loading-button';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useCsrfToken } from '~/root';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -52,7 +51,7 @@ function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
 }
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('applicationSpokes', 'application', 'gcweb'),
+  i18nNamespaces: ['applicationSpokes', 'application', 'gcweb'],
   pageIdentifier: pageIds.public.application.spokes.verifyEmail,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/status/child.tsx
+++ b/frontend/app/routes/public/status/child.tsx
@@ -32,7 +32,6 @@ import { useClientEnv, useFeature } from '~/root';
 import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/application-code-utils';
 import { extractDateParts, getAgeFromDateString, isPastDateString, isValidDateString } from '~/utils/date-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -46,7 +45,7 @@ const CHILD_HAS_SIN = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
+  i18nNamespaces: ['status', 'gcweb'],
   pageIdentifier: pageIds.public.status.child,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/status/index.tsx
+++ b/frontend/app/routes/public/status/index.tsx
@@ -22,7 +22,6 @@ import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
 import { useClientEnv, useFeature } from '~/root';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -34,7 +33,7 @@ const CHECK_FOR = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
+  i18nNamespaces: ['status', 'gcweb'],
   pageIdentifier: pageIds.public.status.index,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/status/layout.tsx
+++ b/frontend/app/routes/public/status/layout.tsx
@@ -7,11 +7,10 @@ import { getLocale } from '~/.server/utils/locale.utils';
 import { PublicLayout, i18nNamespaces as layoutI18nNamespaces } from '~/components/layouts/public-layout';
 import SessionTimeout from '~/components/session-timeout';
 import { useApiSession } from '~/utils/api-session-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces(...layoutI18nNamespaces),
+  i18nNamespaces: layoutI18nNamespaces,
 } as const satisfies RouteHandleData;
 
 // eslint-disable-next-line @typescript-eslint/require-await

--- a/frontend/app/routes/public/status/myself.tsx
+++ b/frontend/app/routes/public/status/myself.tsx
@@ -24,7 +24,6 @@ import { pageIds } from '~/page-ids';
 import { useClientEnv, useFeature } from '~/root';
 import { applicationCodeInputPatternFormat, isValidCodeOrNumber } from '~/utils/application-code-utils';
 import { useHCaptcha } from '~/utils/hcaptcha-utils';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -33,7 +32,7 @@ import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils'
 import { extractDigits } from '~/utils/string-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
+  i18nNamespaces: ['status', 'gcweb'],
   pageIdentifier: pageIds.public.status.myself,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/status/result.tsx
+++ b/frontend/app/routes/public/status/result.tsx
@@ -17,7 +17,6 @@ import { ContextualAlert } from '~/components/contextual-alert';
 import { CsrfTokenInput } from '~/components/csrf-token-input';
 import { useFetcherSubmissionState } from '~/hooks';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
@@ -29,7 +28,7 @@ const FORM_ACTION = {
 } as const;
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('status', 'gcweb'),
+  i18nNamespaces: ['status', 'gcweb'],
   pageIdentifier: pageIds.public.status.result,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/routes/public/unable-to-process-request.tsx
+++ b/frontend/app/routes/public/unable-to-process-request.tsx
@@ -7,13 +7,12 @@ import { AppPageTitle } from '~/components/app-page-title';
 import { InlineLink } from '~/components/inline-link';
 import { PublicLayout } from '~/components/layouts/public-layout';
 import { pageIds } from '~/page-ids';
-import { getTypedI18nNamespaces } from '~/utils/locale-utils';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
 
 export const handle = {
-  i18nNamespaces: getTypedI18nNamespaces('unableToProcessRequest', 'gcweb'),
+  i18nNamespaces: ['unableToProcessRequest', 'gcweb'],
   pageIdentifier: pageIds.public.unableToProcessRequest,
 } as const satisfies RouteHandleData;
 

--- a/frontend/app/utils/locale-utils.ts
+++ b/frontend/app/utils/locale-utils.ts
@@ -1,11 +1,10 @@
-import type { FlatNamespace, LanguageDetectorModule, TOptions, i18n } from 'i18next';
+import type { LanguageDetectorModule, TOptions, i18n } from 'i18next';
 import { createInstance } from 'i18next';
 import I18NextHttpBackend from 'i18next-http-backend';
 import { initReactI18next } from 'react-i18next';
 
 import { getClientEnv } from '~/utils/env-utils';
 import type { ParsedKeysByNamespaces, RouteHandleData } from '~/utils/route-utils';
-import { i18nNamespacesSchema } from '~/utils/route-utils';
 
 /**
  * A constant array representing the supported application locales.
@@ -100,8 +99,7 @@ export function getNamespaces(routes?: ({ handle?: unknown } | undefined)[]) {
 
   const namespaces = routes
     .map((route) => route?.handle as RouteHandleData | undefined)
-    .map((handle) => i18nNamespacesSchema.safeParse(handle?.i18nNamespaces))
-    .flatMap((result) => (result.success ? result.data : undefined))
+    .flatMap((handle) => handle?.i18nNamespaces)
     .filter((i18nNamespaces) => i18nNamespaces !== undefined);
 
   return [...new Set(namespaces)];
@@ -110,7 +108,7 @@ export function getNamespaces(routes?: ({ handle?: unknown } | undefined)[]) {
 /**
  * Initializes the client instance of i18next.
  */
-export async function initI18n(namespaces: Array<string>) {
+export async function initI18n(namespaces: ReadonlyArray<string>) {
   const { BUILD_REVISION, I18NEXT_DEBUG } = getClientEnv();
   const i18n = createInstance();
 
@@ -136,26 +134,6 @@ export async function initI18n(namespaces: Array<string>) {
     });
 
   return i18n;
-}
-
-/**
- * Returns a tuple representing a typed list of namespaces.
- *
- * @template T - The primary namespace to include in the tuple.
- * @template T2 - Additional namespaces to include in the tuple. Should only contain distinct values.
- * @param ns - The primary namespace of type T.
- * @param rest - Additional namespaces of type T2 (should be distinct).
- * @returns A tuple containing the primary namespace and additional namespaces.
- *
- * @note Ensure that the values in the `rest` parameter are distinct to avoid duplicates in the resulting tuple.
- *
- * @example
- * // Usage example:
- * const result = getTypedI18nNs("common", "gcweb", "other");
- * // result is of type: readonly ["common", "gcweb", "other"]
- */
-export function getTypedI18nNamespaces<const T extends Readonly<FlatNamespace>, const T2 extends ReadonlyArray<Exclude<FlatNamespace, T>>>(ns: T, ...rest: T2) {
-  return [ns, ...rest] as const;
 }
 
 /**

--- a/frontend/app/utils/route-utils.ts
+++ b/frontend/app/utils/route-utils.ts
@@ -3,11 +3,20 @@ import { generatePath, useMatches } from 'react-router';
 
 import { invariant } from '@dts-stn/invariant';
 import type { FlatNamespace, KeysByTOptions, Namespace, ParseKeysByNamespaces, TOptions } from 'i18next';
-import validator from 'validator';
 import * as z from 'zod';
 
 import type { I18nPageRoute, I18nRoute, Language } from '~/routes/routes';
 import { i18nRoutes, isI18nLayoutRoute, isI18nPageRoute } from '~/routes/routes';
+
+/**
+ * React-i18next internal Helpers
+ *
+ * A tuple type that requires at least one element of type T, but can contain additional elements of the same type.
+ *
+ * @template T - The type of the elements in the tuple.
+ * @see https://github.com/i18next/react-i18next/blob/5e892a27a78b243b5c2eb3691da76ea1daa41b65/helpers.d.ts#L2
+ */
+type $Tuple<T> = readonly [T?, ...T[]];
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export type ParsedKeysByNamespaces<TOpt extends TOptions = {}> = ParseKeysByNamespaces<Namespace, KeysByTOptions<TOpt>>;
@@ -38,18 +47,13 @@ const buildInfoSchema = z
   })
   .readonly();
 
-export const i18nNamespacesSchema = z
-  .array(z.custom<FlatNamespace>())
-  .refine((arr) => Array.isArray(arr) && arr.every((val) => typeof val === 'string' && !validator.isEmpty(val)))
-  .readonly();
-
 const pageIdentifierSchema = z.string().readonly();
 
 export type Breadcrumbs = z.infer<typeof breadcrumbsSchema>;
 
 export type BuildInfo = z.infer<typeof buildInfoSchema>;
 
-export type I18nNamespaces = z.infer<typeof i18nNamespacesSchema>;
+export type I18nNamespaces = $Tuple<FlatNamespace>;
 
 export type TransformAdobeAnalyticsUrl = (url: string | URL) => URL;
 
@@ -93,8 +97,7 @@ export function useTransformAdobeAnalyticsUrl() {
 export function useI18nNamespaces() {
   const namespaces = useMatches()
     .map(({ handle }) => handle as RouteHandleData | undefined)
-    .map((handle) => i18nNamespacesSchema.safeParse(handle?.i18nNamespaces))
-    .flatMap((result) => (result.success ? result.data : undefined))
+    .flatMap((handle) => handle?.i18nNamespaces)
     .filter((i18nNamespaces) => i18nNamespaces !== undefined);
   return [...new Set(namespaces)];
 }


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request refactors how i18n namespaces are specified throughout the codebase, removing the `getTypedI18nNamespaces` utility and replacing it with direct array assignments using the `satisfies I18nNamespaces` type where appropriate. This simplifies the code and improves type safety. Additionally, the now-unused `getTypedI18nNamespaces` function and its tests are removed.

**i18n Namespace Refactoring:**

* Replaced all usage of `getTypedI18nNamespaces` with direct array literals for `i18nNamespaces` in route handles and components, using `satisfies I18nNamespaces` for type safety where needed [[1]](diffhunk://#diff-4c8d307678c68d2a637cf2de0702dc4e2c04b8da9dc995ce0f0b2baa4da59294L25-R29) [[2]](diffhunk://#diff-dc68400e3602636b16a9e075383d33edee5c06ddbfedeffefb0abdf2e74cf931L20-R22) [[3]](diffhunk://#diff-f87b1f3e3e66119cea7ca833e5059758b38a44c0ce784bc1fa0619df47adbd25L11-R13) [[4]](diffhunk://#diff-08327591a9d2a991e079bfb707f083d27041df954308b1ae4c0d434c5c14a978L4-R9) [[5]](diffhunk://#diff-a628df9607ad6d11ff72e139427c9955e9b040984202c3da3eaef61d620f2ffbL19-R24) [[6]](diffhunk://#diff-042f722662be794845600f58d85669f8e8e66f56a86d7b9ab73c7a9fac224113L21-R26) [[7]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67L21) [[8]](diffhunk://#diff-935411a4d8bff166d7e98b22dc8b7b856e1e8e5a7979b1da120397564adb5e67L30-R29) [[9]](diffhunk://#diff-6799521ec868d6d18271aa28a6c11841dfd25432879ea4ef47b3f766a38a3fe9L19-R26) [[10]](diffhunk://#diff-43e61c3d1e5b0474431750b376c4358fed8526461a992b3a603351f071789275L23-R29) [[11]](diffhunk://#diff-aca9acaf133116c747d6cc2aa667e9a33f1c13a3e76745a4bc880bb312729203L22-R27) [[12]](diffhunk://#diff-6ebf67c137351c7074b635ab33b6eaf4c0bc6dcf5b7bf283b04f86603a9d2528L20-R25) [[13]](diffhunk://#diff-f0acfd6cf04a3a54a3e8cd6b75e5f126675343693229935e4c2760fa76f4486aL18-R23) [[14]](diffhunk://#diff-a0589d158f30f0135a9411996906e98cbbcf10c0ec7e85ab197bde79b23aea80L20-R26) [[15]](diffhunk://#diff-e16fe02d7dc847eb26ce26ca3bba2974d6c8b93dafb1e5440bb082e024e9c15cL27) [[16]](diffhunk://#diff-e16fe02d7dc847eb26ce26ca3bba2974d6c8b93dafb1e5440bb082e024e9c15cL38-R37) [[17]](diffhunk://#diff-4375312162bc5084cb0917f6de43bd206c9f9611e4cc0007972f5b9f8868469fL27) [[18]](diffhunk://#diff-4375312162bc5084cb0917f6de43bd206c9f9611e4cc0007972f5b9f8868469fL37-R36) [[19]](diffhunk://#diff-f329064a804f4b4c6875303594039f5d4a7e2932b6612369a1d518a142b7b7ddL23-R29) [[20]](diffhunk://#diff-4f0bdf8033fa464949abe97b5c5d5181df2b22e3a00f777fd422b346be76154fL18-R23) [[21]](diffhunk://#diff-3935961261e2c991235a3c27fd2981e07bec7b2138bfcca57caf3a84575a8f9fL21-R27) [[22]](diffhunk://#diff-91d54f25e390fac8236c525ec1094ef829b7e936d228654740485c1944f7faffL27) [[23]](diffhunk://#diff-91d54f25e390fac8236c525ec1094ef829b7e936d228654740485c1944f7faffL38-R37).

**Code Cleanup:**

* Removed the `getTypedI18nNamespaces` import and all related code from test files and application code.
* Deleted the `getTypedI18nNamespaces` test suite from `locale-utils.test.ts`.

These changes streamline the handling of i18n namespaces, making the code easier to read and maintain.