### PR TITLE
feat(frontend): add hcaptcha to public and protected routes

### DIFF
--- a/frontend/app/routes/protected/application/intake-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeAdultStateForReview } from '~/.server/routes/helpers/protected-application-intake-adult-route-helpers';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/intake-adult/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -79,6 +81,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -113,6 +119,27 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -145,8 +172,9 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/protected/application/intake-children/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-children/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeChildStateForReview } from '~/.server/routes/helpers/protected-application-intake-child-route-helpers';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/intake-children/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -85,6 +87,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -121,6 +127,27 @@ export default function ProtectedNewChildrenSubmit({ loaderData, params }: Route
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -155,8 +182,9 @@ export default function ProtectedNewChildrenSubmit({ loaderData, params }: Route
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/protected/application/intake-family/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-family/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationIntakeFamilyStateForReview } from '~/.server/routes/helpers/protected-application-intake-family-route-helpers';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/intake-family/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -86,6 +88,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -122,6 +128,27 @@ export default function ProtectedNewFamilySubmit({ loaderData, params }: Route.C
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -157,8 +184,9 @@ export default function ProtectedNewFamilySubmit({ loaderData, params }: Route.C
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationIntakeFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/protected/application/renewal-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalAdultStateForReview } from '~/.server/routes/helpers/protected-application-renewal-adult-route-helpers';
-import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/renewal-adult/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -82,6 +84,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -117,6 +123,27 @@ export default function ProtectedNewAdultSubmit({ loaderData, params }: Route.Co
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -149,8 +176,9 @@ export default function ProtectedNewAdultSubmit({ loaderData, params }: Route.Co
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/protected/application/renewal-children/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalChildStateForReview } from '~/.server/routes/helpers/protected-application-renewal-child-route-helpers';
-import { saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/renewal-children/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -86,6 +88,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -123,6 +129,27 @@ export default function ProtectedRenewChildrenSubmit({ loaderData, params }: Rou
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -157,8 +184,9 @@ export default function ProtectedRenewChildrenSubmit({ loaderData, params }: Rou
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/protected/application/renewal-family/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadProtectedApplicationRenewalFamilyStateForReview } from '~/.server/routes/helpers/protected-application-renewal-family-route-helpers';
-import { saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { clearProtectedApplicationState, saveProtectedApplicationState, shouldSkipMaritalStatus, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/protected/application/renewal-family/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -88,6 +90,10 @@ export async function action({ context: { appContainer, session }, request, para
   const t = await getFixedT(request, handle.i18nNamespaces);
 
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearProtectedApplicationState({ params, session });
+    throw redirect(getPathById('protected/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -125,6 +131,27 @@ export default function ProtectedRenewalFamilySubmit({ loaderData, params }: Rou
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -160,8 +187,9 @@ export default function ProtectedRenewalFamilySubmit({ loaderData, params }: Rou
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.protectedApplicationRenewalFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/full-adult/submit.tsx
+++ b/frontend/app/routes/public/application/full-adult/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullAdultStateForReview } from '~/.server/routes/helpers/public-application-full-adult-route-helpers';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/full-adult/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -83,6 +85,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -124,6 +130,27 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
   const { isSubmitting } = useFetcherSubmissionState(fetcher);
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -156,8 +183,9 @@ export default function NewAdultSubmit({ loaderData, params }: Route.ComponentPr
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/full-children/submit.tsx
+++ b/frontend/app/routes/public/application/full-children/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullChildStateForReview } from '~/.server/routes/helpers/public-application-full-child-route-helpers';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/full-children/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -88,6 +90,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -131,6 +137,27 @@ export default function NewChildrenSubmit({ loaderData, params }: Route.Componen
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -165,8 +192,9 @@ export default function NewChildrenSubmit({ loaderData, params }: Route.Componen
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/full-family/submit.tsx
+++ b/frontend/app/routes/public/application/full-family/submit.tsx
@@ -1,6 +1,7 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
@@ -8,7 +9,7 @@ import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
 import { loadPublicApplicationFullFamilyStateForReview } from '~/.server/routes/helpers/public-application-full-family-route-helpers';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/full-family/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -89,6 +91,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -132,6 +138,27 @@ export default function NewFamilySubmit({ loaderData, params }: Route.ComponentP
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -167,8 +194,9 @@ export default function NewFamilySubmit({ loaderData, params }: Route.ComponentP
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationFullFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/simplified-adult/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/submit.tsx
@@ -1,13 +1,14 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
 import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedAdultStateForReview } from '~/.server/routes/helpers/public-application-simplified-adult-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/simplified-adult/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -75,6 +77,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -111,6 +117,27 @@ export default function RenewAdultSubmit({ loaderData, params }: Route.Component
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -143,8 +170,9 @@ export default function RenewAdultSubmit({ loaderData, params }: Route.Component
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedAdult.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/simplified-children/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-children/submit.tsx
@@ -1,13 +1,14 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
 import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedChildStateForReview } from '~/.server/routes/helpers/public-application-simplified-child-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/simplified-children/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -80,6 +82,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -116,6 +122,27 @@ export default function RenewChildrenSubmit({ loaderData, params }: Route.Compon
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -150,8 +177,9 @@ export default function RenewChildrenSubmit({ loaderData, params }: Route.Compon
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedChild.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}

--- a/frontend/app/routes/public/application/simplified-family/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-family/submit.tsx
@@ -1,13 +1,14 @@
 import { data, redirect, useFetcher } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
+import HCaptcha from '@hcaptcha/react-hcaptcha';
 import { Trans, useTranslation } from 'react-i18next';
 import * as z from 'zod';
 
 import type { Route } from './+types/submit';
 
 import { TYPES } from '~/.server/constants';
-import { savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { clearPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { loadPublicApplicationSimplifiedFamilyStateForReview } from '~/.server/routes/helpers/public-application-simplified-family-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -21,8 +22,9 @@ import { InlineLink } from '~/components/inline-link';
 import { InputCheckbox } from '~/components/input-checkbox';
 import { LoadingButton } from '~/components/loading-button';
 import { NavigationButtonLink } from '~/components/navigation-buttons';
-import { useFetcherSubmissionState } from '~/hooks';
+import { useFetcherSubmissionState, useHCaptcha } from '~/hooks';
 import { pageIds } from '~/page-ids';
+import { useFeature } from '~/root';
 import { ProgressStepper } from '~/routes/public/application/simplified-family/progress-stepper';
 import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
@@ -81,6 +83,10 @@ export async function action({ context: { appContainer, session }, request, para
 
   const securityHandler = appContainer.get(TYPES.SecurityHandler);
   securityHandler.validateCsrfToken({ formData, session });
+  await securityHandler.validateHCaptchaResponse({ formData, request }, () => {
+    clearPublicApplicationState({ params, session });
+    throw redirect(getPathById('public/unable-to-process-request', params));
+  });
 
   const submitTermsSchema = z.object({
     acknowledgeInfo: z.literal(true, {
@@ -117,6 +123,27 @@ export default function SimplifiedFamilySubmit({ loaderData, params }: Route.Com
 
   const errors = fetcher.data?.errors;
 
+  const hCaptchaEnabled = useFeature('hcaptcha');
+  const { captchaRef, onLoad, sitekey } = useHCaptcha();
+
+  async function handleSubmit(event: React.SyntheticEvent<HTMLFormElement, SubmitEvent>) {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+
+    if (hCaptchaEnabled && captchaRef.current) {
+      try {
+        const response = captchaRef.current.getResponse();
+        formData.set('h-captcha-response', response);
+      } catch {
+        /* intentionally ignore and proceed with submission */
+      } finally {
+        captchaRef.current.resetCaptcha();
+      }
+    }
+
+    await fetcher.submit(formData, { method: 'POST' });
+  }
+
   const eligibilityLink = <InlineLink to={t(($) => $.submit.doYouQualifyHref)} className="external-link" newTabIndicator target="_blank" />;
 
   return (
@@ -152,8 +179,9 @@ export default function SimplifiedFamilySubmit({ loaderData, params }: Route.Com
               <p>
                 <Trans ns={handle.i18nNamespaces} i18nKey={($) => $.applicationSimplifiedFamily.submit.reviewEligibilityCriteria} components={{ eligibilityLink }} />
               </p>
-              <fetcher.Form method="post" noValidate>
+              <fetcher.Form method="post" onSubmit={handleSubmit} noValidate>
                 <CsrfTokenInput />
+                {hCaptchaEnabled && <HCaptcha size="invisible" sitekey={sitekey} ref={captchaRef} onLoad={onLoad} />}
                 <div className="space-y-2">
                   <InputCheckbox id="acknowledge-info" name="acknowledgeInfo" value={CHECKBOX_VALUE.yes} errorMessage={errors?.acknowledgeInfo} required>
                     {t(($) => $.submit.infoIsCorrect)}


### PR DESCRIPTION
### Description
add hcaptcha validation to submit routes in both public and protected space.

### Related Azure Boards Work Items
[AB#8664](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8664)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->