### PR TITLE
move email to communication preference on confirmation page

### DIFF
--- a/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/confirmation.tsx
@@ -242,11 +242,6 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -277,6 +272,11 @@ export default function ApplyFlowConfirm({ loaderData, params }: Route.Component
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/intake-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-children/confirmation.tsx
@@ -258,11 +258,6 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -293,6 +288,11 @@ export default function ProtectedNewChildrenConfirmation({ loaderData, params }:
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/intake-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/intake-family/confirmation.tsx
@@ -267,11 +267,6 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -302,6 +297,11 @@ export default function ProtectedNewFamilyConfirmation({ loaderData, params }: R
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/confirmation.tsx
@@ -262,11 +262,6 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -297,6 +292,11 @@ export default function ProtectedApplicationFlowConfirm({ loaderData, params }: 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
 

--- a/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/confirmation.tsx
@@ -284,11 +284,6 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -319,6 +314,11 @@ export default function ProtectedRenewChildrenConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
           </section>

--- a/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/confirmation.tsx
@@ -305,11 +305,6 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
                 <DefinitionListItem term={t(($) => $.confirm.altPhoneNumber)}>
                   <span className="text-nowrap">{userInfo.phoneNumber.alternate}</span>
                 </DefinitionListItem>
-                {userInfo.email && (
-                  <DefinitionListItem term={t(($) => $.confirm.email)}>
-                    <span className="text-nowrap">{userInfo.email}</span>
-                  </DefinitionListItem>
-                )}
                 <DefinitionListItem term={t(($) => $.confirm.mailing)}>
                   <Address
                     address={{
@@ -340,6 +335,11 @@ export default function ProtectedRenewalFamilyConfirmation({ loaderData, params 
               <DefinitionList border>
                 <DefinitionListItem term={t(($) => $.confirm.langPref)}>{userInfo.communicationPreferences.preferredLanguage.name}</DefinitionListItem>
                 <DefinitionListItem term={t(($) => $.confirm.sunLifeCommPrefTitle)}>{userInfo.communicationPreferences.preferredMethodSunLife.name}</DefinitionListItem>
+                {userInfo.email && (
+                  <DefinitionListItem term={t(($) => $.confirm.email)}>
+                    <span className="text-nowrap">{userInfo.email}</span>
+                  </DefinitionListItem>
+                )}
               </DefinitionList>
             </section>
 


### PR DESCRIPTION
### Description
Move email field from contact information to communication preference

### Related Azure Boards Work Items
AB#41780

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->