### PR TITLE
chore(frontend): upgrade node to v26

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 26.x
       - run: npm clean-install
         working-directory: frontend/
       - run: npm run format:check
@@ -78,7 +78,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 26.x
       - run: npm clean-install
         working-directory: frontend/
       - run: podman build --file dockerfile .

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 24.x
+          node-version: 26.x
       - run: npm clean-install
         working-directory: frontend/
       - run: npm run build

--- a/frontend/dockerfile
+++ b/frontend/dockerfile
@@ -24,7 +24,7 @@
 
 
 # Base image used for all future stages
-FROM docker.io/node:24.16.0-trixie-slim AS base
+FROM docker.io/node:26.2.0-trixie-slim AS base
 ENV NODE_ENV production
 
 # ---------------------------------------------------------------------------- #

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -91,7 +91,7 @@
         "@types/express-session": "^1.19.0",
         "@types/jsdom": "^28.0.3",
         "@types/morgan": "^1.9.10",
-        "@types/node": "^24.12.4",
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.15",
         "@types/react-dom": "^19.2.3",
         "@types/source-map-support": "^0.5.10",
@@ -6602,18 +6602,18 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
-      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": ">=7.24.0 <7.24.7"
       }
     },
     "node_modules/@types/node/node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "license": "MIT"
     },
     "node_modules/@types/oracledb": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -110,7 +110,7 @@
     "@types/express-session": "^1.19.0",
     "@types/jsdom": "^28.0.3",
     "@types/morgan": "^1.9.10",
-    "@types/node": "^24.12.4",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.15",
     "@types/react-dom": "^19.2.3",
     "@types/source-map-support": "^0.5.10",
@@ -149,7 +149,7 @@
     "vitest-mock-extended": "^4.0.0"
   },
   "engines": {
-    "node": ">=24.13.0",
+    "node": ">=26.0.0",
     "npm": ">=11.10.0"
   }
 }


### PR DESCRIPTION
This pull request updates the Node.js version used in the frontend to 26.x, along with related dependency updates to ensure compatibility. The most important changes are summarized below.

Node.js version upgrade:

* Updated the base Docker image in `frontend/dockerfile` from `node:24.16.0-trixie-slim` to `node:26.2.0-trixie-slim` to use the latest Node.js LTS version.
* Increased the required Node.js version in the `engines` field of `frontend/package.json` from `>=24.13.0` to `>=26.0.0`.

Dependency updates for compatibility:

* Upgraded `@types/node` from `^24.12.4` to `^25.9.1` in both `frontend/package.json` and `frontend/package-lock.json` to match the new Node.js version. [[1]](diffhunk://#diff-da6498268e99511d9ba0df3c13e439d10556a812881c9d03955b2ef7c6c1c655L113-R113) [[2]](diffhunk://#diff-4a2d9aa3e849b134993936ca81b83fb139edd2b0218077ab0f403b8c4803c62aL94-R94)
* Updated the actual version and integrity of `@types/node` and its dependency `undici-types` in `frontend/package-lock.json` for compatibility with Node.js 26.