### PR TITLE
refactor(frontend): Refactor public and protected application route helpers

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
@@ -21,13 +21,13 @@ import type {
   SunLifeCommunicationMethodService,
 } from '~/.server/domain/services';
 import {
-  resolveRenewalStateChildDentalBenefitsValue,
-  resolveRenewalStateCommunicationPreferencesValue,
-  resolveRenewalStateDentalBenefitsValue,
-  resolveRenewalStateEmailValue,
-  resolveRenewalStateHomeAddressValue,
-  resolveRenewalStateMailingAddressValue,
-  resolveRenewalStatePhoneNumberValue,
+  resolveProtectedStateChildDentalBenefitsValue,
+  resolveProtectedStateCommunicationPreferencesValue,
+  resolveProtectedStateDentalBenefitsValue,
+  resolveProtectedStateEmailValue,
+  resolveProtectedStateHomeAddressValue,
+  resolveProtectedStateMailingAddressValue,
+  resolveProtectedStatePhoneNumberValue,
   shouldSkipMaritalStatus,
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 
@@ -65,7 +65,7 @@ describe('protected-application-route-helpers', () => {
     });
   });
 
-  describe('resolveRenewalStateCommunicationPreferencesValue', () => {
+  describe('resolveProtectedStateCommunicationPreferencesValue', () => {
     const mockLanguage: LanguageLocalizedDto = { id: 'lang-1', code: 'en', name: 'English' };
     const mockSunLifeMethod: SunLifeCommunicationMethodLocalizedDto = { id: 'sl-1', code: 'email', name: 'Email' };
     const mockGCMethod: GCCommunicationMethodLocalizedDto = { id: 'gc-1', code: 'mail', name: 'Mail' };
@@ -87,7 +87,7 @@ describe('protected-application-route-helpers', () => {
       sunLifeService.getLocalizedSunLifeCommunicationMethodById.mockReturnValue(mockSunLifeMethod);
       gcService.getLocalizedGCCommunicationMethodById.mockReturnValue(mockGCMethod);
 
-      const result = resolveRenewalStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
+      const result = resolveProtectedStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
 
       expect(result).toEqual({ hasChanged: true, preferredLanguage: mockLanguage, preferredMethodSunLife: mockSunLifeMethod, preferredMethodGovernmentOfCanada: mockGCMethod });
       expect(languageService.getLocalizedLanguageById).toHaveBeenCalledWith('lang-1', 'en');
@@ -115,7 +115,7 @@ describe('protected-application-route-helpers', () => {
       sunLifeService.getLocalizedSunLifeCommunicationMethodById.mockReturnValue(mockSunLifeMethod);
       gcService.getLocalizedGCCommunicationMethodById.mockReturnValue(mockGCMethod);
 
-      const result = resolveRenewalStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
+      const result = resolveProtectedStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
 
       expect(result).toEqual({ hasChanged: false, preferredLanguage: mockLanguage, preferredMethodSunLife: mockSunLifeMethod, preferredMethodGovernmentOfCanada: mockGCMethod });
       expect(languageService.getLocalizedLanguageById).toHaveBeenCalledWith('lang-2', 'en');
@@ -124,14 +124,14 @@ describe('protected-application-route-helpers', () => {
     });
   });
 
-  describe('resolveRenewalStatePhoneNumberValue', () => {
+  describe('resolveProtectedStatePhoneNumberValue', () => {
     it('returns state phone numbers when hasChanged is true', () => {
       const state = {
         phoneNumber: { hasChanged: true, value: { primary: '555-1234', alternate: '555-5678' } },
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: '555-0001' } },
       } as const;
 
-      expect(resolveRenewalStatePhoneNumberValue(state)).toEqual({ hasChanged: true, primary: '555-1234', alternate: '555-5678' });
+      expect(resolveProtectedStatePhoneNumberValue(state)).toEqual({ hasChanged: true, primary: '555-1234', alternate: '555-5678' });
     });
 
     it('returns client application phone numbers when hasChanged is false', () => {
@@ -140,7 +140,7 @@ describe('protected-application-route-helpers', () => {
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: '555-0001' } },
       } as const;
 
-      expect(resolveRenewalStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: '555-0001' });
+      expect(resolveProtectedStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: '555-0001' });
     });
 
     it('returns client application phone number without alternate when alt is undefined', () => {
@@ -149,11 +149,11 @@ describe('protected-application-route-helpers', () => {
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: undefined } },
       } as const;
 
-      expect(resolveRenewalStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: undefined });
+      expect(resolveProtectedStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: undefined });
     });
   });
 
-  describe('resolveRenewalStateMailingAddressValue', () => {
+  describe('resolveProtectedStateMailingAddressValue', () => {
     const mockCountry: CountryLocalizedDto = { id: 'CA', name: 'Canada' };
     const mockProvince: ProvinceTerritoryStateLocalizedDto = { id: 'ON', countryId: 'CA', abbr: 'ON', name: 'Ontario' };
 
@@ -171,7 +171,7 @@ describe('protected-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveRenewalStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '123 Main St', city: 'Ottawa', country: mockCountry, postalCode: 'K1A 0A9', province: mockProvince });
     });
@@ -189,7 +189,7 @@ describe('protected-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveRenewalStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '123 Main St', city: 'Ottawa', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
@@ -208,7 +208,7 @@ describe('protected-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveRenewalStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '456 Elm St', city: 'Toronto', country: mockCountry, postalCode: 'M5G 2C8', province: mockProvince });
     });
@@ -225,14 +225,14 @@ describe('protected-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveRenewalStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '456 Elm St', city: 'Toronto', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
     });
   });
 
-  describe('resolveRenewalStateHomeAddressValue', () => {
+  describe('resolveProtectedStateHomeAddressValue', () => {
     const mockCountry: CountryLocalizedDto = { id: 'CA', name: 'Canada' };
     const mockProvince: ProvinceTerritoryStateLocalizedDto = { id: 'BC', countryId: 'CA', abbr: 'BC', name: 'British Columbia' };
 
@@ -250,7 +250,7 @@ describe('protected-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveRenewalStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '789 Oak Ave', city: 'Vancouver', country: mockCountry, postalCode: 'V6B 1A1', province: mockProvince });
     });
@@ -268,7 +268,7 @@ describe('protected-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveRenewalStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '789 Oak Ave', city: 'Vancouver', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
@@ -287,7 +287,7 @@ describe('protected-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveRenewalStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '321 Pine Rd', city: 'Calgary', country: mockCountry, postalCode: 'T2P 1J9', province: mockProvince });
     });
@@ -304,21 +304,21 @@ describe('protected-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveRenewalStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolveProtectedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '321 Pine Rd', city: 'Calgary', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
     });
   });
 
-  describe('resolveRenewalStateEmailValue', () => {
+  describe('resolveProtectedStateEmailValue', () => {
     it('returns state email when it is defined', () => {
       const state = {
         email: 'user@example.com',
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
-      expect(resolveRenewalStateEmailValue(state)).toBe('user@example.com');
+      expect(resolveProtectedStateEmailValue(state)).toBe('user@example.com');
     });
 
     it('falls back to client application email when state email is undefined', () => {
@@ -327,7 +327,7 @@ describe('protected-application-route-helpers', () => {
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
-      expect(resolveRenewalStateEmailValue(state)).toBe('client@example.com');
+      expect(resolveProtectedStateEmailValue(state)).toBe('client@example.com');
     });
 
     it('returns undefined when both state and client application emails are undefined', () => {
@@ -336,11 +336,11 @@ describe('protected-application-route-helpers', () => {
         clientApplication: { contactInformation: { email: undefined } },
       } as const;
 
-      expect(resolveRenewalStateEmailValue(state)).toBeUndefined();
+      expect(resolveProtectedStateEmailValue(state)).toBeUndefined();
     });
   });
 
-  describe('resolveRenewalStateDentalBenefitsValue', () => {
+  describe('resolveProtectedStateDentalBenefitsValue', () => {
     const mockFederalPlan: FederalGovernmentInsurancePlanLocalizedDto = { id: 'fed-1', name: 'Federal Plan A' };
     const mockProvincialPlan: ProvincialGovernmentInsurancePlanLocalizedDto = { id: 'prov-1', name: 'Provincial Plan B', provinceTerritoryStateId: 'ON' };
 
@@ -358,7 +358,7 @@ describe('protected-application-route-helpers', () => {
       federalService.getLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(mockFederalPlan);
       provincialService.getLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(mockProvincialPlan);
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -375,7 +375,7 @@ describe('protected-application-route-helpers', () => {
       const federalService = mock<FederalGovernmentInsurancePlanService>();
       const provincialService = mock<ProvincialGovernmentInsurancePlanService>();
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
       expect(federalService.getLocalizedFederalGovernmentInsurancePlanById).not.toHaveBeenCalled();
@@ -393,7 +393,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(Some(mockFederalPlan));
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: undefined });
     });
@@ -409,7 +409,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -425,7 +425,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
     });
@@ -441,13 +441,13 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValueOnce(Some(mockFederalPlan)).mockResolvedValueOnce(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveRenewalStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
   });
 
-  describe('resolveRenewalStateChildDentalBenefitsValue', () => {
+  describe('resolveProtectedStateChildDentalBenefitsValue', () => {
     const mockFederalPlan: FederalGovernmentInsurancePlanLocalizedDto = { id: 'fed-1', name: 'Federal Plan A' };
     const mockProvincialPlan: ProvincialGovernmentInsurancePlanLocalizedDto = { id: 'prov-1', name: 'Provincial Plan B', provinceTerritoryStateId: 'ON' };
 
@@ -465,7 +465,7 @@ describe('protected-application-route-helpers', () => {
       federalService.getLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(mockFederalPlan);
       provincialService.getLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(mockProvincialPlan);
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -482,7 +482,7 @@ describe('protected-application-route-helpers', () => {
       const federalService = mock<FederalGovernmentInsurancePlanService>();
       const provincialService = mock<ProvincialGovernmentInsurancePlanService>();
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
       expect(federalService.getLocalizedFederalGovernmentInsurancePlanById).not.toHaveBeenCalled();
@@ -498,7 +498,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(Some(mockFederalPlan));
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: undefined });
     });
@@ -512,7 +512,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -526,7 +526,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
     });
@@ -540,7 +540,7 @@ describe('protected-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValueOnce(Some(mockFederalPlan)).mockResolvedValueOnce(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveRenewalStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolveProtectedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });

--- a/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
@@ -21,17 +21,17 @@ import type {
   SunLifeCommunicationMethodService,
 } from '~/.server/domain/services';
 import {
-  resolveSimplifiedStateChildDentalBenefitsValue,
-  resolveSimplifiedStateCommunicationPreferencesValue,
-  resolveSimplifiedStateDentalBenefitsValue,
-  resolveSimplifiedStateEmailValue,
-  resolveSimplifiedStateHomeAddressValue,
-  resolveSimplifiedStateMailingAddressValue,
-  resolveSimplifiedStatePhoneNumberValue,
+  resolvePublicStateChildDentalBenefitsValue,
+  resolvePublicStateCommunicationPreferencesValue,
+  resolvePublicStateDentalBenefitsValue,
+  resolvePublicStateEmailValue,
+  resolvePublicStateHomeAddressValue,
+  resolvePublicStateMailingAddressValue,
+  resolvePublicStatePhoneNumberValue,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 
 describe('public-application-route-helpers', () => {
-  describe('resolveSimplifiedStateCommunicationPreferencesValue', () => {
+  describe('resolvePublicStateCommunicationPreferencesValue', () => {
     const mockLanguage: LanguageLocalizedDto = { id: 'lang-1', code: 'en', name: 'English' };
     const mockSunLifeMethod: SunLifeCommunicationMethodLocalizedDto = { id: 'sl-1', code: 'email', name: 'Email' };
     const mockGCMethod: GCCommunicationMethodLocalizedDto = { id: 'gc-1', code: 'mail', name: 'Mail' };
@@ -53,7 +53,7 @@ describe('public-application-route-helpers', () => {
       sunLifeService.getLocalizedSunLifeCommunicationMethodById.mockReturnValue(mockSunLifeMethod);
       gcService.getLocalizedGCCommunicationMethodById.mockReturnValue(mockGCMethod);
 
-      const result = resolveSimplifiedStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
+      const result = resolvePublicStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
 
       expect(result).toEqual({ hasChanged: true, preferredLanguage: mockLanguage, preferredMethodSunLife: mockSunLifeMethod, preferredMethodGovernmentOfCanada: mockGCMethod });
       expect(languageService.getLocalizedLanguageById).toHaveBeenCalledWith('lang-1', 'en');
@@ -81,7 +81,7 @@ describe('public-application-route-helpers', () => {
       sunLifeService.getLocalizedSunLifeCommunicationMethodById.mockReturnValue(mockSunLifeMethod);
       gcService.getLocalizedGCCommunicationMethodById.mockReturnValue(mockGCMethod);
 
-      const result = resolveSimplifiedStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
+      const result = resolvePublicStateCommunicationPreferencesValue(state, 'en', languageService, sunLifeService, gcService);
 
       expect(result).toEqual({ hasChanged: false, preferredLanguage: mockLanguage, preferredMethodSunLife: mockSunLifeMethod, preferredMethodGovernmentOfCanada: mockGCMethod });
       expect(languageService.getLocalizedLanguageById).toHaveBeenCalledWith('lang-2', 'en');
@@ -90,14 +90,14 @@ describe('public-application-route-helpers', () => {
     });
   });
 
-  describe('resolveSimplifiedStatePhoneNumberValue', () => {
+  describe('resolvePublicStatePhoneNumberValue', () => {
     it('returns state phone numbers with hasChanged=true when user changed phone number', () => {
       const state = {
         phoneNumber: { hasChanged: true, value: { primary: '555-1234', alternate: '555-5678' } },
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: '555-0001' } },
       } as const;
 
-      expect(resolveSimplifiedStatePhoneNumberValue(state)).toEqual({ hasChanged: true, primary: '555-1234', alternate: '555-5678' });
+      expect(resolvePublicStatePhoneNumberValue(state)).toEqual({ hasChanged: true, primary: '555-1234', alternate: '555-5678' });
     });
 
     it('returns client application phone numbers with hasChanged=false when user did not change phone number', () => {
@@ -106,7 +106,7 @@ describe('public-application-route-helpers', () => {
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: '555-0001' } },
       } as const;
 
-      expect(resolveSimplifiedStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: '555-0001' });
+      expect(resolvePublicStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: '555-0001' });
     });
 
     it('returns client application phone number without alternate when alt is undefined', () => {
@@ -115,11 +115,11 @@ describe('public-application-route-helpers', () => {
         clientApplication: { contactInformation: { phoneNumber: '555-0000', phoneNumberAlt: undefined } },
       } as const;
 
-      expect(resolveSimplifiedStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: undefined });
+      expect(resolvePublicStatePhoneNumberValue(state)).toEqual({ hasChanged: false, primary: '555-0000', alternate: undefined });
     });
   });
 
-  describe('resolveSimplifiedStateMailingAddressValue', () => {
+  describe('resolvePublicStateMailingAddressValue', () => {
     const mockCountry: CountryLocalizedDto = { id: 'CA', name: 'Canada' };
     const mockProvince: ProvinceTerritoryStateLocalizedDto = { id: 'ON', countryId: 'CA', abbr: 'ON', name: 'Ontario' };
 
@@ -137,7 +137,7 @@ describe('public-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveSimplifiedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '123 Main St', city: 'Ottawa', country: mockCountry, postalCode: 'K1A 0A9', province: mockProvince });
     });
@@ -155,7 +155,7 @@ describe('public-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveSimplifiedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '123 Main St', city: 'Ottawa', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
@@ -174,7 +174,7 @@ describe('public-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveSimplifiedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '456 Elm St', city: 'Toronto', country: mockCountry, postalCode: 'M5G 2C8', province: mockProvince });
     });
@@ -191,14 +191,14 @@ describe('public-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveSimplifiedStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateMailingAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '456 Elm St', city: 'Toronto', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
     });
   });
 
-  describe('resolveSimplifiedStateHomeAddressValue', () => {
+  describe('resolvePublicStateHomeAddressValue', () => {
     const mockCountry: CountryLocalizedDto = { id: 'CA', name: 'Canada' };
     const mockProvince: ProvinceTerritoryStateLocalizedDto = { id: 'BC', countryId: 'CA', abbr: 'BC', name: 'British Columbia' };
 
@@ -216,7 +216,7 @@ describe('public-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveSimplifiedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '789 Oak Ave', city: 'Vancouver', country: mockCountry, postalCode: 'V6B 1A1', province: mockProvince });
     });
@@ -234,7 +234,7 @@ describe('public-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveSimplifiedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: true, address: '789 Oak Ave', city: 'Vancouver', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
@@ -253,7 +253,7 @@ describe('public-application-route-helpers', () => {
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
       provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById.mockResolvedValue(mockProvince);
 
-      const result = await resolveSimplifiedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '321 Pine Rd', city: 'Calgary', country: mockCountry, postalCode: 'T2P 1J9', province: mockProvince });
     });
@@ -270,21 +270,21 @@ describe('public-application-route-helpers', () => {
       const provinceTerritoryStateService = mock<ProvinceTerritoryStateService>();
       countryService.getLocalizedCountryById.mockResolvedValue(mockCountry);
 
-      const result = await resolveSimplifiedStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
+      const result = await resolvePublicStateHomeAddressValue(state, 'en', countryService, provinceTerritoryStateService);
 
       expect(result).toEqual({ hasChanged: false, address: '321 Pine Rd', city: 'Calgary', country: mockCountry, postalCode: undefined, province: undefined });
       expect(provinceTerritoryStateService.getLocalizedProvinceTerritoryStateById).not.toHaveBeenCalled();
     });
   });
 
-  describe('resolveSimplifiedStateEmailValue', () => {
+  describe('resolvePublicStateEmailValue', () => {
     it('returns state email when it is defined', () => {
       const state = {
         email: 'user@example.com',
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
-      expect(resolveSimplifiedStateEmailValue(state)).toBe('user@example.com');
+      expect(resolvePublicStateEmailValue(state)).toBe('user@example.com');
     });
 
     it('falls back to client application email when state email is undefined', () => {
@@ -293,7 +293,7 @@ describe('public-application-route-helpers', () => {
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
-      expect(resolveSimplifiedStateEmailValue(state)).toBe('client@example.com');
+      expect(resolvePublicStateEmailValue(state)).toBe('client@example.com');
     });
 
     it('returns undefined when both state and client application emails are undefined', () => {
@@ -302,11 +302,11 @@ describe('public-application-route-helpers', () => {
         clientApplication: { contactInformation: { email: undefined } },
       } as const;
 
-      expect(resolveSimplifiedStateEmailValue(state)).toBeUndefined();
+      expect(resolvePublicStateEmailValue(state)).toBeUndefined();
     });
   });
 
-  describe('resolveSimplifiedStateDentalBenefitsValue', () => {
+  describe('resolvePublicStateDentalBenefitsValue', () => {
     const mockFederalPlan: FederalGovernmentInsurancePlanLocalizedDto = { id: 'fed-1', name: 'Federal Plan A' };
     const mockProvincialPlan: ProvincialGovernmentInsurancePlanLocalizedDto = { id: 'prov-1', name: 'Provincial Plan B', provinceTerritoryStateId: 'ON' };
 
@@ -324,7 +324,7 @@ describe('public-application-route-helpers', () => {
       federalService.getLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(mockFederalPlan);
       provincialService.getLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(mockProvincialPlan);
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -341,7 +341,7 @@ describe('public-application-route-helpers', () => {
       const federalService = mock<FederalGovernmentInsurancePlanService>();
       const provincialService = mock<ProvincialGovernmentInsurancePlanService>();
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
       expect(federalService.getLocalizedFederalGovernmentInsurancePlanById).not.toHaveBeenCalled();
@@ -359,7 +359,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(Some(mockFederalPlan));
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: undefined });
     });
@@ -375,7 +375,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -391,7 +391,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
     });
@@ -407,13 +407,13 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValueOnce(Some(mockFederalPlan)).mockResolvedValueOnce(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveSimplifiedStateDentalBenefitsValue(state, 'en', federalService, provincialService);
+      const result = await resolvePublicStateDentalBenefitsValue(state, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
   });
 
-  describe('resolveSimplifiedStateChildDentalBenefitsValue', () => {
+  describe('resolvePublicStateChildDentalBenefitsValue', () => {
     const mockFederalPlan: FederalGovernmentInsurancePlanLocalizedDto = { id: 'fed-1', name: 'Federal Plan A' };
     const mockProvincialPlan: ProvincialGovernmentInsurancePlanLocalizedDto = { id: 'prov-1', name: 'Provincial Plan B', provinceTerritoryStateId: 'ON' };
 
@@ -431,7 +431,7 @@ describe('public-application-route-helpers', () => {
       federalService.getLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(mockFederalPlan);
       provincialService.getLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(mockProvincialPlan);
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -448,7 +448,7 @@ describe('public-application-route-helpers', () => {
       const federalService = mock<FederalGovernmentInsurancePlanService>();
       const provincialService = mock<ProvincialGovernmentInsurancePlanService>();
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: true, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
       expect(federalService.getLocalizedFederalGovernmentInsurancePlanById).not.toHaveBeenCalled();
@@ -464,7 +464,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(Some(mockFederalPlan));
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: undefined });
     });
@@ -478,7 +478,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });
@@ -492,7 +492,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValue(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(None);
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: undefined, provincialGovernmentInsurancePlan: undefined });
     });
@@ -506,7 +506,7 @@ describe('public-application-route-helpers', () => {
       federalService.findLocalizedFederalGovernmentInsurancePlanById.mockResolvedValueOnce(Some(mockFederalPlan)).mockResolvedValueOnce(None);
       provincialService.findLocalizedProvincialGovernmentInsurancePlanById.mockResolvedValue(Some(mockProvincialPlan));
 
-      const result = await resolveSimplifiedStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
+      const result = await resolvePublicStateChildDentalBenefitsValue(childState, childClientApplication, 'en', federalService, provincialService);
 
       expect(result).toEqual({ hasChanged: false, federalGovernmentInsurancePlan: mockFederalPlan, provincialGovernmentInsurancePlan: mockProvincialPlan });
     });

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -4,7 +4,7 @@ import type { Params } from 'react-router';
 import { UTCDate } from '@date-fns/utc';
 import { invariant } from '@dts-stn/invariant';
 import { differenceInMinutes } from 'date-fns';
-import type { PickDeep, ReadonlyDeep } from 'type-fest';
+import type { PickDeep, ReadonlyDeep, SetRequired } from 'type-fest';
 
 import type {
   ClientApplicationRenewalEligibleDto,
@@ -536,19 +536,19 @@ export function shouldSkipNewOrReturningMember(state: PickDeep<ProtectedApplicat
 }
 
 /**
- * Resolves the effective communication preferences value for a renewal application state.
+ * Resolves the effective communication preferences value for a protected application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The renewal application state containing communication preferences and client application data.
+ * @param state - The protected application state containing communication preferences and client application data.
  * @param locale - The locale used to retrieve localized values.
  * @param languageService - Service for resolving localized language details.
  * @param sunLifeCommunicationMethodService - Service for resolving localized Sun Life communication methods.
  * @param gcCommunicationMethodService - Service for resolving localized Government of Canada communication methods.
  * @returns The resolved preferred language, Sun Life communication method, and Government of Canada communication method.
  */
-export function resolveRenewalStateCommunicationPreferencesValue(
-  state: Required<PickDeep<ProtectedApplicationState, 'communicationPreferences' | 'clientApplication.communicationPreferences'>>,
+export function resolveProtectedStateCommunicationPreferencesValue(
+  state: SetRequired<PickDeep<ProtectedApplicationState, 'communicationPreferences' | 'clientApplication.communicationPreferences'>, 'communicationPreferences'>,
   locale: AppLocale,
   languageService: LanguageService,
   sunLifeCommunicationMethodService: SunLifeCommunicationMethodService,
@@ -568,9 +568,10 @@ export function resolveRenewalStateCommunicationPreferencesValue(
     };
   }
 
-  // If hash changed is false, client application communication preferences must be defined, as the value would have
+  // If hasChanged is false, client application communication preferences must be defined, as the value would have
   // been set on the state when the user made a change to the communication preferences step, which requires client
   // application communication preferences to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when communicationPreferences.hasChanged is false');
   invariant(state.clientApplication.communicationPreferences.preferredLanguage, 'Expected clientApplication.communicationPreferences.preferredLanguage to be defined when communicationPreferences.hasChanged is false');
   invariant(state.clientApplication.communicationPreferences.preferredMethodSunLife, 'Expected clientApplication.communicationPreferences.preferredMethodSunLife to be defined when communicationPreferences.hasChanged is false');
   invariant(state.clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada, 'Expected clientApplication.communicationPreferences.preferredMethodGovernmentOfCanada to be defined when communicationPreferences.hasChanged is false');
@@ -584,14 +585,14 @@ export function resolveRenewalStateCommunicationPreferencesValue(
 }
 
 /**
- * Resolves the effective phone number value for a renewal application state.
+ * Resolves the effective phone number value for a protected application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The renewal application state containing phone number and client application contact information.
+ * @param state - The protected application state containing phone number and client application contact information.
  * @returns The resolved primary phone number and optional alternate phone number.
  */
-export function resolveRenewalStatePhoneNumberValue(state: Required<PickDeep<ProtectedApplicationState, 'phoneNumber' | 'clientApplication.contactInformation.phoneNumber' | 'clientApplication.contactInformation.phoneNumberAlt'>>): {
+export function resolveProtectedStatePhoneNumberValue(state: SetRequired<PickDeep<ProtectedApplicationState, 'phoneNumber' | 'clientApplication.contactInformation.phoneNumber' | 'clientApplication.contactInformation.phoneNumberAlt'>, 'phoneNumber'>): {
   hasChanged: boolean;
   primary: string;
   alternate?: string;
@@ -604,9 +605,10 @@ export function resolveRenewalStatePhoneNumberValue(state: Required<PickDeep<Pro
     };
   }
 
-  // If hash changed is false, client application phone number must be defined, as the value would have been set on the
+  // If hasChanged is false, client application phone number must be defined, as the value would have been set on the
   // state when the user made a change to the phone number step, which requires client application phone number to be
   // defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when phoneNumber.hasChanged is false');
   invariant(state.clientApplication.contactInformation.phoneNumber, 'Expected clientApplication.contactInformation.phoneNumber to be defined when phoneNumber.hasChanged is false');
 
   return {
@@ -617,18 +619,18 @@ export function resolveRenewalStatePhoneNumberValue(state: Required<PickDeep<Pro
 }
 
 /**
- * Resolves the effective mailing address value for a renewal application state.
+ * Resolves the effective mailing address value for a protected application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The renewal application state containing mailing address and client application contact information.
+ * @param state - The protected application state containing mailing address and client application contact information.
  * @param locale - The locale used to retrieve localized country and province/territory values.
  * @param countryService - Service for resolving localized country details.
  * @param provinceTerritoryStateService - Service for resolving localized province/territory/state details.
  * @returns The resolved mailing address including address, city, country, and optional postal code and province.
  */
-export async function resolveRenewalStateMailingAddressValue(
-  state: Required<
+export async function resolveProtectedStateMailingAddressValue(
+  state: SetRequired<
     PickDeep<
       ProtectedApplicationState,
       | 'mailingAddress'
@@ -637,7 +639,8 @@ export async function resolveRenewalStateMailingAddressValue(
       | 'clientApplication.contactInformation.mailingAddress.country'
       | 'clientApplication.contactInformation.mailingAddress.postalCode'
       | 'clientApplication.contactInformation.mailingAddress.province'
-    >
+    >,
+    'mailingAddress'
   >,
   locale: AppLocale,
   countryService: CountryService,
@@ -661,6 +664,12 @@ export async function resolveRenewalStateMailingAddressValue(
     };
   }
 
+  // If hasChanged is false, client application mailing address fields must be defined, as the value would have
+  // been set on the state when the user made a change to the mailing address step, which requires client
+  // application mailing address to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when mailingAddress.hasChanged is false');
+  invariant(state.clientApplication.contactInformation.mailingAddress, 'Expected clientApplication.contactInformation.mailingAddress to be defined when mailingAddress.hasChanged is false');
+
   return {
     hasChanged: false,
     address: state.clientApplication.contactInformation.mailingAddress.address,
@@ -672,18 +681,18 @@ export async function resolveRenewalStateMailingAddressValue(
 }
 
 /**
- * Resolves the effective home address value for a renewal application state.
+ * Resolves the effective home address value for a protected application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The renewal application state containing home address and client application contact information.
+ * @param state - The protected application state containing home address and client application contact information.
  * @param locale - The locale used to retrieve localized country and province/territory values.
  * @param countryService - Service for resolving localized country details.
  * @param provinceTerritoryStateService - Service for resolving localized province/territory/state details.
  * @returns The resolved home address including address, city, country, and optional postal code and province.
  */
-export async function resolveRenewalStateHomeAddressValue(
-  state: Required<
+export async function resolveProtectedStateHomeAddressValue(
+  state: SetRequired<
     PickDeep<
       ProtectedApplicationState,
       | 'homeAddress'
@@ -692,7 +701,8 @@ export async function resolveRenewalStateHomeAddressValue(
       | 'clientApplication.contactInformation.homeAddress.country'
       | 'clientApplication.contactInformation.homeAddress.postalCode'
       | 'clientApplication.contactInformation.homeAddress.province'
-    >
+    >,
+    'homeAddress'
   >,
   locale: AppLocale,
   countryService: CountryService,
@@ -716,9 +726,10 @@ export async function resolveRenewalStateHomeAddressValue(
     };
   }
 
-  // If hash changed is false, client application home address fields must be defined, as the value would have
+  // If hasChanged is false, client application home address fields must be defined, as the value would have
   // been set on the state when the user made a change to the home address step, which requires client
   // application home address to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when homeAddress.hasChanged is false');
   invariant(state.clientApplication.contactInformation.homeAddress, 'Expected clientApplication.contactInformation.homeAddress to be defined when homeAddress.hasChanged is false');
 
   return {
@@ -732,31 +743,31 @@ export async function resolveRenewalStateHomeAddressValue(
 }
 
 /**
- * Resolves the effective email value for a renewal application state.
+ * Resolves the effective email value for a protected application state.
  * The state email (set by the user during the session) takes precedence over the
  * client application email on file.
  *
- * @param state - The renewal application state containing the optional email and client application contact information.
+ * @param state - The protected application state containing the optional email and client application contact information.
  * @returns The resolved email address, or `undefined` if neither is available.
  */
-export function resolveRenewalStateEmailValue(state: Pick<ProtectedApplicationState, 'email'> & Required<PickDeep<ProtectedApplicationState, 'clientApplication.contactInformation.email'>>): string | undefined {
-  return state.email ?? state.clientApplication.contactInformation.email;
+export function resolveProtectedStateEmailValue(state: PickDeep<ProtectedApplicationState, 'email' | 'clientApplication.contactInformation.email'>): string | undefined {
+  return state.email ?? state.clientApplication?.contactInformation.email;
 }
 
 /**
- * Resolves the effective dental benefits value for a renewal application state.
+ * Resolves the effective dental benefits value for a protected application state.
  * If the user has declared a change, the updated federal and provincial program selections from the state
  * are used; otherwise, the benefit IDs from the client application are matched against both federal
  * and provincial insurance plan services to determine the applicable plans.
  *
- * @param state - The renewal application state containing dental benefits and client application dental benefits.
+ * @param state - The protected application state containing dental benefits and client application dental benefits.
  * @param locale - The locale used to retrieve localized insurance plan details.
  * @param federalGovernmentInsurancePlanService - Service for resolving localized federal government insurance plans.
  * @param provincialGovernmentInsurancePlanService - Service for resolving localized provincial government insurance plans.
  * @returns The resolved federal and provincial government insurance plans, each of which may be `undefined` if not applicable.
  */
-export async function resolveRenewalStateDentalBenefitsValue(
-  state: Required<Pick<ProtectedApplicationState, 'dentalBenefits'>> & Required<PickDeep<ProtectedApplicationState, 'clientApplication.dentalBenefits'>>,
+export async function resolveProtectedStateDentalBenefitsValue(
+  state: SetRequired<PickDeep<ProtectedApplicationState, 'dentalBenefits' | 'clientApplication.dentalBenefits'>, 'dentalBenefits'>,
   locale: AppLocale,
   federalGovernmentInsurancePlanService: FederalGovernmentInsurancePlanService,
   provincialGovernmentInsurancePlanService: ProvincialGovernmentInsurancePlanService,
@@ -777,6 +788,8 @@ export async function resolveRenewalStateDentalBenefitsValue(
     };
   }
 
+  // If hasChanged is false, client application dental benefits must be defined, as the value would have been set on the state when the user made a change to the dental benefits step, which requires client application dental benefits to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when hasChanged is false');
   invariant(state.clientApplication.dentalBenefits, 'Expected clientApplication.dentalBenefits to be defined when hasChanged is false');
 
   let federalGovernmentInsurancePlan: FederalGovernmentInsurancePlanLocalizedDto | undefined;
@@ -803,20 +816,20 @@ export async function resolveRenewalStateDentalBenefitsValue(
 }
 
 /**
- * Resolves the effective child dental benefits value for a renewal application state.
+ * Resolves the effective child dental benefits value for a protected application state.
  * If the user has declared a change, the updated federal and provincial program selections from the state
  * are used; otherwise, the benefit IDs from the client application are matched against both federal
  * and provincial insurance plan services to determine the applicable plans.
  *
- * @param childState - The renewal application state containing child dental benefits and client application child dental benefits.
+ * @param childState - The protected application state containing child dental benefits and client application child dental benefits.
  * @param locale - The locale used to retrieve localized insurance plan details.
  * @param federalGovernmentInsurancePlanService - Service for resolving localized federal government insurance plans.
  * @param provincialGovernmentInsurancePlanService - Service for resolving localized provincial government insurance plans.
  * @returns The resolved federal and provincial government insurance plans, each of which may be `undefined` if not applicable.
  */
-export async function resolveRenewalStateChildDentalBenefitsValue(
+export async function resolveProtectedStateChildDentalBenefitsValue(
   childState: Required<Pick<ProtectedApplicationState['children'][number], 'dentalBenefits'>>,
-  childClientApplication: Pick<NonNullable<ProtectedApplicationState['clientApplication']>['children'][number], 'dentalBenefits'>,
+  childClientApplication: Pick<NonNullable<ProtectedApplicationState['clientApplication']>['children'][number], 'dentalBenefits'> | undefined,
   locale: AppLocale,
   federalGovernmentInsurancePlanService: FederalGovernmentInsurancePlanService,
   provincialGovernmentInsurancePlanService: ProvincialGovernmentInsurancePlanService,
@@ -836,6 +849,11 @@ export async function resolveRenewalStateChildDentalBenefitsValue(
         : undefined,
     };
   }
+
+  // If hasChanged is false, child client application dental benefits must be defined, as the value would have been set
+  // on the state when the user made a change to the child dental benefits step, which requires child client application
+  // dental benefits to be defined.
+  invariant(childClientApplication, 'Expected childClientApplication to be defined when hasChanged is false');
 
   let federalGovernmentInsurancePlan: FederalGovernmentInsurancePlanLocalizedDto | undefined;
   let provincialGovernmentInsurancePlan: ProvincialGovernmentInsurancePlanLocalizedDto | undefined;

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -4,7 +4,7 @@ import type { Params } from 'react-router';
 import { UTCDate } from '@date-fns/utc';
 import { invariant } from '@dts-stn/invariant';
 import { differenceInMinutes } from 'date-fns';
-import type { PickDeep, ReadonlyDeep } from 'type-fest';
+import type { PickDeep, ReadonlyDeep, SetRequired } from 'type-fest';
 
 import type {
   ClientApplicationRenewalEligibleDto,
@@ -418,18 +418,18 @@ export function isWithinRenewalPeriod(date: Date = new Date()): boolean {
 }
 
 /**
- * Resolves the effective communication preferences value for a simplified application state.
+ * Resolves the effective communication preferences value for a public application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The simplified application state containing communication preferences and client application data.
+ * @param state - The public application state containing communication preferences and client application data.
  * @param locale - The locale used to retrieve localized values.
  * @param languageService - Service for resolving localized language details.
  * @param sunLifeCommunicationMethodService - Service for resolving localized Sun Life communication methods.
  * @param gcCommunicationMethodService - Service for resolving localized Government of Canada communication methods.
  * @returns The resolved preferred language, Sun Life communication method, and Government of Canada communication method.
  */
-export function resolveSimplifiedStateCommunicationPreferencesValue(
+export function resolvePublicStateCommunicationPreferencesValue(
   state: Required<PickDeep<PublicApplicationState, 'communicationPreferences' | 'clientApplication.communicationPreferences'>>,
   locale: AppLocale,
   languageService: LanguageService,
@@ -450,7 +450,7 @@ export function resolveSimplifiedStateCommunicationPreferencesValue(
     };
   }
 
-  // If hash changed is false, client application communication preferences must be defined, as the value would have
+  // If hasChanged is false, client application communication preferences must be defined, as the value would have
   // been set on the state when the user made a change to the communication preferences step, which requires client
   // application communication preferences to be defined.
   invariant(state.clientApplication.communicationPreferences.preferredLanguage, 'Expected clientApplication.communicationPreferences.preferredLanguage to be defined when communicationPreferences.hasChanged is false');
@@ -466,14 +466,14 @@ export function resolveSimplifiedStateCommunicationPreferencesValue(
 }
 
 /**
- * Resolves the effective phone number value for a simplified application state.
+ * Resolves the effective phone number value for a public application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The simplified application state containing phone number and client application contact information.
+ * @param state - The public application state containing phone number and client application contact information.
  * @returns The resolved primary phone number and optional alternate phone number.
  */
-export function resolveSimplifiedStatePhoneNumberValue(state: Required<PickDeep<PublicApplicationState, 'phoneNumber' | 'clientApplication.contactInformation.phoneNumber' | 'clientApplication.contactInformation.phoneNumberAlt'>>): {
+export function resolvePublicStatePhoneNumberValue(state: SetRequired<PickDeep<PublicApplicationState, 'phoneNumber' | 'clientApplication.contactInformation.phoneNumber' | 'clientApplication.contactInformation.phoneNumberAlt'>, 'phoneNumber'>): {
   hasChanged: boolean;
   primary: string;
   alternate?: string;
@@ -486,9 +486,10 @@ export function resolveSimplifiedStatePhoneNumberValue(state: Required<PickDeep<
     };
   }
 
-  // If hash changed is false, client application phone number must be defined, as the value would have been set on the
+  // If hasChanged is false, client application phone number must be defined, as the value would have been set on the
   // state when the user made a change to the phone number step, which requires client application phone number to be
   // defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when phoneNumber.hasChanged is false');
   invariant(state.clientApplication.contactInformation.phoneNumber, 'Expected clientApplication.contactInformation.phoneNumber to be defined when phoneNumber.hasChanged is false');
 
   return {
@@ -499,18 +500,18 @@ export function resolveSimplifiedStatePhoneNumberValue(state: Required<PickDeep<
 }
 
 /**
- * Resolves the effective mailing address value for a simplified application state.
+ * Resolves the effective mailing address value for a public application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The simplified application state containing mailing address and client application contact information.
+ * @param state - The public application state containing mailing address and client application contact information.
  * @param locale - The locale used to retrieve localized country and province/territory values.
  * @param countryService - Service for resolving localized country details.
  * @param provinceTerritoryStateService - Service for resolving localized province/territory/state details.
  * @returns The resolved mailing address including address, city, country, and optional postal code and province.
  */
-export async function resolveSimplifiedStateMailingAddressValue(
-  state: Required<
+export async function resolvePublicStateMailingAddressValue(
+  state: SetRequired<
     PickDeep<
       PublicApplicationState,
       | 'mailingAddress'
@@ -519,7 +520,8 @@ export async function resolveSimplifiedStateMailingAddressValue(
       | 'clientApplication.contactInformation.mailingAddress.country'
       | 'clientApplication.contactInformation.mailingAddress.postalCode'
       | 'clientApplication.contactInformation.mailingAddress.province'
-    >
+    >,
+    'mailingAddress'
   >,
   locale: AppLocale,
   countryService: CountryService,
@@ -543,6 +545,11 @@ export async function resolveSimplifiedStateMailingAddressValue(
     };
   }
 
+  // If hasChanged is false, client application mailing address fields must be defined, as the value would have
+  // been set on the state when the user made a change to the mailing address step, which requires client application
+  // mailing address to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when mailingAddress.hasChanged is false');
+
   return {
     hasChanged: false,
     address: state.clientApplication.contactInformation.mailingAddress.address,
@@ -554,18 +561,18 @@ export async function resolveSimplifiedStateMailingAddressValue(
 }
 
 /**
- * Resolves the effective home address value for a simplified application state.
+ * Resolves the effective home address value for a public application state.
  * If the user has declared a change, the updated values from the state are used;
  * otherwise, the values are sourced from the client application data.
  *
- * @param state - The simplified application state containing home address and client application contact information.
+ * @param state - The public application state containing home address and client application contact information.
  * @param locale - The locale used to retrieve localized country and province/territory values.
  * @param countryService - Service for resolving localized country details.
  * @param provinceTerritoryStateService - Service for resolving localized province/territory/state details.
  * @returns The resolved home address including address, city, country, and optional postal code and province.
  */
-export async function resolveSimplifiedStateHomeAddressValue(
-  state: Required<
+export async function resolvePublicStateHomeAddressValue(
+  state: SetRequired<
     PickDeep<
       PublicApplicationState,
       | 'homeAddress'
@@ -574,7 +581,8 @@ export async function resolveSimplifiedStateHomeAddressValue(
       | 'clientApplication.contactInformation.homeAddress.country'
       | 'clientApplication.contactInformation.homeAddress.postalCode'
       | 'clientApplication.contactInformation.homeAddress.province'
-    >
+    >,
+    'homeAddress'
   >,
   locale: AppLocale,
   countryService: CountryService,
@@ -598,9 +606,10 @@ export async function resolveSimplifiedStateHomeAddressValue(
     };
   }
 
-  // If hash changed is false, client application home address fields must be defined, as the value would have
+  // If hasChanged is false, client application home address fields must be defined, as the value would have
   // been set on the state when the user made a change to the home address step, which requires client
   // application home address to be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when homeAddress.hasChanged is false');
   invariant(state.clientApplication.contactInformation.homeAddress, 'Expected clientApplication.contactInformation.homeAddress to be defined when homeAddress.hasChanged is false');
 
   return {
@@ -614,31 +623,31 @@ export async function resolveSimplifiedStateHomeAddressValue(
 }
 
 /**
- * Resolves the effective email value for a simplified application state.
+ * Resolves the effective email value for a public application state.
  * The state email (set by the user during the session) takes precedence over the
  * client application email on file.
  *
- * @param state - The simplified application state containing the optional email and client application contact information.
+ * @param state - The public application state containing the optional email and client application contact information.
  * @returns The resolved email address, or `undefined` if neither is available.
  */
-export function resolveSimplifiedStateEmailValue(state: Pick<PublicApplicationState, 'email'> & Required<PickDeep<PublicApplicationState, 'clientApplication.contactInformation.email'>>): string | undefined {
-  return state.email ?? state.clientApplication.contactInformation.email;
+export function resolvePublicStateEmailValue(state: Pick<PublicApplicationState, 'email'> & PickDeep<PublicApplicationState, 'clientApplication.contactInformation.email'>): string | undefined {
+  return state.email ?? state.clientApplication?.contactInformation.email;
 }
 
 /**
- * Resolves the effective dental benefits value for a simplified application state.
+ * Resolves the effective dental benefits value for a public application state.
  * If the user has declared a change, the updated federal and provincial program selections from the state
  * are used; otherwise, the benefit IDs from the client application are matched against both federal
  * and provincial insurance plan services to determine the applicable plans.
  *
- * @param state - The simplified application state containing dental benefits and client application dental benefits.
+ * @param state - The public application state containing dental benefits and client application dental benefits.
  * @param locale - The locale used to retrieve localized insurance plan details.
  * @param federalGovernmentInsurancePlanService - Service for resolving localized federal government insurance plans.
  * @param provincialGovernmentInsurancePlanService - Service for resolving localized provincial government insurance plans.
  * @returns The resolved federal and provincial government insurance plans, each of which may be `undefined` if not applicable.
  */
-export async function resolveSimplifiedStateDentalBenefitsValue(
-  state: Required<Pick<PublicApplicationState, 'dentalBenefits'>> & Required<PickDeep<PublicApplicationState, 'clientApplication.dentalBenefits'>>,
+export async function resolvePublicStateDentalBenefitsValue(
+  state: SetRequired<PickDeep<PublicApplicationState, 'dentalBenefits' | 'clientApplication.dentalBenefits'>, 'dentalBenefits'>,
   locale: AppLocale,
   federalGovernmentInsurancePlanService: FederalGovernmentInsurancePlanService,
   provincialGovernmentInsurancePlanService: ProvincialGovernmentInsurancePlanService,
@@ -659,6 +668,10 @@ export async function resolveSimplifiedStateDentalBenefitsValue(
     };
   }
 
+  // If hasChanged is false, client application dental benefits must be defined, as the value would have been set on the
+  // state when the user made a change to the dental benefits step, which requires client application dental benefits to
+  // be defined.
+  invariant(state.clientApplication, 'Expected clientApplication to be defined when dentalBenefits.hasChanged is false');
   invariant(state.clientApplication.dentalBenefits, 'Expected clientApplication.dentalBenefits to be defined when hasChanged is false');
 
   let federalGovernmentInsurancePlan: FederalGovernmentInsurancePlanLocalizedDto | undefined;
@@ -685,20 +698,20 @@ export async function resolveSimplifiedStateDentalBenefitsValue(
 }
 
 /**
- * Resolves the effective child dental benefits value for a simplified application state.
+ * Resolves the effective child dental benefits value for a public application state.
  * If the user has declared a change, the updated federal and provincial program selections from the state
  * are used; otherwise, the benefit IDs from the client application are matched against both federal
  * and provincial insurance plan services to determine the applicable plans.
  *
- * @param childState - The simplified application state containing child dental benefits and client application child dental benefits.
+ * @param childState - The public application state containing child dental benefits and client application child dental benefits.
  * @param locale - The locale used to retrieve localized insurance plan details.
  * @param federalGovernmentInsurancePlanService - Service for resolving localized federal government insurance plans.
  * @param provincialGovernmentInsurancePlanService - Service for resolving localized provincial government insurance plans.
  * @returns The resolved federal and provincial government insurance plans, each of which may be `undefined` if not applicable.
  */
-export async function resolveSimplifiedStateChildDentalBenefitsValue(
+export async function resolvePublicStateChildDentalBenefitsValue(
   childState: Required<Pick<PublicApplicationState['children'][number], 'dentalBenefits'>>,
-  childClientApplication: Pick<NonNullable<PublicApplicationState['clientApplication']>['children'][number], 'dentalBenefits'>,
+  childClientApplication: Pick<NonNullable<PublicApplicationState['clientApplication']>['children'][number], 'dentalBenefits'> | undefined,
   locale: AppLocale,
   federalGovernmentInsurancePlanService: FederalGovernmentInsurancePlanService,
   provincialGovernmentInsurancePlanService: ProvincialGovernmentInsurancePlanService,
@@ -718,6 +731,11 @@ export async function resolveSimplifiedStateChildDentalBenefitsValue(
         : undefined,
     };
   }
+
+  // If hasChanged is false, client application child dental benefits must be defined, as the value would have been set on the
+  // state when the user made a change to the child dental benefits step, which requires client application child dental benefits to
+  // be defined.
+  invariant(childClientApplication, 'Expected child client application to be defined when child dentalBenefits.hasChanged is false');
 
   let federalGovernmentInsurancePlan: FederalGovernmentInsurancePlanLocalizedDto | undefined;
   let provincialGovernmentInsurancePlan: ProvincialGovernmentInsurancePlanLocalizedDto | undefined;

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -9,12 +9,12 @@ import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-
 import { loadProtectedApplicationRenewalAdultState } from '~/.server/routes/helpers/protected-application-renewal-adult-route-helpers';
 import {
   clearProtectedApplicationState,
-  resolveRenewalStateCommunicationPreferencesValue,
-  resolveRenewalStateDentalBenefitsValue,
-  resolveRenewalStateEmailValue,
-  resolveRenewalStateHomeAddressValue,
-  resolveRenewalStateMailingAddressValue,
-  resolveRenewalStatePhoneNumberValue,
+  resolveProtectedStateCommunicationPreferencesValue,
+  resolveProtectedStateDentalBenefitsValue,
+  resolveProtectedStateEmailValue,
+  resolveProtectedStateHomeAddressValue,
+  resolveProtectedStateMailingAddressValue,
+  resolveProtectedStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
@@ -78,18 +78,18 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveRenewalStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveRenewalStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveRenewalStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveRenewalStateCommunicationPreferencesValue(
+  const phoneNumber = resolveProtectedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolveProtectedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolveProtectedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolveProtectedStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveRenewalStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
-  const dentalBenefits = await resolveRenewalStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const dentalBenefits = await resolveProtectedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
     memberId: state.clientApplication.applicantInformation.clientNumber,

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -10,12 +10,12 @@ import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-
 import { loadProtectedApplicationRenewalChildState } from '~/.server/routes/helpers/protected-application-renewal-child-route-helpers';
 import {
   clearProtectedApplicationState,
-  resolveRenewalStateChildDentalBenefitsValue,
-  resolveRenewalStateCommunicationPreferencesValue,
-  resolveRenewalStateEmailValue,
-  resolveRenewalStateHomeAddressValue,
-  resolveRenewalStateMailingAddressValue,
-  resolveRenewalStatePhoneNumberValue,
+  resolveProtectedStateChildDentalBenefitsValue,
+  resolveProtectedStateCommunicationPreferencesValue,
+  resolveProtectedStateEmailValue,
+  resolveProtectedStateHomeAddressValue,
+  resolveProtectedStateMailingAddressValue,
+  resolveProtectedStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
@@ -84,17 +84,17 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveRenewalStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveRenewalStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveRenewalStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveRenewalStateCommunicationPreferencesValue(
+  const phoneNumber = resolveProtectedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolveProtectedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolveProtectedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolveProtectedStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveRenewalStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,
@@ -139,7 +139,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       invariant(childApplication?.dentalBenefits, `Expected dental benefits for child with memberId ${childState.information?.memberId}`);
       invariant(childState.dentalInsurance, "Child's dental insurance must be defined");
 
-      const childDentalBenefits = await resolveRenewalStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+      const childDentalBenefits = await resolveProtectedStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
       const eligibility = getEligibilityStatus({
         hasPrivateDentalInsurance: childState.dentalInsurance.hasDentalInsurance,
         privateDentalInsuranceOnRecord: childApplication.privateDentalInsurance,

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -10,13 +10,13 @@ import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-
 import { loadProtectedApplicationRenewalFamilyState } from '~/.server/routes/helpers/protected-application-renewal-family-route-helpers';
 import {
   clearProtectedApplicationState,
-  resolveRenewalStateChildDentalBenefitsValue,
-  resolveRenewalStateCommunicationPreferencesValue,
-  resolveRenewalStateDentalBenefitsValue,
-  resolveRenewalStateEmailValue,
-  resolveRenewalStateHomeAddressValue,
-  resolveRenewalStateMailingAddressValue,
-  resolveRenewalStatePhoneNumberValue,
+  resolveProtectedStateChildDentalBenefitsValue,
+  resolveProtectedStateCommunicationPreferencesValue,
+  resolveProtectedStateDentalBenefitsValue,
+  resolveProtectedStateEmailValue,
+  resolveProtectedStateHomeAddressValue,
+  resolveProtectedStateMailingAddressValue,
+  resolveProtectedStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
@@ -87,18 +87,18 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveRenewalStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveRenewalStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveRenewalStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveRenewalStateCommunicationPreferencesValue(
+  const phoneNumber = resolveProtectedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolveProtectedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolveProtectedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolveProtectedStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveRenewalStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
-  const dentalBenefits = await resolveRenewalStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const dentalBenefits = await resolveProtectedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
     memberId: state.applicantInformation.memberId,
@@ -149,7 +149,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       invariant(childApplication?.dentalBenefits, `Expected dental benefits for child with memberId ${childState.information?.memberId}`);
       invariant(childState.dentalInsurance, "Child's dental insurance must be defined");
 
-      const childDentalBenefits = await resolveRenewalStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+      const childDentalBenefits = await resolveProtectedStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
       const eligibility = getEligibilityStatus({
         hasPrivateDentalInsurance: childState.dentalInsurance.hasDentalInsurance,
         privateDentalInsuranceOnRecord: childApplication.privateDentalInsurance,

--- a/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
@@ -8,12 +8,12 @@ import { TYPES } from '~/.server/constants';
 import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-route-helpers';
 import {
   clearPublicApplicationState,
-  resolveSimplifiedStateCommunicationPreferencesValue,
-  resolveSimplifiedStateDentalBenefitsValue,
-  resolveSimplifiedStateEmailValue,
-  resolveSimplifiedStateHomeAddressValue,
-  resolveSimplifiedStateMailingAddressValue,
-  resolveSimplifiedStatePhoneNumberValue,
+  resolvePublicStateCommunicationPreferencesValue,
+  resolvePublicStateDentalBenefitsValue,
+  resolvePublicStateEmailValue,
+  resolvePublicStateHomeAddressValue,
+  resolvePublicStateMailingAddressValue,
+  resolvePublicStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedAdultState } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
@@ -76,18 +76,18 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveSimplifiedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveSimplifiedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveSimplifiedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveSimplifiedStateCommunicationPreferencesValue(
+  const phoneNumber = resolvePublicStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolvePublicStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolvePublicStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolvePublicStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveSimplifiedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
-  const dentalBenefits = await resolveSimplifiedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const dentalBenefits = await resolvePublicStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,

--- a/frontend/app/routes/public/application/simplified-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-children/confirmation.tsx
@@ -9,12 +9,12 @@ import { TYPES } from '~/.server/constants';
 import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-route-helpers';
 import {
   clearPublicApplicationState,
-  resolveSimplifiedStateChildDentalBenefitsValue,
-  resolveSimplifiedStateCommunicationPreferencesValue,
-  resolveSimplifiedStateEmailValue,
-  resolveSimplifiedStateHomeAddressValue,
-  resolveSimplifiedStateMailingAddressValue,
-  resolveSimplifiedStatePhoneNumberValue,
+  resolvePublicStateChildDentalBenefitsValue,
+  resolvePublicStateCommunicationPreferencesValue,
+  resolvePublicStateEmailValue,
+  resolvePublicStateHomeAddressValue,
+  resolvePublicStateMailingAddressValue,
+  resolvePublicStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedChildState } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
@@ -76,17 +76,17 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveSimplifiedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveSimplifiedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveSimplifiedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveSimplifiedStateCommunicationPreferencesValue(
+  const phoneNumber = resolvePublicStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolvePublicStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolvePublicStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolvePublicStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveSimplifiedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,
@@ -136,7 +136,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       invariant(childApplication?.dentalBenefits, `Expected dental benefits for child with memberId ${childState.information?.memberId}`);
       invariant(childState.dentalInsurance, "Child's dental insurance must be defined");
 
-      const childDentalBenefits = await resolveSimplifiedStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+      const childDentalBenefits = await resolvePublicStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
       const eligibility = getEligibilityStatus({
         hasPrivateDentalInsurance: childState.dentalInsurance.hasDentalInsurance,
         privateDentalInsuranceOnRecord: childApplication.privateDentalInsurance,

--- a/frontend/app/routes/public/application/simplified-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-family/confirmation.tsx
@@ -9,13 +9,13 @@ import { TYPES } from '~/.server/constants';
 import { getEligibilityStatus } from '~/.server/routes/helpers/base-application-route-helpers';
 import {
   clearPublicApplicationState,
-  resolveSimplifiedStateChildDentalBenefitsValue,
-  resolveSimplifiedStateCommunicationPreferencesValue,
-  resolveSimplifiedStateDentalBenefitsValue,
-  resolveSimplifiedStateEmailValue,
-  resolveSimplifiedStateHomeAddressValue,
-  resolveSimplifiedStateMailingAddressValue,
-  resolveSimplifiedStatePhoneNumberValue,
+  resolvePublicStateChildDentalBenefitsValue,
+  resolvePublicStateCommunicationPreferencesValue,
+  resolvePublicStateDentalBenefitsValue,
+  resolvePublicStateEmailValue,
+  resolvePublicStateHomeAddressValue,
+  resolvePublicStateMailingAddressValue,
+  resolvePublicStatePhoneNumberValue,
   validateApplicationFlow,
 } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedFamilyState } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
@@ -79,18 +79,18 @@ export async function loader({ context: { appContainer, session }, params, reque
   const provincialGovernmentInsurancePlanService = appContainer.get(TYPES.ProvincialGovernmentInsurancePlanService);
   const sunLifeCommunicationMethodService = appContainer.get(TYPES.SunLifeCommunicationMethodService);
 
-  const phoneNumber = resolveSimplifiedStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
-  const mailingAddress = await resolveSimplifiedStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
-  const homeAddress = await resolveSimplifiedStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
-  const communicationPreferences = resolveSimplifiedStateCommunicationPreferencesValue(
+  const phoneNumber = resolvePublicStatePhoneNumberValue({ clientApplication: state.clientApplication, phoneNumber: state.phoneNumber });
+  const mailingAddress = await resolvePublicStateMailingAddressValue({ clientApplication: state.clientApplication, mailingAddress: state.mailingAddress }, locale, countryService, provinceTerritoryStateService);
+  const homeAddress = await resolvePublicStateHomeAddressValue({ clientApplication: state.clientApplication, homeAddress: state.homeAddress }, locale, countryService, provinceTerritoryStateService);
+  const communicationPreferences = resolvePublicStateCommunicationPreferencesValue(
     { clientApplication: state.clientApplication, communicationPreferences: state.communicationPreferences },
     locale,
     languageService,
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveSimplifiedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
-  const dentalBenefits = await resolveSimplifiedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+  const dentalBenefits = await resolvePublicStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
     memberId: state.applicantInformation.memberId,
@@ -147,7 +147,7 @@ export async function loader({ context: { appContainer, session }, params, reque
       invariant(childApplication?.dentalBenefits, `Expected dental benefits for child with memberId ${childState.information?.memberId}`);
       invariant(childState.dentalInsurance, "Child's dental insurance must be defined");
 
-      const childDentalBenefits = await resolveSimplifiedStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
+      const childDentalBenefits = await resolvePublicStateChildDentalBenefitsValue({ dentalBenefits: childState.dentalBenefits }, childApplication, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
       const eligibility = getEligibilityStatus({
         hasPrivateDentalInsurance: childState.dentalInsurance.hasDentalInsurance,
         privateDentalInsuranceOnRecord: childApplication.privateDentalInsurance,


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request updates the test file `protected-application-route-helpers.test.ts` to use the new `resolveProtectedState*` helper function names instead of the old `resolveRenewalState*` names. All relevant imports, describe blocks, and function calls have been renamed for consistency with the updated helper functions.

The most important changes are:

**Test helper renaming:**

* Updated all imports from `resolveRenewalState*` to `resolveProtectedState*` in `protected-application-route-helpers.test.ts` to match the new function names.
* Renamed all `describe` blocks and test cases to use the new `resolveProtectedState*` function names. [[1]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L68-R68) [[2]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L127-R134) [[3]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L152-R156) [[4]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L228-R235) [[5]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L307-R321) [[6]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L339-R343) [[7]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L396-R396)

**Test implementation updates:**

* Replaced all calls to the old `resolveRenewalState*` functions with calls to the corresponding new `resolveProtectedState*` functions throughout the test cases. [[1]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L90-R90) [[2]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L118-R118) [[3]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L143-R143) [[4]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L174-R174) [[5]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L192-R192) [[6]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L211-R211) [[7]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L253-R253) [[8]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L271-R271) [[9]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L290-R290) [[10]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L330-R330) [[11]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L361-R361) [[12]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L378-R378) [[13]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L412-R412) [[14]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L428-R428)
