### PR TITLE
refactor(frontend): enhance email resolution logic and guard email display in confirmation pages

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
@@ -312,9 +312,10 @@ describe('protected-application-route-helpers', () => {
   });
 
   describe('resolveProtectedStateEmailValue', () => {
-    it('returns state email when it is defined', () => {
+    it('returns state email when it is a valid email and emailVerified is true', () => {
       const state = {
         email: 'user@example.com',
+        emailVerified: true,
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
@@ -324,6 +325,27 @@ describe('protected-application-route-helpers', () => {
     it('falls back to client application email when state email is undefined', () => {
       const state = {
         email: undefined,
+        emailVerified: undefined,
+        clientApplication: { contactInformation: { email: 'client@example.com' } },
+      } as const;
+
+      expect(resolveProtectedStateEmailValue(state)).toBe('client@example.com');
+    });
+
+    it('falls back to client application email when state email is invalid', () => {
+      const state = {
+        email: 'not-a-valid-email',
+        emailVerified: true,
+        clientApplication: { contactInformation: { email: 'client@example.com' } },
+      } as const;
+
+      expect(resolveProtectedStateEmailValue(state)).toBe('client@example.com');
+    });
+
+    it('falls back to client application email when emailVerified is false', () => {
+      const state = {
+        email: 'user@example.com',
+        emailVerified: false,
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
@@ -333,7 +355,18 @@ describe('protected-application-route-helpers', () => {
     it('returns undefined when both state and client application emails are undefined', () => {
       const state = {
         email: undefined,
+        emailVerified: undefined,
         clientApplication: { contactInformation: { email: undefined } },
+      } as const;
+
+      expect(resolveProtectedStateEmailValue(state)).toBeUndefined();
+    });
+
+    it('returns undefined when clientApplication is undefined', () => {
+      const state = {
+        email: undefined,
+        emailVerified: undefined,
+        clientApplication: undefined,
       } as const;
 
       expect(resolveProtectedStateEmailValue(state)).toBeUndefined();

--- a/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
@@ -278,9 +278,10 @@ describe('public-application-route-helpers', () => {
   });
 
   describe('resolvePublicStateEmailValue', () => {
-    it('returns state email when it is defined', () => {
+    it('returns state email when it is a valid email and emailVerified is true', () => {
       const state = {
         email: 'user@example.com',
+        emailVerified: true,
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
@@ -290,6 +291,27 @@ describe('public-application-route-helpers', () => {
     it('falls back to client application email when state email is undefined', () => {
       const state = {
         email: undefined,
+        emailVerified: undefined,
+        clientApplication: { contactInformation: { email: 'client@example.com' } },
+      } as const;
+
+      expect(resolvePublicStateEmailValue(state)).toBe('client@example.com');
+    });
+
+    it('falls back to client application email when state email is invalid', () => {
+      const state = {
+        email: 'not-a-valid-email',
+        emailVerified: true,
+        clientApplication: { contactInformation: { email: 'client@example.com' } },
+      } as const;
+
+      expect(resolvePublicStateEmailValue(state)).toBe('client@example.com');
+    });
+
+    it('falls back to client application email when emailVerified is false', () => {
+      const state = {
+        email: 'user@example.com',
+        emailVerified: false,
         clientApplication: { contactInformation: { email: 'client@example.com' } },
       } as const;
 
@@ -299,7 +321,18 @@ describe('public-application-route-helpers', () => {
     it('returns undefined when both state and client application emails are undefined', () => {
       const state = {
         email: undefined,
+        emailVerified: undefined,
         clientApplication: { contactInformation: { email: undefined } },
+      } as const;
+
+      expect(resolvePublicStateEmailValue(state)).toBeUndefined();
+    });
+
+    it('returns undefined when clientApplication is undefined', () => {
+      const state = {
+        email: undefined,
+        emailVerified: undefined,
+        clientApplication: undefined,
       } as const;
 
       expect(resolvePublicStateEmailValue(state)).toBeUndefined();

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -5,6 +5,7 @@ import { UTCDate } from '@date-fns/utc';
 import { invariant } from '@dts-stn/invariant';
 import { differenceInMinutes } from 'date-fns';
 import type { PickDeep, ReadonlyDeep, SetRequired } from 'type-fest';
+import validator from 'validator';
 
 import type {
   ClientApplicationRenewalEligibleDto,
@@ -750,8 +751,9 @@ export async function resolveProtectedStateHomeAddressValue(
  * @param state - The protected application state containing the optional email and client application contact information.
  * @returns The resolved email address, or `undefined` if neither is available.
  */
-export function resolveProtectedStateEmailValue(state: PickDeep<ProtectedApplicationState, 'email' | 'clientApplication.contactInformation.email'>): string | undefined {
-  return state.email ?? state.clientApplication?.contactInformation.email;
+export function resolveProtectedStateEmailValue(state: PickDeep<ProtectedApplicationState, 'email' | 'emailVerified' | 'clientApplication.contactInformation.email'>): string | undefined {
+  const hasValidEmailInState = typeof state.email === 'string' && validator.isEmail(state.email) && state.emailVerified === true;
+  return hasValidEmailInState ? state.email : state.clientApplication?.contactInformation.email;
 }
 
 /**

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -5,6 +5,7 @@ import { UTCDate } from '@date-fns/utc';
 import { invariant } from '@dts-stn/invariant';
 import { differenceInMinutes } from 'date-fns';
 import type { PickDeep, ReadonlyDeep, SetRequired } from 'type-fest';
+import validator from 'validator';
 
 import type {
   ClientApplicationRenewalEligibleDto,
@@ -630,8 +631,9 @@ export async function resolvePublicStateHomeAddressValue(
  * @param state - The public application state containing the optional email and client application contact information.
  * @returns The resolved email address, or `undefined` if neither is available.
  */
-export function resolvePublicStateEmailValue(state: Pick<PublicApplicationState, 'email'> & PickDeep<PublicApplicationState, 'clientApplication.contactInformation.email'>): string | undefined {
-  return state.email ?? state.clientApplication?.contactInformation.email;
+export function resolvePublicStateEmailValue(state: PickDeep<PublicApplicationState, 'email' | 'emailVerified' | 'clientApplication.contactInformation.email'>): string | undefined {
+  const hasValidEmailInState = typeof state.email === 'string' && validator.isEmail(state.email) && state.emailVerified === true;
+  return hasValidEmailInState ? state.email : state.clientApplication?.contactInformation.email;
 }
 
 /**

--- a/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeAdultState } from '~/.server/routes/helpers/protected-application-intake-adult-route-helpers';
-import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, resolveProtectedStateEmailValue, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -83,7 +83,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -311,7 +311,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
@@ -83,7 +83,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -276,9 +276,9 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -311,7 +311,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/intake-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-children/confirmation.tsx
@@ -77,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -302,9 +302,9 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -337,7 +337,7 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/intake-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-children/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeChildState } from '~/.server/routes/helpers/protected-application-intake-child-route-helpers';
-import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, resolveProtectedStateEmailValue, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -77,7 +77,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -300,11 +300,11 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
                 {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -337,7 +337,6 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/intake-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-family/confirmation.tsx
@@ -87,7 +87,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -318,9 +318,9 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -353,7 +353,7 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/intake-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-family/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeFamilyState } from '~/.server/routes/helpers/protected-application-intake-family-route-helpers';
-import { clearProtectedApplicationState, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, resolveProtectedStateEmailValue, shouldSkipNewOrReturningMember, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -87,7 +87,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
   };
 
@@ -316,11 +316,11 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
                 {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -353,7 +353,6 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -101,7 +101,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.clientApplication.dateOfBirth), locale),
     sin: state.clientApplication.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: email,
+    email: email,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
   };
 
@@ -315,9 +315,9 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
                     <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                   </DefinitionListItem>
                 )}
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -350,7 +350,7 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -88,7 +88,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+
   const dentalBenefits = await resolveProtectedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
@@ -101,7 +101,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.clientApplication.dateOfBirth), locale),
     sin: state.clientApplication.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
   };
 
@@ -350,7 +350,6 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -94,7 +94,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,
@@ -105,7 +104,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     memberId: state.applicantInformation.memberId,
   };
@@ -343,11 +342,11 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
                 {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -380,7 +379,6 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -105,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: email,
+    email: email,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     memberId: state.applicantInformation.memberId,
   };
@@ -345,9 +345,9 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -380,7 +380,7 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -110,7 +110,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: email,
+    email: email,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
   };
 
@@ -368,9 +368,9 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -403,7 +403,7 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -97,7 +97,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolveProtectedStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
+
   const dentalBenefits = await resolveProtectedStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
@@ -110,7 +110,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: email,
+    email: resolveProtectedStateEmailValue(state),
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
   };
 
@@ -366,11 +366,11 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
                 {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -403,7 +403,6 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullAdultState } from '~/.server/routes/helpers/public-application-full-adult-route-helpers';
-import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, getMemberIdForFullApplication, resolvePublicStateEmailValue, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -80,7 +80,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolvePublicStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -273,11 +273,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -309,7 +304,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/full-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-adult/confirmation.tsx
@@ -80,7 +80,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -273,9 +273,9 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail}</span>
+                    <span className="text-nowrap">{userInfo.email}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -309,7 +309,7 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -74,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -300,9 +300,9 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -336,7 +336,7 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/public/application/full-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-children/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullChildState } from '~/.server/routes/helpers/public-application-full-child-route-helpers';
-import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, getMemberIdForFullApplication, resolvePublicStateEmailValue, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -74,7 +74,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolvePublicStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -298,13 +298,8 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -336,7 +331,7 @@ export default function NewChildrenConfirmation({ loaderData, params }: Route.Co
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>}
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -84,7 +84,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    contactInformationEmail: state.email,
+    email: state.email,
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -315,9 +315,9 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.contactInformationEmail} </span>
+                    <span className="text-nowrap">{userInfo.email} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -351,7 +351,7 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.contactInformationEmail}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/full-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/full-family/confirmation.tsx
@@ -6,7 +6,7 @@ import type { Route } from './+types/confirmation';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullFamilyState } from '~/.server/routes/helpers/public-application-full-family-route-helpers';
-import { clearPublicApplicationState, getMemberIdForFullApplication, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, getMemberIdForFullApplication, resolvePublicStateEmailValue, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { Address } from '~/components/address';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -84,7 +84,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     birthday: toLocaleDateString(parseDateString(state.applicantInformation.dateOfBirth), locale),
     sin: state.applicantInformation.socialInsuranceNumber,
     maritalStatus: state.maritalStatus ? appContainer.get(TYPES.MaritalStatusService).getLocalizedMaritalStatusById(state.maritalStatus, locale).name : '',
-    email: state.email,
+    email: resolvePublicStateEmailValue(state),
     communicationSunLifePreference: appContainer.get(TYPES.SunLifeCommunicationMethodService).getLocalizedSunLifeCommunicationMethodById(state.communicationPreferences.value.preferredMethod, locale),
     communicationGOCPreference: appContainer.get(TYPES.GCCommunicationMethodService).getLocalizedGCCommunicationMethodById(state.communicationPreferences.value.preferredNotificationMethod, locale),
   };
@@ -313,13 +313,8 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
                   <span className="text-nowrap">{userInfo.phoneNumber}</span>
                 </DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
-                  <span className="text-nowrap">{userInfo.altPhoneNumber} </span>
+                  <span className="text-nowrap">{userInfo.altPhoneNumber}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email} </span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -351,7 +346,7 @@ export default function NewFamilyConfirmation({ loaderData, params }: Route.Comp
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationSunLifePreference.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.communicationGOCPreference.name}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.email}</DefinitionListItem>}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
@@ -102,7 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    contactInformationEmail: email,
+    email: email,
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -301,9 +301,9 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -345,7 +345,7 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/confirmation.tsx
@@ -86,7 +86,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
   const dentalBenefits = await resolvePublicStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
@@ -102,7 +101,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    email: email,
+    email: resolvePublicStateEmailValue(state),
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -301,11 +300,6 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)} </span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   {mailingAddressInfo.hasMailingAddressChanged ? (
                     <Address
@@ -345,7 +339,7 @@ export default function RenewAdultConfirm({ loaderData, params }: Route.Componen
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/simplified-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-children/confirmation.tsx
@@ -86,7 +86,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
 
   const userInfo = {
     firstName: state.applicantInformation.firstName,
@@ -102,7 +101,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    email: email,
+    email: resolvePublicStateEmailValue(state),
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -331,11 +330,6 @@ export default function RenewChildrenConfirmation({ loaderData, params }: Route.
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   {mailingAddressInfo.hasMailingAddressChanged ? (
                     <Address
@@ -375,7 +369,7 @@ export default function RenewChildrenConfirmation({ loaderData, params }: Route.
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>}
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/public/application/simplified-children/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-children/confirmation.tsx
@@ -102,7 +102,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    contactInformationEmail: email,
+    email: email,
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -331,9 +331,9 @@ export default function RenewChildrenConfirmation({ loaderData, params }: Route.
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</span>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -375,7 +375,7 @@ export default function RenewChildrenConfirmation({ loaderData, params }: Route.
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/public/application/simplified-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-family/confirmation.tsx
@@ -106,7 +106,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    contactInformationEmail: email,
+    email: email,
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -355,9 +355,9 @@ export default function SimplifiedFamilyConfirmation({ loaderData, params }: Rou
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.contactInformationEmail && (
+                {userInfo.email && (
                   <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)} </span>
+                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)} </span>
                   </DefinitionListItem>
                 )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
@@ -399,7 +399,7 @@ export default function SimplifiedFamilyConfirmation({ loaderData, params }: Rou
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.contactInformationEmail : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/public/application/simplified-family/confirmation.tsx
+++ b/frontend/app/routes/public/application/simplified-family/confirmation.tsx
@@ -89,7 +89,6 @@ export async function loader({ context: { appContainer, session }, params, reque
     sunLifeCommunicationMethodService,
     gcCommunicationMethodService,
   );
-  const email = resolvePublicStateEmailValue({ clientApplication: state.clientApplication, email: state.email });
   const dentalBenefits = await resolvePublicStateDentalBenefitsValue({ dentalBenefits: state.dentalBenefits, clientApplication: state.clientApplication }, locale, federalGovernmentInsurancePlanService, provincialGovernmentInsurancePlanService);
 
   const userInfo = {
@@ -106,7 +105,7 @@ export async function loader({ context: { appContainer, session }, params, reque
     preferredLanguage: communicationPreferences.preferredLanguage,
     communicationSunLifePreference: communicationPreferences.preferredMethodSunLife,
     communicationGOCPreference: communicationPreferences.preferredMethodGovernmentOfCanada,
-    email: email,
+    email: resolvePublicStateEmailValue(state),
   };
 
   const spouseInfo = state.partnerInformation && {
@@ -355,11 +354,6 @@ export default function SimplifiedFamilyConfirmation({ loaderData, params }: Rou
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.hasPhoneNumberChanged ? userInfo.altPhoneNumber : t(($) => $.confirm.noUpdate)}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)} </span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   {mailingAddressInfo.hasMailingAddressChanged ? (
                     <Address
@@ -399,7 +393,7 @@ export default function SimplifiedFamilyConfirmation({ loaderData, params }: Rou
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.preferredLanguage.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationSunLifePreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.gocCommPrefTitle)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.communicationGOCPreference.name : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
-                <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>
+                {userInfo.email && <DefinitionListItem term={t(($) => $.confirm.email)}>{userInfo.hasCommunicationPreferencesChanged ? userInfo.email : t(($) => $.confirm.noUpdate)}</DefinitionListItem>}
               </DefinitionList>
             </section>
 


### PR DESCRIPTION
### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request enhances how email addresses are resolved and displayed throughout the protected and public application flows. The main improvement is stricter validation: user-provided emails are only used if they are valid and verified; otherwise, the system falls back to the client application's contact email. This change is consistently applied in both backend logic and frontend display, and is thoroughly tested.

The most important changes are:

**Email resolution logic:**

* Updated `resolveProtectedStateEmailValue` and `resolvePublicStateEmailValue` to only return the user's email if it is both valid (per `validator.isEmail`) and `emailVerified` is `true`; otherwise, the client application's contact email is used. If neither is available, `undefined` is returned. (`frontend/app/.server/routes/helpers/protected-application-route-helpers.ts` [[1]](diffhunk://#diff-039c8b364a90138a6c482f90803bfe32f2a2f52954c3e634141fd2cee3f68b9dL753-R756) `frontend/app/.server/routes/helpers/public-application-route-helpers.ts` [[2]](diffhunk://#diff-a4df438b0b3a9519e2893cc5e2341f86b025acb957475ddbe4a5d3aff65c27baL633-R636)

**Frontend integration:**

* Refactored confirmation pages (`intake-adult`, `intake-children`, `intake-family`) to use the new email resolution logic, ensuring only valid, verified emails are displayed. Updated variable names and conditional rendering to match the new logic. (`frontend/app/routes/protected/application/intake-adult/confirmation.tsx` [[1]](diffhunk://#diff-43e61c3d1e5b0474431750b376c4358fed8526461a992b3a603351f071789275L86-R86) [[2]](diffhunk://#diff-43e61c3d1e5b0474431750b376c4358fed8526461a992b3a603351f071789275L279-R281) [[3]](diffhunk://#diff-43e61c3d1e5b0474431750b376c4358fed8526461a992b3a603351f071789275L314); `frontend/app/routes/protected/application/intake-children/confirmation.tsx` [[4]](diffhunk://#diff-f329064a804f4b4c6875303594039f5d4a7e2932b6612369a1d518a142b7b7ddL80-R80) [[5]](diffhunk://#diff-f329064a804f4b4c6875303594039f5d4a7e2932b6612369a1d518a142b7b7ddL305-R307) [[6]](diffhunk://#diff-f329064a804f4b4c6875303594039f5d4a7e2932b6612369a1d518a142b7b7ddL340); `frontend/app/routes/protected/application/intake-family/confirmation.tsx` [[7]](diffhunk://#diff-866cca11a9d6f73099e6da33baa9ac520a69c4f56fc0bdd6100e7b577ed3b20aL90-R90) [[8]](diffhunk://#diff-866cca11a9d6f73099e6da33baa9ac520a69c4f56fc0bdd6100e7b577ed3b20aL321-R323) [[9]](diffhunk://#diff-866cca11a9d6f73099e6da33baa9ac520a69c4f56fc0bdd6100e7b577ed3b20aL356)

**Test coverage:**

* Expanded and clarified tests for both email resolution helpers to cover all edge cases: valid/invalid emails, verified/unverified status, and missing client application data. (`frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts` [[1]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056L315-R318) [[2]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056R328-R348) [[3]](diffhunk://#diff-91254ea35c82f6634ffdd78d092d06ef9ccf3dca89f64d856ab78aea68316056R358-R373); `frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts` [[4]](diffhunk://#diff-65ecb6ca384b760532fcc240edf60224cc27f62c1d8118bedad58e3f6a857c4fL281-R284) [[5]](diffhunk://#diff-65ecb6ca384b760532fcc240edf60224cc27f62c1d8118bedad58e3f6a857c4fR294-R314) [[6]](diffhunk://#diff-65ecb6ca384b760532fcc240edf60224cc27f62c1d8118bedad58e3f6a857c4fR324-R339)

**Code maintenance:**

* Updated imports to include the `validator` library where needed. (`frontend/app/.server/routes/helpers/protected-application-route-helpers.ts` [[1]](diffhunk://#diff-039c8b364a90138a6c482f90803bfe32f2a2f52954c3e634141fd2cee3f68b9dR8) `frontend/app/.server/routes/helpers/public-application-route-helpers.ts` [[2]](diffhunk://#diff-a4df438b0b3a9519e2893cc5e2341f86b025acb957475ddbe4a5d3aff65c27baR8)
* Cleaned up unused variables and references to the old email property in confirmation pages. (`frontend/app/routes/protected/application/renewal-adult/confirmation.tsx` [frontend/app/routes/protected/application/renewal-adult/confirmation.tsxL91-R91](diffhunk://#diff-ace407a568f33f7da3269a1d2a34692c75c4183826f93972bbbeae4b570bcc2aL91-R91))

These changes ensure greater data integrity and a better user experience by preventing the display or use of invalid or unverified email addresses.