### PR TITLE
chore(gitops): disable maintenance ingress and re-enable frontend ingress in prod overlay

### DIFF
--- a/gitops/overlays/prod/configs/redis/replica.conf
+++ b/gitops/overlays/prod/configs/redis/replica.conf
@@ -1,1 +1,1 @@
-slaveof redis-0.redis-headless 6379
+replicaof redis-0.redis-headless 6379

--- a/gitops/overlays/prod/ingresses-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-maintenance.yaml
@@ -58,6 +58,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: maintenance
+                name: frontend
                 port:
                   name: http

--- a/gitops/overlays/prod/ingresses-maintenance.yaml
+++ b/gitops/overlays/prod/ingresses-maintenance.yaml
@@ -58,6 +58,6 @@ spec:
             pathType: Prefix
             backend:
               service:
-                name: frontend
+                name: maintenance
                 port:
                   name: http

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  # - ./ingresses.yaml
-  - ./ingresses-maintenance.yaml
+  - ./ingresses.yaml
+  # - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml

--- a/gitops/overlays/prod/kustomization.yaml
+++ b/gitops/overlays/prod/kustomization.yaml
@@ -27,8 +27,8 @@ resources:
   #
   # For renewal application downtime with a 404 response, uncomment ./ingresses-renew-error-404.yaml
   #
-  - ./ingresses.yaml
-  # - ./ingresses-maintenance.yaml
+  # - ./ingresses.yaml
+  - ./ingresses-maintenance.yaml
   # - ./ingresses-apply-maintenance.yaml
   # Note: for the letters maintenance page, see the maintenance configMapGenerator below
   # - ./ingresses-letters-maintenance.yaml
@@ -61,10 +61,10 @@ configMapGenerator:
   - name: maintenance
     behavior: merge
     literals:
-      - startTimeEn=April 22, 2026, at 6:00 a.m.
-      - startTimeFr=22 avril 2026 à 06 h 00
-      - endTimeEn=April 22, 2026, at 7:00 a.m. (EDT)
-      - endTimeFr=22 avril 2026 à 07 h 00 (HAE)
+      - startTimeEn=June 2, 2026, at 12:00 a.m. (EDT)
+      - startTimeFr=2 juin 2026 à 00 h 00 (HAE)
+      - endTimeEn=June 2, 2026, at 7:00 a.m. (EDT)
+      - endTimeFr=2 juin 2026 à 07 h 00 (HAE)
     # TODO :: GjB :: this is a temporary override of the maintenance page HTML
     #                it should be removed when the letters are brought back online
     # TODO :: GjB :: I am commenting this out but leaving the updated 503 page in

--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.2.1
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.0
           envFrom:
             - configMapRef:
                 name: frontend

--- a/gitops/overlays/prod/patches/stateful-sets.yaml
+++ b/gitops/overlays/prod/patches/stateful-sets.yaml
@@ -10,14 +10,14 @@ spec:
       app.kubernetes.io/name: redis
   template:
     #
-    # pin all versions to v7.2.4
+    # pin all versions to v8.8.0
     #
     spec:
       initContainers:
         - name: init
-          image: docker.io/redis:7.2.4
+          image: docker.io/redis:8.8.0
       containers:
         - name: redis
-          image: docker.io/redis:7.2.4
+          image: docker.io/redis:8.8.0
         - name: redis-sentinel
-          image: docker.io/redis:7.2.4
+          image: docker.io/redis:8.8.0


### PR DESCRIPTION
> [!WARNING]
> **SCHEDULED MERGE — DO NOT MERGE EARLY**
> This PR must be merged **no sooner than June 2, 2026 at 7:00 a.m. EDT**.
> Merging before the scheduled window will re-enable the production frontend before the maintenance window has concluded.

This pull request restores normal production traffic routing after the scheduled maintenance window by swapping the active ingress configuration back to the standard frontend ingress.

**Changes:**

* Re-enabled `ingresses.yaml` in kustomization.yaml, restoring live traffic routing to the frontend application.
* Commented out `ingresses-maintenance.yaml`, disabling the maintenance page.