### PR TITLE
chore: enhance github actions and npm security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,9 @@ updates:
   - package-ecosystem: npm
     directory: /frontend
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
     cooldown:
-      default-days: 3
-      semver-major-days: 7
-      semver-minor-days: 5
+      default-days: 7
     groups:
       dev-minor-versions:
         dependency-type: development
@@ -18,33 +15,34 @@ updates:
           - minor
           - patch
         patterns:
-          - '*'
+          - "*"
         exclude-patterns:
-          - 'react-router'
-          - '@react-router/*'
+          - "react-router"
+          - "@react-router/*"
       prod-minor-versions:
         dependency-type: production
         update-types:
           - minor
           - patch
         patterns:
-          - '*'
+          - "*"
         exclude-patterns:
-          - 'react-router'
-          - '@react-router/*'
+          - "react-router"
+          - "@react-router/*"
       react-router-versions:
         update-types:
           - minor
           - patch
         patterns:
-          - 'react-router'
-          - '@react-router/*'
+          - "react-router"
+          - "@react-router/*"
 
   - package-ecosystem: docker
     directory: /frontend
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
+    cooldown:
+      default-days: 7
     # Ignore major updates
     ignore:
       - dependency-name: "*"
@@ -53,5 +51,13 @@ updates:
   - package-ecosystem: terraform
     directory: /infrastructure
     schedule:
-      interval: weekly
-      day: monday
+      interval: daily
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,21 +21,21 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.repository == 'DTS-STN/canadian-dental-care-plan' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - id: frontend
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             src:
               - frontend/**
       - id: gitops
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             src:
               - gitops/**
       - id: infrastructure
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3
         with:
           filters: |
             src:
@@ -50,8 +50,8 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.frontend-changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 26.x
       - run: npm clean-install
@@ -75,8 +75,8 @@ jobs:
     needs: detect-changes
     if: ${{ needs.detect-changes.outputs.frontend-changed == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 26.x
       - run: npm clean-install

--- a/.github/workflows/nightly-e2e.yaml
+++ b/.github/workflows/nightly-e2e.yaml
@@ -15,8 +15,8 @@ jobs:
     if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/release/')
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 26.x
       - run: npm clean-install

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,7 +1,8 @@
-# Require packages to have been published for at least 3 days before they can be installed.
+# Require packages to have been published for at least 7 days before they can be installed.
 # This helps protect against supply chain attacks via freshly-published malicious packages.
 # Requires npm >= 11.10.0 — see: https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age
-min-release-age=3
+min-release-age=7
+
 # Enforce package manager engine constraints declared in package.json.
 # See: https://docs.npmjs.com/cli/v11/using-npm/config#engine-strict
 engine-strict=true


### PR DESCRIPTION
This pull request updates dependency management and CI/CD workflows to improve security, reliability, and maintainability. The main changes include increasing the minimum age for npm packages, adjusting Dependabot update schedules and cooldowns, explicitly pinning GitHub Actions to specific commit SHAs, and adding support for GitHub Actions updates in Dependabot.

**Dependency and update policy improvements:**

* Increased the minimum publish age for npm packages in `frontend/.npmrc` from 3 to 7 days to further protect against supply chain attacks.
* Changed Dependabot schedules in `.github/dependabot.yml` for `npm`, `docker`, and `terraform` to run daily instead of weekly, and standardized the cooldown period to 7 days for all ecosystems. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L8-R45) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28L56-R63)
* Added Dependabot support for `github-actions` updates, running daily with a 7-day cooldown.

**CI/CD workflow security and reliability:**

* Updated all GitHub Actions in `.github/workflows/ci.yaml` and `.github/workflows/nightly-e2e.yaml` to use explicit commit SHAs instead of floating version tags, improving supply chain security and build reproducibility. [[1]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL24-R38) [[2]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL53-R54) [[3]](diffhunk://#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddL78-R79) [[4]](diffhunk://#diff-d3096608b85d20e90b2de04022d99c8923e2ba69266f04550741bea52bf11c4bL18-R19)

**Other improvements:**

* Standardized quote style in Dependabot group patterns and exclude-patterns for consistency.