### PR TITLE
fix(frontend): use correct applicant SIN source for uniqueness checks based on intake vs renewal context

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
@@ -9,6 +9,7 @@ import {
   getEligibilityStatus,
   isChildClientNumberValid,
   isChildOrYouth,
+  isSinReserved,
   maritalStatusHasPartner,
 } from '~/.server/routes/helpers/base-application-route-helpers';
 
@@ -418,5 +419,49 @@ describe('getAllowedTypeOfApplication', () => {
       expect(maritalStatusHasPartner('DIVORCED')).toBe(false);
       expect(maritalStatusHasPartner('WIDOWED')).toBe(false);
     });
+  });
+});
+
+// 123456782 and 520325317 are fictitious but structurally valid SINs (pass Luhn check).
+// 123456789 is correctly formatted but fails the Luhn check (invalid SIN).
+describe('isSinReserved', () => {
+  it('returns false when the reserved list is empty', () => {
+    expect(isSinReserved('123456782', [])).toBe(false);
+  });
+
+  it('returns false when no reserved SIN matches the candidate', () => {
+    expect(isSinReserved('123456782', ['520325317'])).toBe(false);
+  });
+
+  it('returns true when a reserved SIN matches the candidate', () => {
+    expect(isSinReserved('123456782', ['123456782'])).toBe(true);
+  });
+
+  it('normalizes separators before comparing', () => {
+    expect(isSinReserved('123456782', ['123 456 782'])).toBe(true);
+    expect(isSinReserved('123 456 782', ['123456782'])).toBe(true);
+    expect(isSinReserved('123-456-782', ['123456782'])).toBe(true);
+  });
+
+  it('returns true when the match is among multiple reserved SINs', () => {
+    expect(isSinReserved('123456782', ['520325317', '123456782'])).toBe(true);
+  });
+
+  it('skips undefined entries in the reserved list', () => {
+    expect(isSinReserved('123456782', [undefined])).toBe(false);
+    expect(isSinReserved('123456782', [undefined, '123456782'])).toBe(true);
+  });
+
+  it('returns false when the candidate SIN is invalid', () => {
+    expect(isSinReserved('123456789', ['123456782'])).toBe(false);
+  });
+
+  it('skips invalid SINs in the reserved list', () => {
+    expect(isSinReserved('123456782', ['123456789'])).toBe(false);
+    expect(isSinReserved('123456782', ['123456789', '123456782'])).toBe(true);
+  });
+
+  it('returns false when the reserved list contains only undefined and invalid SINs', () => {
+    expect(isSinReserved('123456782', [undefined, '123456789'])).toBe(false);
   });
 });

--- a/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/protected-application-route-helpers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldSkipMaritalStatus } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getProtectedApplicantSin, getProtectedChildrenSins, getProtectedPartnerSin, shouldSkipMaritalStatus } from '~/.server/routes/helpers/protected-application-route-helpers';
 
 describe('protected-application-route-helpers', () => {
   describe('shouldSkipMaritalStatus', () => {
@@ -33,6 +33,107 @@ describe('protected-application-route-helpers', () => {
       } as const;
 
       expect(shouldSkipMaritalStatus(state)).toBe(true);
+    });
+  });
+
+  describe('getProtectedApplicantSin', () => {
+    it('returns the intake SIN when context is intake', () => {
+      const state = {
+        context: 'intake',
+        applicantInformation: { socialInsuranceNumber: '123456782' },
+        clientApplication: { applicantInformation: { socialInsuranceNumber: '520325317' } },
+      } as const;
+
+      expect(getProtectedApplicantSin(state)).toBe('123456782');
+    });
+
+    it('returns the renewal SIN when context is renewal', () => {
+      const state = {
+        context: 'renewal',
+        applicantInformation: { socialInsuranceNumber: '123456782' },
+        clientApplication: { applicantInformation: { socialInsuranceNumber: '520325317' } },
+      } as const;
+
+      expect(getProtectedApplicantSin(state)).toBe('520325317');
+    });
+
+    it('returns undefined when applicantInformation is absent in intake context', () => {
+      const state = {
+        context: 'intake',
+        applicantInformation: undefined,
+        clientApplication: undefined,
+      } as const;
+
+      expect(getProtectedApplicantSin(state)).toBeUndefined();
+    });
+
+    it('returns undefined when clientApplication is absent in renewal context', () => {
+      const state = {
+        context: 'renewal',
+        applicantInformation: undefined,
+        clientApplication: undefined,
+      } as const;
+
+      expect(getProtectedApplicantSin(state)).toBeUndefined();
+    });
+  });
+
+  describe('getProtectedPartnerSin', () => {
+    it('returns the partner SIN when set', () => {
+      const state = {
+        partnerInformation: { socialInsuranceNumber: '123456782' },
+      } as const;
+
+      expect(getProtectedPartnerSin(state)).toBe('123456782');
+    });
+
+    it('returns undefined when partnerInformation is absent', () => {
+      const state = {
+        partnerInformation: undefined,
+      } as const;
+
+      expect(getProtectedPartnerSin(state)).toBeUndefined();
+    });
+  });
+
+  describe('getProtectedChildrenSins', () => {
+    it('returns all children SINs when no excludeChildId is given', () => {
+      const state = {
+        children: [
+          { id: 'a', information: { socialInsuranceNumber: '123456782' } },
+          { id: 'b', information: { socialInsuranceNumber: '520325317' } },
+        ],
+      } as const;
+
+      expect(getProtectedChildrenSins(state)).toEqual(['123456782', '520325317']);
+    });
+
+    it('excludes the child matching excludeChildId', () => {
+      const state = {
+        children: [
+          { id: 'a', information: { socialInsuranceNumber: '123456782' } },
+          { id: 'b', information: { socialInsuranceNumber: '520325317' } },
+        ],
+      } as const;
+
+      expect(getProtectedChildrenSins(state, 'a')).toEqual(['520325317']);
+    });
+
+    it('returns undefined entries for children with no information', () => {
+      const state = {
+        children: [
+          { id: 'a', information: undefined },
+          { id: 'b', information: { socialInsuranceNumber: '123456782' } },
+        ],
+      } as const;
+
+      expect(getProtectedChildrenSins(state)).toEqual([undefined, '123456782']);
+    });
+
+    it('returns an empty array when no children exist', () => {
+      const state = { children: [] } as const;
+
+      expect(getProtectedChildrenSins(state)).toEqual([]);
     });
   });
 });

--- a/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/public-application-route-helpers.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPublicApplicantSin, getPublicChildrenSins, getPublicPartnerSin } from '~/.server/routes/helpers/public-application-route-helpers';
+
+describe('public-application-route-helpers', () => {
+  describe('getPublicApplicantSin', () => {
+    it('returns the applicant SIN when set', () => {
+      const state = {
+        applicantInformation: { socialInsuranceNumber: '123456782' },
+      } as const;
+
+      expect(getPublicApplicantSin(state)).toBe('123456782');
+    });
+
+    it('returns undefined when applicantInformation is absent', () => {
+      const state = {
+        applicantInformation: undefined,
+      } as const;
+
+      expect(getPublicApplicantSin(state)).toBeUndefined();
+    });
+  });
+
+  describe('getPublicPartnerSin', () => {
+    it('returns the partner SIN when set', () => {
+      const state = {
+        partnerInformation: { socialInsuranceNumber: '123456782' },
+      } as const;
+
+      expect(getPublicPartnerSin(state)).toBe('123456782');
+    });
+
+    it('returns undefined when partnerInformation is absent', () => {
+      const state = {
+        partnerInformation: undefined,
+      } as const;
+
+      expect(getPublicPartnerSin(state)).toBeUndefined();
+    });
+  });
+
+  describe('getPublicChildrenSins', () => {
+    it('returns all children SINs when no excludeChildId is given', () => {
+      const state = {
+        children: [
+          { id: 'a', information: { socialInsuranceNumber: '123456782' } },
+          { id: 'b', information: { socialInsuranceNumber: '520325317' } },
+        ],
+      } as const;
+
+      expect(getPublicChildrenSins(state)).toEqual(['123456782', '520325317']);
+    });
+
+    it('excludes the child matching excludeChildId', () => {
+      const state = {
+        children: [
+          { id: 'a', information: { socialInsuranceNumber: '123456782' } },
+          { id: 'b', information: { socialInsuranceNumber: '520325317' } },
+        ],
+      } as const;
+
+      expect(getPublicChildrenSins(state, 'a')).toEqual(['520325317']);
+    });
+
+    it('returns undefined entries for children with no information', () => {
+      const state = {
+        children: [
+          { id: 'a', information: undefined },
+          { id: 'b', information: { socialInsuranceNumber: '123456782' } },
+        ],
+      } as const;
+
+      expect(getPublicChildrenSins(state)).toEqual([undefined, '123456782']);
+    });
+
+    it('returns an empty array when no children exist', () => {
+      const state = { children: [] } as const;
+
+      expect(getPublicChildrenSins(state)).toEqual([]);
+    });
+  });
+});

--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -7,6 +7,7 @@ import { getEnv } from '~/.server/utils/env.utils';
 import type { EligibilityType } from '~/components/eligibility';
 import { expectDefined } from '~/utils/assert-utils';
 import { getAgeFromDateString } from '~/utils/date-utils';
+import { formatSin, isValidSin } from '~/utils/sin-utils';
 
 /**
  * The context of the application, either 'intake' for new applications or 'renewal' for renewal applications.
@@ -365,4 +366,26 @@ export function maritalStatusHasPartner(maritalStatus?: string) {
   if (!maritalStatus) return false;
   const { MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED } = getEnv();
   return [MARITAL_STATUS_CODE_COMMON_LAW, MARITAL_STATUS_CODE_MARRIED].includes(maritalStatus);
+}
+
+/**
+ * Returns true if the given SIN matches any SIN in the reserved list.
+ * `undefined` entries and entries that fail SIN validation in the reserved list are silently skipped.
+ * Both the candidate and each reserved SIN are normalized with `formatSin` before comparison.
+ *
+ * @param sin - The SIN to check. Returns `false` immediately if not a valid SIN.
+ * @param reservedSins - The list of SINs to check against. `undefined` values and invalid SINs are skipped.
+ * @returns `true` if the SIN is reserved, `false` otherwise.
+ */
+export function isSinReserved(sin: string, reservedSins: ReadonlyArray<string | undefined>): boolean {
+  if (!isValidSin(sin)) {
+    return false;
+  }
+
+  const formattedReserved: ReadonlyArray<string> = reservedSins.flatMap((s) => {
+    if (!s || !isValidSin(s)) return [];
+    return [formatSin(s)];
+  });
+
+  return formattedReserved.includes(formatSin(sin));
 }

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -4,7 +4,7 @@ import type { Params } from 'react-router';
 import { UTCDate } from '@date-fns/utc';
 import { invariant } from '@dts-stn/invariant';
 import { differenceInMinutes } from 'date-fns';
-import type { PickDeep, ReadonlyDeep } from 'type-fest';
+import type { ArrayElement, PickDeep, ReadonlyDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { createLogger } from '~/.server/logging';
@@ -519,4 +519,31 @@ export function isNewOrReturningMember(state: PickDeep<ProtectedApplicationState
 
 export function shouldSkipNewOrReturningMember(state: PickDeep<ProtectedApplicationState, 'context' | 'applicantInformation.dateOfBirth' | 'livingIndependently'>): boolean {
   return !isNewOrReturningMember(state);
+}
+
+/**
+ * Returns the applicant's SIN for a protected application.
+ *
+ * In intake context the SIN is captured during the flow (`state.applicantInformation`).
+ * In renewal context it comes from the pre-loaded client application record (`state.clientApplication`).
+ */
+export function getProtectedApplicantSin(state: PickDeep<ProtectedApplicationState, 'context' | 'applicantInformation.socialInsuranceNumber' | 'clientApplication.applicantInformation.socialInsuranceNumber'>): string | undefined {
+  return state.context === 'renewal' ? state.clientApplication?.applicantInformation.socialInsuranceNumber : state.applicantInformation?.socialInsuranceNumber;
+}
+
+/**
+ * Returns the partner's SIN for a protected application,
+ * or `undefined` if no partner information has been captured yet.
+ */
+export function getProtectedPartnerSin(state: PickDeep<ProtectedApplicationState, 'partnerInformation.socialInsuranceNumber'>): string | undefined {
+  return state.partnerInformation?.socialInsuranceNumber;
+}
+
+/**
+ * Returns the SINs of all children in a protected application.
+ * Pass `excludeChildId` to omit a specific child (e.g. the child currently being edited).
+ * Entries may be `undefined` for children that have not yet provided a SIN.
+ */
+export function getProtectedChildrenSins(state: { readonly children: ReadonlyArray<PickDeep<ArrayElement<ProtectedApplicationState['children']>, 'id' | 'information.socialInsuranceNumber'>> }, excludeChildId?: string): ReadonlyArray<string | undefined> {
+  return state.children.filter((child) => child.id !== excludeChildId).map((child) => child.information?.socialInsuranceNumber);
 }

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -3,7 +3,7 @@ import type { Params } from 'react-router';
 
 import { UTCDate } from '@date-fns/utc';
 import { differenceInMinutes } from 'date-fns';
-import type { PickDeep, ReadonlyDeep } from 'type-fest';
+import type { ArrayElement, PickDeep, ReadonlyDeep } from 'type-fest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import { createLogger } from '~/.server/logging';
@@ -441,4 +441,30 @@ export function getMemberIdForFullApplication(state: PickDeep<PublicApplicationS
     return shouldSkipNewOrReturningMember(state) ? undefined : state.newOrReturningMember?.memberId;
   }
   return state.applicantInformation?.memberId;
+}
+
+/**
+ * Returns the applicant's SIN for a public application.
+ *
+ * Public flows are always intake, so the SIN is always read from `state.applicantInformation`.
+ */
+export function getPublicApplicantSin(state: PickDeep<PublicApplicationState, 'applicantInformation.socialInsuranceNumber'>): string | undefined {
+  return state.applicantInformation?.socialInsuranceNumber;
+}
+
+/**
+ * Returns the partner's SIN for a public application,
+ * or `undefined` if no partner information has been captured yet.
+ */
+export function getPublicPartnerSin(state: PickDeep<PublicApplicationState, 'partnerInformation.socialInsuranceNumber'>): string | undefined {
+  return state.partnerInformation?.socialInsuranceNumber;
+}
+
+/**
+ * Returns the SINs of all children in a public application.
+ * Pass `excludeChildId` to omit a specific child (e.g. the child currently being edited).
+ * Entries may be `undefined` for children that have not yet provided a SIN.
+ */
+export function getPublicChildrenSins(state: { readonly children: ReadonlyArray<PickDeep<ArrayElement<PublicApplicationState['children']>, 'id' | 'information.socialInsuranceNumber'>> }, excludeChildId?: string): ReadonlyArray<string | undefined> {
+  return state.children.filter((child) => child.id !== excludeChildId).map((child) => child.information?.socialInsuranceNumber);
 }

--- a/frontend/app/routes/protected/application/spokes/child-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-information.tsx
@@ -197,32 +197,28 @@ export async function action({ context: { appContainer, session }, params, reque
       socialInsuranceNumber: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.hasSocialInsuranceNumber) {
-        if (!val.socialInsuranceNumber) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinRequired),
-            path: ['socialInsuranceNumber'],
-          });
-        } else if (!isValidSin(val.socialInsuranceNumber)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinValid),
-            path: ['socialInsuranceNumber'],
-          });
-        } else if (
-          val.socialInsuranceNumber &&
-          [state.applicantInformation?.socialInsuranceNumber, state.partnerInformation?.socialInsuranceNumber, ...state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin))
-            .includes(formatSin(val.socialInsuranceNumber))
-        ) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinUnique),
-            path: ['socialInsuranceNumber'],
-          });
-        }
+      if (!val.hasSocialInsuranceNumber) return;
+
+      if (!val.socialInsuranceNumber) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinRequired), path: ['socialInsuranceNumber'] });
+        return;
+      }
+
+      if (!isValidSin(val.socialInsuranceNumber)) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinValid), path: ['socialInsuranceNumber'] });
+        return;
+      }
+
+      // Check if the SIN is already used by the applicant, their partner (if applicable) or their other children
+      // - In intake context the applicant's SIN is captured during the flow (state.applicantInformation).
+      // - In renewal context it comes from the pre-loaded client application record (state.clientApplication).
+      const applicantSin = state.context === 'renewal' ? state.clientApplication?.applicantInformation.socialInsuranceNumber : state.applicantInformation?.socialInsuranceNumber;
+      const partnerSin = state.partnerInformation?.socialInsuranceNumber;
+      const otherChildrenSins = state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber);
+      const reservedSins = [applicantSin, partnerSin, ...otherChildrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+      if (reservedSins.includes(formatSin(val.socialInsuranceNumber))) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinUnique), path: ['socialInsuranceNumber'] });
       }
     }) satisfies z.ZodType<ProtectedApplicationChildSinState>;
 

--- a/frontend/app/routes/protected/application/spokes/child-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-information.tsx
@@ -9,9 +9,17 @@ import * as z from 'zod';
 import type { Route } from './+types/child-information';
 
 import { TYPES } from '~/.server/constants';
-import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
+import { isChildOrYouth, isSinReserved } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ProtectedApplicationChildInformationState, ProtectedApplicationChildSinState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import {
+  getProtectedApplicantSin,
+  getProtectedApplicationState,
+  getProtectedChildrenSins,
+  getProtectedPartnerSin,
+  getSingleChildState,
+  saveProtectedApplicationState,
+  validateApplicationFlow,
+} from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -34,7 +42,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 const YES_NO_OPTION = {
@@ -209,15 +217,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return;
       }
 
-      // Check if the SIN is already used by the applicant, their partner (if applicable) or their other children
-      // - In intake context the applicant's SIN is captured during the flow (state.applicantInformation).
-      // - In renewal context it comes from the pre-loaded client application record (state.clientApplication).
-      const applicantSin = state.context === 'renewal' ? state.clientApplication?.applicantInformation.socialInsuranceNumber : state.applicantInformation?.socialInsuranceNumber;
-      const partnerSin = state.partnerInformation?.socialInsuranceNumber;
-      const otherChildrenSins = state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber);
-      const reservedSins = [applicantSin, partnerSin, ...otherChildrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-      if (reservedSins.includes(formatSin(val.socialInsuranceNumber))) {
+      if (isSinReserved(val.socialInsuranceNumber, [getProtectedApplicantSin(state), getProtectedPartnerSin(state), ...getProtectedChildrenSins(state, childState.id)])) {
         ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinUnique), path: ['socialInsuranceNumber'] });
       }
     }) satisfies z.ZodType<ProtectedApplicationChildSinState>;

--- a/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
+++ b/frontend/app/routes/protected/application/spokes/child-social-insurance-number.tsx
@@ -6,8 +6,17 @@ import * as z from 'zod';
 import type { Route } from './+types/child-social-insurance-number';
 
 import { TYPES } from '~/.server/constants';
+import { isSinReserved } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ProtectedApplicationChildInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getProtectedApplicationState, getSingleChildState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import {
+  getProtectedApplicantSin,
+  getProtectedApplicationState,
+  getProtectedChildrenSins,
+  getProtectedPartnerSin,
+  getSingleChildState,
+  saveProtectedApplicationState,
+  validateApplicationFlow,
+} from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -23,7 +32,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import { getPathById } from '~/utils/route-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 export const handle = {
   pageIdentifier: pageIds.protected.application.spokes.childSocialInsuranceNumber,
@@ -92,23 +101,12 @@ export async function action({ context: { appContainer, session }, params, reque
       .optional()
       .superRefine((sin, ctx) => {
         if (sin && !isValidSin(sin)) {
-          ctx.addIssue({
-            code: 'custom',
-            path: ['socialInsuranceNumber'],
-            message: t(($) => $.children.socialInsuranceNumber.sinValid),
-          });
-        } else if (
-          sin &&
-          [state.applicantInformation?.socialInsuranceNumber, state.partnerInformation?.socialInsuranceNumber, ...state.children.filter((child) => child.id !== childState.id).map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin))
-            .includes(formatSin(sin))
-        ) {
-          ctx.addIssue({
-            code: 'custom',
-            path: ['socialInsuranceNumber'],
-            message: t(($) => $.children.socialInsuranceNumber.sinUnique),
-          });
+          ctx.addIssue({ code: 'custom', path: ['socialInsuranceNumber'], message: t(($) => $.children.socialInsuranceNumber.sinValid) });
+          return;
+        }
+
+        if (sin && isSinReserved(sin, [getProtectedApplicantSin(state), getProtectedPartnerSin(state), ...getProtectedChildrenSins(state, childState.id)])) {
+          ctx.addIssue({ code: 'custom', path: ['socialInsuranceNumber'], message: t(($) => $.children.socialInsuranceNumber.sinUnique) });
         }
       }),
   });

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -129,23 +129,21 @@ export async function action({ context: { appContainer, session }, params, reque
         1,
         t(($) => $.maritalStatus.errorMessage.sinRequired),
       )
-
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinValid),
-          });
-        } else if (
-          [state.clientApplication?.applicantInformation.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin))
-            .includes(formatSin(sin))
-        ) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinUnique),
-          });
+          ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinValid) });
+          return;
+        }
+
+        // Check if the sin is already used by the applicant or their children
+        // - In intake context the applicant's SIN is captured during the flow (state.applicantInformation).
+        // - In renewal context it comes from the pre-loaded client application record (state.clientApplication).
+        const applicantSin = state.context === 'renewal' ? state.clientApplication?.applicantInformation.socialInsuranceNumber : state.applicantInformation?.socialInsuranceNumber;
+        const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
+        const reservedSins = [applicantSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+        if (reservedSins.includes(formatSin(sin))) {
+          ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinUnique) });
         }
       }),
   }) satisfies z.ZodType<ProtectedApplicationPartnerInformationState>;

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -9,9 +9,9 @@ import * as z from 'zod';
 import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
-import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { isSinReserved, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationFlow, ProtectedApplicationPartnerInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getProtectedApplicationState, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
+import { getProtectedApplicantSin, getProtectedApplicationState, getProtectedChildrenSins, saveProtectedApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -31,7 +31,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
   switch (applicationFlow) {
@@ -135,14 +135,7 @@ export async function action({ context: { appContainer, session }, params, reque
           return;
         }
 
-        // Check if the sin is already used by the applicant or their children
-        // - In intake context the applicant's SIN is captured during the flow (state.applicantInformation).
-        // - In renewal context it comes from the pre-loaded client application record (state.clientApplication).
-        const applicantSin = state.context === 'renewal' ? state.clientApplication?.applicantInformation.socialInsuranceNumber : state.applicantInformation?.socialInsuranceNumber;
-        const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
-        const reservedSins = [applicantSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-        if (reservedSins.includes(formatSin(sin))) {
+        if (isSinReserved(sin, [getProtectedApplicantSin(state), ...getProtectedChildrenSins(state)])) {
           ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinUnique) });
         }
       }),

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -81,7 +81,7 @@ export async function action({ context: { appContainer, session }, params, reque
             return;
           }
 
-          // Check if the SIN is already used by the applicant or their partner (if applicable)
+           // Check if the SIN is already used by the partner (if applicable) or any children
           const partnerSin = state.partnerInformation?.socialInsuranceNumber;
           const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
           const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -77,20 +77,17 @@ export async function action({ context: { appContainer, session }, params, reque
         )
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({
-              code: 'custom',
-              message: t(($) => $.personalInformation.errorMessage.sinValid),
-            });
-          } else if (
-            [state.partnerInformation?.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
-              .filter((sin) => sin !== undefined)
-              .map((sin) => formatSin(sin))
-              .includes(formatSin(sin))
-          ) {
-            ctx.addIssue({
-              code: 'custom',
-              message: t(($) => $.personalInformation.errorMessage.sinUnique),
-            });
+            ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinValid) });
+            return;
+          }
+
+          // Check if the SIN is already used by the applicant or their partner (if applicable)
+          const partnerSin = state.partnerInformation?.socialInsuranceNumber;
+          const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
+          const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+          if (reservedSins.includes(formatSin(sin))) {
+            ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinUnique) });
           }
         }),
       firstName: z

--- a/frontend/app/routes/protected/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/protected/application/spokes/personal-information.tsx
@@ -6,8 +6,17 @@ import * as z from 'zod';
 import type { Route } from './+types/personal-information';
 
 import { TYPES } from '~/.server/constants';
+import { isSinReserved } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ProtectedApplicationApplicantInformationState } from '~/.server/routes/helpers/protected-application-route-helpers';
-import { getContextualAgeCategoryFromDate, getProtectedApplicationState, isNewOrReturningMember, saveProtectedApplicationState, validateProtectedApplicationContext } from '~/.server/routes/helpers/protected-application-route-helpers';
+import {
+  getContextualAgeCategoryFromDate,
+  getProtectedApplicationState,
+  getProtectedChildrenSins,
+  getProtectedPartnerSin,
+  isNewOrReturningMember,
+  saveProtectedApplicationState,
+  validateProtectedApplicationContext,
+} from '~/.server/routes/helpers/protected-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -27,7 +36,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 export const handle = {
@@ -81,12 +90,7 @@ export async function action({ context: { appContainer, session }, params, reque
             return;
           }
 
-           // Check if the SIN is already used by the partner (if applicable) or any children
-          const partnerSin = state.partnerInformation?.socialInsuranceNumber;
-          const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
-          const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-          if (reservedSins.includes(formatSin(sin))) {
+          if (isSinReserved(sin, [getProtectedPartnerSin(state), ...getProtectedChildrenSins(state)])) {
             ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinUnique) });
           }
         }),

--- a/frontend/app/routes/public/application/spokes/child-information.tsx
+++ b/frontend/app/routes/public/application/spokes/child-information.tsx
@@ -10,8 +10,8 @@ import * as z from 'zod';
 import type { Route } from './+types/child-information';
 
 import { TYPES } from '~/.server/constants';
-import { isChildOrYouth } from '~/.server/routes/helpers/base-application-route-helpers';
-import { getPublicApplicationState, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { isChildOrYouth, isSinReserved } from '~/.server/routes/helpers/base-application-route-helpers';
+import { getPublicApplicantSin, getPublicApplicationState, getPublicChildrenSins, getPublicPartnerSin, getSingleChildState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import type { PublicApplicationChildInformationState, PublicApplicationChildSinState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
@@ -36,7 +36,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 const YES_NO_OPTION = {
@@ -234,13 +234,7 @@ export async function action({ context: { appContainer, session }, params, reque
         return;
       }
 
-      // Check if the SIN is already used by the applicant, their partner (if applicable) or their other children
-      const applicantSin = state.applicantInformation?.socialInsuranceNumber;
-      const partnerSin = state.partnerInformation?.socialInsuranceNumber;
-      const otherChildrenSins = state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber);
-      const reservedSins = [applicantSin, partnerSin, ...otherChildrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-      if (reservedSins.includes(formatSin(val.socialInsuranceNumber))) {
+      if (isSinReserved(val.socialInsuranceNumber, [getPublicApplicantSin(state), getPublicPartnerSin(state), ...getPublicChildrenSins(state, childState.id)])) {
         ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinUnique), path: ['socialInsuranceNumber'] });
       }
     }) satisfies z.ZodType<PublicApplicationChildSinState>;

--- a/frontend/app/routes/public/application/spokes/child-information.tsx
+++ b/frontend/app/routes/public/application/spokes/child-information.tsx
@@ -222,32 +222,26 @@ export async function action({ context: { appContainer, session }, params, reque
       socialInsuranceNumber: z.string().trim().optional(),
     })
     .superRefine((val, ctx) => {
-      if (val.hasSocialInsuranceNumber) {
-        if (!val.socialInsuranceNumber) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinRequired),
-            path: ['socialInsuranceNumber'],
-          });
-        } else if (!isValidSin(val.socialInsuranceNumber)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinValid),
-            path: ['socialInsuranceNumber'],
-          });
-        } else if (
-          val.socialInsuranceNumber &&
-          [state.applicantInformation?.socialInsuranceNumber, state.partnerInformation?.socialInsuranceNumber, ...state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin))
-            .includes(formatSin(val.socialInsuranceNumber))
-        ) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.children.information.errorMessage.sinUnique),
-            path: ['socialInsuranceNumber'],
-          });
-        }
+      if (!val.hasSocialInsuranceNumber) return;
+
+      if (!val.socialInsuranceNumber) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinRequired), path: ['socialInsuranceNumber'] });
+        return;
+      }
+
+      if (!isValidSin(val.socialInsuranceNumber)) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinValid), path: ['socialInsuranceNumber'] });
+        return;
+      }
+
+      // Check if the SIN is already used by the applicant, their partner (if applicable) or their other children
+      const applicantSin = state.applicantInformation?.socialInsuranceNumber;
+      const partnerSin = state.partnerInformation?.socialInsuranceNumber;
+      const otherChildrenSins = state.children.filter((child) => childState.id !== child.id).map((child) => child.information?.socialInsuranceNumber);
+      const reservedSins = [applicantSin, partnerSin, ...otherChildrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+      if (reservedSins.includes(formatSin(val.socialInsuranceNumber))) {
+        ctx.addIssue({ code: 'custom', message: t(($) => $.children.information.errorMessage.sinUnique), path: ['socialInsuranceNumber'] });
       }
     }) satisfies z.ZodType<PublicApplicationChildSinState>;
 

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -122,23 +122,19 @@ export async function action({ context: { appContainer, session }, params, reque
         1,
         t(($) => $.maritalStatus.errorMessage.sinRequired),
       )
-
       .superRefine((sin, ctx) => {
         if (!isValidSin(sin)) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinValid),
-          });
-        } else if (
-          [state.applicantInformation?.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
-            .filter((sin) => sin !== undefined)
-            .map((sin) => formatSin(sin))
-            .includes(formatSin(sin))
-        ) {
-          ctx.addIssue({
-            code: 'custom',
-            message: t(($) => $.maritalStatus.errorMessage.sinUnique),
-          });
+          ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinValid) });
+          return;
+        }
+
+        // Check if the SIN is already used by the applicant or their children
+        const applicantSin = state.applicantInformation?.socialInsuranceNumber;
+        const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
+        const reservedSins = [applicantSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+        if (reservedSins.includes(formatSin(sin))) {
+          ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinUnique) });
         }
       }),
   }) satisfies z.ZodType<PublicApplicationPartnerInformationState>;

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -9,9 +9,9 @@ import * as z from 'zod';
 import type { Route } from './+types/marital-status';
 
 import { TYPES } from '~/.server/constants';
-import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { isSinReserved, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { ApplicationFlow, PublicApplicationPartnerInformationState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { getPublicApplicationState, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getPublicApplicantSin, getPublicApplicationState, getPublicChildrenSins, savePublicApplicationState, validateApplicationFlow } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -31,7 +31,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 
 function getRouteFromApplicationFlow(applicationFlow: ApplicationFlow) {
   switch (applicationFlow) {
@@ -128,12 +128,7 @@ export async function action({ context: { appContainer, session }, params, reque
           return;
         }
 
-        // Check if the SIN is already used by the applicant or their children
-        const applicantSin = state.applicantInformation?.socialInsuranceNumber;
-        const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
-        const reservedSins = [applicantSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-        if (reservedSins.includes(formatSin(sin))) {
+        if (isSinReserved(sin, [getPublicApplicantSin(state), ...getPublicChildrenSins(state)])) {
           ctx.addIssue({ code: 'custom', message: t(($) => $.maritalStatus.errorMessage.sinUnique) });
         }
       }),

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -94,7 +94,7 @@ export async function action({ context: { appContainer, session }, params, reque
             return;
           }
 
-          // Check if the SIN is already used by the applicant or their partner (if applicable)
+          // Check if the SIN is already used by the partner (if applicable) or any children
           const partnerSin = state.partnerInformation?.socialInsuranceNumber;
           const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
           const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -9,8 +9,9 @@ import type { Route } from './+types/personal-information';
 
 import { TYPES } from '~/.server/constants';
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
+import { isSinReserved } from '~/.server/routes/helpers/base-application-route-helpers';
 import type { PublicApplicationApplicantInformationState, PublicApplicationInputModelState } from '~/.server/routes/helpers/public-application-route-helpers';
-import { getContextualAgeCategoryFromDate, getPublicApplicationState, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
+import { getContextualAgeCategoryFromDate, getPublicApplicationState, getPublicChildrenSins, getPublicPartnerSin, savePublicApplicationState } from '~/.server/routes/helpers/public-application-route-helpers';
 import { getFixedT, getLocale } from '~/.server/utils/locale.utils';
 import { transformFlattenedError } from '~/.server/utils/zod.utils';
 import { AppPageTitle } from '~/components/app-page-title';
@@ -32,7 +33,7 @@ import { mergeMeta } from '~/utils/meta-utils';
 import type { RouteHandleData } from '~/utils/route-utils';
 import { getPathById } from '~/utils/route-utils';
 import { getTitleMetaTags } from '~/utils/seo-utils';
-import { formatSin, isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
+import { isValidSin, sinInputPatternFormat } from '~/utils/sin-utils';
 import { extractDigits, hasDigits, isAllValidInputCharacters } from '~/utils/string-utils';
 
 export const handle = {
@@ -94,12 +95,7 @@ export async function action({ context: { appContainer, session }, params, reque
             return;
           }
 
-          // Check if the SIN is already used by the partner (if applicable) or any children
-          const partnerSin = state.partnerInformation?.socialInsuranceNumber;
-          const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
-          const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
-
-          if (reservedSins.includes(formatSin(sin))) {
+          if (isSinReserved(sin, [getPublicPartnerSin(state), ...getPublicChildrenSins(state)])) {
             ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinUnique) });
           }
         }),

--- a/frontend/app/routes/public/application/spokes/personal-information.tsx
+++ b/frontend/app/routes/public/application/spokes/personal-information.tsx
@@ -90,20 +90,17 @@ export async function action({ context: { appContainer, session }, params, reque
         )
         .superRefine((sin, ctx) => {
           if (!isValidSin(sin)) {
-            ctx.addIssue({
-              code: 'custom',
-              message: t(($) => $.personalInformation.errorMessage.sinValid),
-            });
-          } else if (
-            [state.partnerInformation?.socialInsuranceNumber, ...state.children.map((child) => child.information?.socialInsuranceNumber)]
-              .filter((sin) => sin !== undefined)
-              .map((sin) => formatSin(sin))
-              .includes(formatSin(sin))
-          ) {
-            ctx.addIssue({
-              code: 'custom',
-              message: t(($) => $.personalInformation.errorMessage.sinUnique),
-            });
+            ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinValid) });
+            return;
+          }
+
+          // Check if the SIN is already used by the applicant or their partner (if applicable)
+          const partnerSin = state.partnerInformation?.socialInsuranceNumber;
+          const childrenSins = state.children.map((child) => child.information?.socialInsuranceNumber);
+          const reservedSins = [partnerSin, ...childrenSins].filter((s) => s !== undefined).map((s) => formatSin(s));
+
+          if (reservedSins.includes(formatSin(sin))) {
+            ctx.addIssue({ code: 'custom', message: t(($) => $.personalInformation.errorMessage.sinUnique) });
           }
         }),
       firstName: z


### PR DESCRIPTION
The protected application flow runs in two contexts: **intake** (new application) and **renewal** (renewing an existing benefit). The marital-status and child-information spokes both include a Zod `superRefine` that checks the submitted partner/child SIN against SINs already registered in the session to prevent duplicates.

The SIN source used for the applicant in this check was:

```ts
state.clientApplication?.applicantInformation.socialInsuranceNumber
```

`clientApplication` is only populated in **renewal** context — it holds the applicant's pre-loaded benefit record. In **intake** context it is `undefined`, meaning the applicant's own SIN was silently absent from the reserved set. A user could therefore enter their own SIN as their partner's or child's SIN and pass client-side validation without error. The duplicate payload was then submitted to the Dynamics CRM Interop API, which rejected it with HTTP 400 and error code `0x80040265`.

This bug only affected **intake** context. During the renewal period the bug was masked because `clientApplication` is always defined in renewal.

### Steps to reproduce

1. Start a protected application in **intake** context (not renewal)
2. On the personal information spoke, enter a valid SIN (e.g. `800 000 002`)
3. On the marital status spoke, select **Married** or **Common-law**
4. Enter the **same SIN** (`800 000 002`) as the partner's SIN — no validation error appears (bug)
5. Continue through to submit → Dynamics CRM returns 400

The same steps apply for the child information spoke (enter the applicant's SIN as a child's SIN).

### Fix

Branch on `state.context` to select the correct applicant SIN source:

```ts
const applicantSin =
  state.context === 'renewal'
    ? state.clientApplication?.applicantInformation.socialInsuranceNumber
    : state.applicantInformation?.socialInsuranceNumber;
```

- In **intake** context, the applicant's SIN is captured during the flow in `state.applicantInformation`
- In **renewal** context, it comes from the pre-loaded client application record in `state.clientApplication`

The same fix was applied to child-information.tsx which had the identical issue for child SIN uniqueness validation.

All six `superRefine` blocks across the protected and public spokes (`marital-status`, `child-information`, `personal-information`) were also refactored for consistency: nested `else if` chains replaced with early returns, and inline chained expressions extracted into named variables (`applicantSin`, `partnerSin`, `childrenSins`, `reservedSins`) for readability.