### PR TITLE
chore(gitops): update prod frontend image version to v7.3.2

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.1
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.2
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
> [!WARNING]
> **SCHEDULED MERGE — DO NOT MERGE EARLY**
> This PR must be merged **no sooner than June 11, 2026 at 7:00 a.m. EDT**.
> Merging before the scheduled window will trigger the frontend change prematurely in production.

### Description
<!-- Provide a brief description of the changes in this PR. -->

This pull request makes a minor update to the production deployment configuration for the frontend. The main change is updating the container image version.

**Deployment configuration update:**

Updated the frontend container image to version [7.3.2](https://github.com/DTS-STN/canadian-dental-care-plan/releases/tag/v7.3.2) in `deployments-frontend.yaml` to deploy the latest changes.