### PR TITLE
fix(frontend): public route review validation for GC communication preference

### DIFF
--- a/frontend/app/.server/routes/helpers/public-application-full-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-adult-route-helpers.ts
@@ -160,7 +160,7 @@ export function validatePublicApplicationFullAdultStateForReview({ params, state
     throw redirect(getPathById('public/application/$id/full-adult/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/full-adult/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-child-route-helpers.ts
@@ -160,7 +160,7 @@ export function validatePublicApplicationFullChildStateForReview({ params, state
     throw redirect(getPathById('public/application/$id/full-children/parent-or-guardian', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/full-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-full-family-route-helpers.ts
@@ -160,7 +160,7 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
     throw redirect(getPathById('public/application/$id/full-family/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/full-family/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-simplified-adult-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-adult-route-helpers.ts
@@ -156,7 +156,7 @@ export function validatePublicRenewAdultStateForReview({ params, state }: Valida
     throw redirect(getPathById('public/application/$id/simplified-adult/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/simplified-adult/contact-information', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-child-route-helpers.ts
@@ -163,7 +163,7 @@ export function validatePublicApplicationSimplifiedChildStateForReview({ params,
     throw redirect(getPathById('public/application/$id/simplified-children/parent-or-guardian', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/simplified-children/parent-or-guardian', params));
   }
 

--- a/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-simplified-family-route-helpers.ts
@@ -155,7 +155,7 @@ export function validatePublicApplicationFamilyStateForReview({ params, state }:
     throw redirect(getPathById('public/application/$id/simplified-family/contact-information', params));
   }
 
-  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
+  if ((communicationPreferences.value?.preferredMethod === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || communicationPreferences.value?.preferredNotificationMethod === COMMUNICATION_METHOD_GC_DIGITAL_ID) && !emailVerified) {
     throw redirect(getPathById('public/application/$id/simplified-family/contact-information', params));
   }
 


### PR DESCRIPTION
### Description
This change fixes a validation bug in the public application review helpers.

The review/submit gate was checking the wrong field when deciding whether a verified email is required for Government of Canada digital communication. It was comparing the GC digital ID against `preferredMethod` (Sunlife) instead of `preferredNotificationMethod` (Government of Canada communication preference).

Because of that mismatch, applications could pass review when:

- Sun Life communication preference was set to mail

- Government of Canada communication preference was set to digital

In that scenario, the review helper could miss the GC digital requirement and allow submission to continue.
This allows user to manipulate url and skip email verification

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->