### PR TITLE
chore(gitops): update prod frontend image to v7.3.1

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -4,7 +4,7 @@ metadata:
   name: frontend
   annotations:
     # reload the pod whenever the secrets change
-    secret.reloader.stakater.com/auto: 'true'
+    secret.reloader.stakater.com/auto: "true"
 spec:
   selector:
     matchLabels:
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.0
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.1
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
> [!WARNING]
> **SCHEDULED MERGE — DO NOT MERGE EARLY**
> This PR must be merged **no sooner than June 5, 2026 at 7:00 a.m. EDT**.
> Merging before the scheduled window will trigger the frontend change prematurely in production.

### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request makes a minor update to the production deployment configuration for the frontend. The main changes are updating the container image version and standardizing the annotation value format.

**Deployment configuration update:**

Updated the frontend container image to version `7.3.1` in `deployments-frontend.yaml` to deploy the latest changes.