### PR TITLE
fix(frontend): preserve existing email when communication preferences are unchanged on renewal

### DIFF
--- a/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
+++ b/frontend/__tests__/.server/routes/helpers/base-application-route-helpers.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import {
+  checkValidAndVerifiedEmailAddress,
   getAgeCategoryFromAge,
   getAgeCategoryFromDateString,
   getAgeCategoryReferenceDate,
@@ -9,6 +10,7 @@ import {
   getEligibilityStatus,
   isChildClientNumberValid,
   isChildOrYouth,
+  isEmailAddressRequired,
   isSinReserved,
   maritalStatusHasPartner,
 } from '~/.server/routes/helpers/base-application-route-helpers';
@@ -18,6 +20,8 @@ vi.mock('~/.server/utils/env.utils', () => ({
     ELIGIBILITY_STATUS_CODE_ELIGIBLE: 'ELIGIBLE',
     MARITAL_STATUS_CODE_COMMON_LAW: 'COMMON_LAW',
     MARITAL_STATUS_CODE_MARRIED: 'MARRIED',
+    COMMUNICATION_METHOD_GC_DIGITAL_ID: 'digital',
+    COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID: 'email',
   })),
 }));
 
@@ -455,6 +459,43 @@ describe('base-application-route-helpers', () => {
       it('returns false when the reserved list contains only undefined and invalid SINs', () => {
         expect(isSinReserved('123456782', [undefined, '123456789'])).toBe(false);
       });
+    });
+  });
+
+  describe('isEmailAddressRequired', () => {
+    it('returns true when preferred method includes GC digital', () => {
+      expect(isEmailAddressRequired({ preferredMethodSunLife: 'mail', preferredMethodGovernmentOfCanada: 'digital' })).toBe(true);
+    });
+
+    it('returns true when preferred method includes Sun Life email', () => {
+      expect(isEmailAddressRequired({ preferredMethodSunLife: 'email', preferredMethodGovernmentOfCanada: 'mail' })).toBe(true);
+    });
+
+    it('returns true when preferred method includes both GC digital and Sun Life email', () => {
+      expect(isEmailAddressRequired({ preferredMethodSunLife: 'email', preferredMethodGovernmentOfCanada: 'digital' })).toBe(true);
+    });
+
+    it('returns false when preferred method includes neither GC digital nor Sun Life email', () => {
+      expect(isEmailAddressRequired({ preferredMethodSunLife: 'mail', preferredMethodGovernmentOfCanada: 'mail' })).toBe(false);
+    });
+  });
+
+  describe('checkValidAndVerifiedEmailAddress', () => {
+    it('returns valid and verified when email is valid and verified', () => {
+      expect(checkValidAndVerifiedEmailAddress({ email: 'valid@example.com', emailVerified: true })).toEqual({ success: true, email: 'valid@example.com', emailVerified: true });
+    });
+
+    it.each([
+      [undefined, false],
+      [undefined, true],
+      [undefined, undefined],
+      ['invalid-email', false],
+      ['invalid-email', true],
+      ['invalid-email', undefined],
+      ['valid@example.com', false],
+      ['valid@example.com', undefined],
+    ])('returns invalid when email is [%s] or not verified is [%s]', (email, emailVerified) => {
+      expect(checkValidAndVerifiedEmailAddress({ email, emailVerified })).toEqual({ success: false, email, emailVerified });
     });
   });
 });

--- a/frontend/app/.server/domain/dtos/benefit-application.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-application.dto.ts
@@ -1,24 +1,26 @@
 import type { ReadonlyDeep } from 'type-fest';
 
 export type BenefitApplicationDto = ReadonlyDeep<{
-  applicantInformation: ApplicantInformationDto;
+  applicationChannelCode: 'protected' | 'public';
+  applicantInformation: BenefitApplicationApplicantInformationDto;
   applicationYearId: string;
-  children: ChildDto[];
-  communicationPreferences: CommunicationPreferencesDto;
-  contactInformation: ContactInformationDto;
+  children: BenefitApplicationChildDto[];
+  communicationPreferences: BenefitApplicationCommunicationPreferencesDto;
+  contactInformation: BenefitApplicationContactInformationDto;
+  emailAddress: BenefitApplicationEmailDto;
   dateOfBirth: string;
   dentalBenefits: string[];
-  dentalInsurance?: DentalInsuranceDto;
+  dentalInsurance?: BenefitApplicationDentalInsuranceDto;
   livingIndependently?: boolean;
-  partnerInformation?: PartnerInformationDto;
-  termsAndConditions: TermsAndConditionsDto;
-  typeOfApplication: TypeOfApplicationDto;
+  partnerInformation?: BenefitApplicationPartnerInformationDto;
+  termsAndConditions: BenefitApplicationTermsAndConditionsDto;
+  typeOfApplication: BenefitApplicationTypeOfApplicationDto;
 
   /** A unique identifier for the user making the request - used for auditing */
   userId: string;
 }>;
 
-export type ApplicantInformationDto = ReadonlyDeep<{
+export type BenefitApplicationApplicantInformationDto = ReadonlyDeep<{
   clientNumber?: string;
   firstName: string;
   lastName: string;
@@ -26,9 +28,9 @@ export type ApplicantInformationDto = ReadonlyDeep<{
   socialInsuranceNumber: string;
 }>;
 
-export type ChildDto = ReadonlyDeep<{
+export type BenefitApplicationChildDto = ReadonlyDeep<{
   dentalBenefits: string[];
-  dentalInsurance: DentalInsuranceDto;
+  dentalInsurance: BenefitApplicationDentalInsuranceDto;
   information: {
     firstName: string;
     lastName: string;
@@ -38,15 +40,18 @@ export type ChildDto = ReadonlyDeep<{
   };
 }>;
 
-export type CommunicationPreferencesDto = ReadonlyDeep<{
-  email?: string;
-  emailVerified?: boolean;
+export type BenefitApplicationEmailDto = ReadonlyDeep<{
+  value?: string;
+  verified?: boolean;
+}>;
+
+export type BenefitApplicationCommunicationPreferencesDto = ReadonlyDeep<{
   preferredLanguage: string;
   preferredMethod: string;
   preferredMethodGovernmentOfCanada: string;
 }>;
 
-export type ContactInformationDto = ReadonlyDeep<{
+export type BenefitApplicationContactInformationDto = ReadonlyDeep<{
   copyMailingAddress: boolean;
   homeAddress: string;
   homeApartment?: string;
@@ -64,21 +69,21 @@ export type ContactInformationDto = ReadonlyDeep<{
   phoneNumberAlt?: string;
 }>;
 
-export type DentalInsuranceDto = ReadonlyDeep<{
+export type BenefitApplicationDentalInsuranceDto = ReadonlyDeep<{
   hasDentalInsurance: boolean;
   dentalInsuranceEligibilityConfirmation?: boolean;
 }>;
 
-export type TermsAndConditionsDto = ReadonlyDeep<{
+export type BenefitApplicationTermsAndConditionsDto = ReadonlyDeep<{
   acknowledgeTerms: boolean;
   acknowledgePrivacy: boolean;
   shareData: boolean;
 }>;
 
-export type PartnerInformationDto = ReadonlyDeep<{
+export type BenefitApplicationPartnerInformationDto = ReadonlyDeep<{
   consentToSharePersonalInformation: true;
   yearOfBirth: string;
   socialInsuranceNumber: string;
 }>;
 
-export type TypeOfApplicationDto = 'adult' | 'adult-child' | 'child';
+export type BenefitApplicationTypeOfApplicationDto = 'adult' | 'adult-child' | 'child';

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -1,20 +1,21 @@
 import type { ReadonlyDeep } from 'type-fest';
 
 export type BenefitRenewalDto = ReadonlyDeep<{
-  applicantInformation: RenewalApplicantInformationDto;
+  applicationChannelCode: 'protected' | 'public';
+  applicantInformation: BenefitRenewalApplicantInformationDto;
   applicationYearId: string;
-  children: RenewalChildDto[];
-  communicationPreferences: RenewalCommunicationPreferencesDto;
-  contactInformation: RenewalContactInformationDto;
-  emailAddress: RenewalEmailDto;
+  children: BenefitRenewalChildDto[];
+  communicationPreferences: BenefitRenewalCommunicationPreferencesDto;
+  contactInformation: BenefitRenewalContactInformationDto;
+  emailAddress: BenefitRenewalEmailDto;
   dateOfBirth: string;
   dentalBenefits: string[];
-  dentalInsurance?: DentalInsuranceDto;
+  dentalInsurance?: BenefitRenewalDentalInsuranceDto;
   livingIndependently?: boolean;
-  partnerInformation?: RenewalPartnerInformationDto;
-  typeOfApplication: RenewalTypeOfApplicationDto;
-  termsAndConditions: TermsAndConditionsDto;
-  changeIndicators?: ChangeIndicatorsDto;
+  partnerInformation?: BenefitRenewalPartnerInformationDto;
+  typeOfApplication: BenefitRenewalTypeOfApplicationDto;
+  termsAndConditions: BenefitRenewalTermsAndConditionsDto;
+  changeIndicators?: BenefitRenewalChangeIndicatorsDto;
 
   /**
    * Indicates whether the renewal request is to create a new benefit application or renew an existing benefit
@@ -31,7 +32,7 @@ export type BenefitRenewalDto = ReadonlyDeep<{
   userId: string;
 }>;
 
-export type RenewalApplicantInformationDto = ReadonlyDeep<{
+export type BenefitRenewalApplicantInformationDto = ReadonlyDeep<{
   clientId: string;
   clientNumber: string;
   firstName: string;
@@ -40,11 +41,11 @@ export type RenewalApplicantInformationDto = ReadonlyDeep<{
   socialInsuranceNumber: string;
 }>;
 
-export type RenewalChildDto = ReadonlyDeep<{
+export type BenefitRenewalChildDto = ReadonlyDeep<{
   clientId: string;
   clientNumber: string;
   dentalBenefits: string[];
-  dentalInsurance: DentalInsuranceDto;
+  dentalInsurance: BenefitRenewalDentalInsuranceDto;
   information: {
     firstName: string;
     lastName: string;
@@ -54,18 +55,18 @@ export type RenewalChildDto = ReadonlyDeep<{
   };
 }>;
 
-export type RenewalEmailDto = ReadonlyDeep<{
+export type BenefitRenewalEmailDto = ReadonlyDeep<{
   value?: string;
   verified?: boolean;
 }>;
 
-export type RenewalCommunicationPreferencesDto = ReadonlyDeep<{
+export type BenefitRenewalCommunicationPreferencesDto = ReadonlyDeep<{
   preferredLanguage: string;
   preferredMethod: string;
   preferredMethodGovernmentOfCanada: string;
 }>;
 
-export type RenewalContactInformationDto = ReadonlyDeep<{
+export type BenefitRenewalContactInformationDto = ReadonlyDeep<{
   copyMailingAddress: boolean;
   homeAddress: string;
   homeApartment?: string;
@@ -83,27 +84,27 @@ export type RenewalContactInformationDto = ReadonlyDeep<{
   phoneNumberAlt?: string;
 }>;
 
-export type RenewalPartnerInformationDto = ReadonlyDeep<{
+export type BenefitRenewalPartnerInformationDto = ReadonlyDeep<{
   clientId?: string;
   consentToSharePersonalInformation: true;
   socialInsuranceNumber: string;
   yearOfBirth: string;
 }>;
 
-export type RenewalTypeOfApplicationDto = 'adult' | 'adult-child' | 'child';
+export type BenefitRenewalTypeOfApplicationDto = 'adult' | 'adult-child' | 'child';
 
-type DentalInsuranceDto = ReadonlyDeep<{
+export type BenefitRenewalDentalInsuranceDto = ReadonlyDeep<{
   hasDentalInsurance: boolean;
   dentalInsuranceEligibilityConfirmation?: boolean;
 }>;
 
-type TermsAndConditionsDto = ReadonlyDeep<{
+export type BenefitRenewalTermsAndConditionsDto = ReadonlyDeep<{
   acknowledgeTerms: boolean;
   acknowledgePrivacy: boolean;
   shareData: boolean;
 }>;
 
-export type ChangeIndicatorsDto = ReadonlyDeep<{
+export type BenefitRenewalChangeIndicatorsDto = ReadonlyDeep<{
   hasAddressChanged?: boolean;
   hasMaritalStatusChanged?: boolean;
   hasPhoneChanged?: boolean;

--- a/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
+++ b/frontend/app/.server/domain/dtos/benefit-renewal.dto.ts
@@ -6,6 +6,7 @@ export type BenefitRenewalDto = ReadonlyDeep<{
   children: RenewalChildDto[];
   communicationPreferences: RenewalCommunicationPreferencesDto;
   contactInformation: RenewalContactInformationDto;
+  emailAddress: RenewalEmailDto;
   dateOfBirth: string;
   dentalBenefits: string[];
   dentalInsurance?: DentalInsuranceDto;
@@ -53,9 +54,12 @@ export type RenewalChildDto = ReadonlyDeep<{
   };
 }>;
 
+export type RenewalEmailDto = ReadonlyDeep<{
+  value?: string;
+  verified?: boolean;
+}>;
+
 export type RenewalCommunicationPreferencesDto = ReadonlyDeep<{
-  email?: string;
-  emailVerified?: boolean;
   preferredLanguage: string;
   preferredMethod: string;
   preferredMethodGovernmentOfCanada: string;
@@ -77,7 +81,6 @@ export type RenewalContactInformationDto = ReadonlyDeep<{
   mailingProvince?: string;
   phoneNumber?: string;
   phoneNumberAlt?: string;
-  email?: string;
 }>;
 
 export type RenewalPartnerInformationDto = ReadonlyDeep<{

--- a/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-application.dto.mapper.ts
@@ -4,14 +4,14 @@ import validator from 'validator';
 
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
-import type { BenefitApplicationDto, ChildDto, ContactInformationDto, PartnerInformationDto, TypeOfApplicationDto } from '~/.server/domain/dtos';
+import type { BenefitApplicationChildDto, BenefitApplicationContactInformationDto, BenefitApplicationDto, BenefitApplicationPartnerInformationDto, BenefitApplicationTypeOfApplicationDto } from '~/.server/domain/dtos';
 import type { BenefitApplicationRequestEntity, BenefitApplicationResponseEntity } from '~/.server/domain/entities';
 import { expectDefined } from '~/utils/assert-utils';
 import { parseDateString } from '~/utils/date-utils';
 import { sanitizeSin } from '~/utils/sin-utils';
 
 export interface BenefitApplicationDtoMapper {
-  mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto: BenefitApplicationDto, applicationChannelCode: 'protected' | 'public'): BenefitApplicationRequestEntity;
+  mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto: BenefitApplicationDto): BenefitApplicationRequestEntity;
   mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity: BenefitApplicationResponseEntity): string;
 }
 
@@ -25,31 +25,27 @@ interface ToAddressArgs {
   province?: string;
 }
 
-interface ToEmailAddressArgs {
-  email?: string;
-}
+type DefaultBenefitApplicationDtoMapperServerConfig = Pick<
+  ServerConfig,
+  'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED'
+>;
 
 @injectable()
 export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDtoMapper {
-  private readonly serverConfig: Pick<
-    ServerConfig,
-    'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED'
-  >;
+  private readonly serverConfig: DefaultBenefitApplicationDtoMapperServerConfig;
 
-  constructor(
-    @inject(TYPES.ServerConfig)
-    serverConfig: Pick<ServerConfig, 'APPLICANT_CATEGORY_CODE_INDIVIDUAL' | 'APPLICANT_CATEGORY_CODE_FAMILY' | 'APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC' | 'BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED'>,
-  ) {
+  constructor(@inject(TYPES.ServerConfig) serverConfig: DefaultBenefitApplicationDtoMapperServerConfig) {
     this.serverConfig = serverConfig;
   }
 
-  mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto: BenefitApplicationDto, applicationChannelCode: 'protected' | 'public'): BenefitApplicationRequestEntity {
+  mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto: BenefitApplicationDto): BenefitApplicationRequestEntity {
     const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC } = this.serverConfig;
-    return this.toBenefitApplicationRequestEntity(benefitApplicationDto, applicationChannelCode === 'protected' ? BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED : BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC);
+    const applicationChannelCode = benefitApplicationDto.applicationChannelCode === 'protected' ? BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED : BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC;
+    return this.toBenefitApplicationRequestEntity(benefitApplicationDto, applicationChannelCode);
   }
 
   private toBenefitApplicationRequestEntity(benefitApplication: BenefitApplicationDto, applicationChannelCode: string): BenefitApplicationRequestEntity {
-    const { applicantInformation, applicationYearId, children, communicationPreferences, contactInformation, dateOfBirth, dentalBenefits, dentalInsurance, livingIndependently, partnerInformation, termsAndConditions, typeOfApplication } =
+    const { applicantInformation, applicationYearId, children, communicationPreferences, contactInformation, emailAddress, dateOfBirth, dentalBenefits, dentalInsurance, livingIndependently, partnerInformation, termsAndConditions, typeOfApplication } =
       benefitApplication;
     return {
       BenefitApplication: {
@@ -62,7 +58,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
             SharingConsentIndicator: termsAndConditions.shareData,
             EligibilityAttestationIndicator: true,
             AccuracyConfirmationIndicator: true,
-            ApplicantEmailVerifiedIndicator: communicationPreferences.emailVerified,
+            ApplicantEmailVerifiedIndicator: emailAddress.verified,
             InsurancePlan: this.toInsurancePlan(dentalBenefits),
           },
           ClientIdentification: this.toClientIdentification(applicantInformation.clientNumber),
@@ -70,7 +66,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
           PersonContactInformation: [
             {
               Address: [this.toMailingAddress(contactInformation), this.toHomeAddress(contactInformation)],
-              EmailAddress: this.toEmailAddress({ email: communicationPreferences.email }),
+              EmailAddress: emailAddress.value && validator.isEmail(emailAddress.value) ? [{ EmailAddressID: emailAddress.value }] : [],
               TelephoneNumber: this.toTelephoneNumber(contactInformation),
             },
           ],
@@ -143,7 +139,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     };
   }
 
-  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: ContactInformationDto) {
+  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: BenefitApplicationContactInformationDto) {
     return this.toAddress({
       address: mailingAddress,
       apartment: mailingApartment,
@@ -155,7 +151,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     });
   }
 
-  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: ContactInformationDto) {
+  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: BenefitApplicationContactInformationDto) {
     return this.toAddress({
       address: homeAddress,
       apartment: homeApartment,
@@ -191,13 +187,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     };
   }
 
-  private toEmailAddress({ email }: ToEmailAddressArgs) {
-    return email && !validator.isEmpty(email) //
-      ? [{ EmailAddressID: email }]
-      : [];
-  }
-
-  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: ContactInformationDto) {
+  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: BenefitApplicationContactInformationDto) {
     const telephoneNumber = [];
 
     if (phoneNumber && !validator.isEmpty(phoneNumber)) {
@@ -221,7 +211,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     return telephoneNumber;
   }
 
-  private toRelatedPersons(partnerInformation: PartnerInformationDto | undefined, children: ReadonlyArray<ChildDto>) {
+  private toRelatedPersons(partnerInformation: BenefitApplicationPartnerInformationDto | undefined, children: ReadonlyArray<BenefitApplicationChildDto>) {
     const relatedPersons = [];
 
     if (partnerInformation) {
@@ -234,7 +224,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     return relatedPersons;
   }
 
-  private toRelatedPersonSpouse({ consentToSharePersonalInformation, socialInsuranceNumber, yearOfBirth }: PartnerInformationDto) {
+  private toRelatedPersonSpouse({ consentToSharePersonalInformation, socialInsuranceNumber, yearOfBirth }: BenefitApplicationPartnerInformationDto) {
     return {
       PersonBirthDate: {
         YearDate: yearOfBirth,
@@ -251,7 +241,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     };
   }
 
-  private toRelatedPersonDependent(children: ReadonlyArray<ChildDto>) {
+  private toRelatedPersonDependent(children: ReadonlyArray<BenefitApplicationChildDto>) {
     return children.map((child) => ({
       PersonBirthDate: this.toDate(child.information.dateOfBirth),
       PersonName: [
@@ -274,7 +264,7 @@ export class DefaultBenefitApplicationDtoMapper implements BenefitApplicationDto
     }));
   }
 
-  private toBenefitApplicationCategoryCode(typeOfApplication: TypeOfApplicationDto) {
+  private toBenefitApplicationCategoryCode(typeOfApplication: BenefitApplicationTypeOfApplicationDto) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_FAMILY, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
     if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL;
     if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -5,16 +5,16 @@ import validator from 'validator';
 import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import type {
+  BenefitRenewalApplicantInformationDto,
+  BenefitRenewalChangeIndicatorsDto,
+  BenefitRenewalChildDto,
+  BenefitRenewalCommunicationPreferencesDto,
+  BenefitRenewalContactInformationDto,
+  BenefitRenewalDentalInsuranceDto,
   BenefitRenewalDto,
-  ChangeIndicatorsDto,
-  DentalInsuranceDto,
-  RenewalApplicantInformationDto,
-  RenewalChildDto,
-  RenewalCommunicationPreferencesDto,
-  RenewalContactInformationDto,
-  RenewalEmailDto,
-  RenewalPartnerInformationDto,
-  RenewalTypeOfApplicationDto,
+  BenefitRenewalEmailDto,
+  BenefitRenewalPartnerInformationDto,
+  BenefitRenewalTypeOfApplicationDto,
 } from '~/.server/domain/dtos';
 import type { BenefitRenewalRequestEntity, BenefitRenewalResponseEntity } from '~/.server/domain/entities';
 import { expectDefined } from '~/utils/assert-utils';
@@ -22,7 +22,7 @@ import { parseDateString } from '~/utils/date-utils';
 import { sanitizeSin } from '~/utils/sin-utils';
 
 export interface BenefitRenewalDtoMapper {
-  mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto: BenefitRenewalDto, applicationChannelCode: 'protected' | 'public'): BenefitRenewalRequestEntity;
+  mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto: BenefitRenewalDto): BenefitRenewalRequestEntity;
   mapBenefitRenewalResponseEntityToApplicationCode(benefitRenewalResponseEntity: BenefitRenewalResponseEntity): string;
 }
 
@@ -39,19 +39,19 @@ interface ToBenefitRenewalRequestEntityArgs {
   applicationCategoryCodeName: 'New' | 'Renewal';
 
   applicationChannelCode: string;
-  applicantInformation: RenewalApplicantInformationDto;
+  applicantInformation: BenefitRenewalApplicantInformationDto;
   applicationYearId: string;
-  changeIndicators?: ChangeIndicatorsDto;
-  children: readonly RenewalChildDto[];
-  communicationPreferences: RenewalCommunicationPreferencesDto;
-  contactInformation: RenewalContactInformationDto;
-  emailAddress: RenewalEmailDto;
+  changeIndicators?: BenefitRenewalChangeIndicatorsDto;
+  children: readonly BenefitRenewalChildDto[];
+  communicationPreferences: BenefitRenewalCommunicationPreferencesDto;
+  contactInformation: BenefitRenewalContactInformationDto;
+  emailAddress: BenefitRenewalEmailDto;
   dateOfBirth: string;
   dentalBenefits: readonly string[];
-  dentalInsurance?: DentalInsuranceDto;
+  dentalInsurance?: BenefitRenewalDentalInsuranceDto;
   livingIndependently?: boolean;
-  partnerInformation?: RenewalPartnerInformationDto;
-  typeOfApplication: RenewalTypeOfApplicationDto;
+  partnerInformation?: BenefitRenewalPartnerInformationDto;
+  typeOfApplication: BenefitRenewalTypeOfApplicationDto;
 }
 
 interface ToAddressArgs {
@@ -81,12 +81,14 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     this.serverConfig = serverConfig;
   }
 
-  mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto: BenefitRenewalDto, applicationChannelCode: 'protected' | 'public'): BenefitRenewalRequestEntity {
+  mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto: BenefitRenewalDto): BenefitRenewalRequestEntity {
     const { BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED, BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC } = this.serverConfig;
+    const applicationChannelCode = benefitRenewalDto.applicationChannelCode === 'protected' ? BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED : BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC;
+
     return this.toBenefitRenewalRequestEntity({
       applicantInformation: benefitRenewalDto.applicantInformation,
       applicationCategoryCodeName: benefitRenewalDto.applicationCategoryCodeName,
-      applicationChannelCode: applicationChannelCode === 'protected' ? BENEFIT_APPLICATION_CHANNEL_CODE_PROTECTED : BENEFIT_APPLICATION_CHANNEL_CODE_PUBLIC,
+      applicationChannelCode: applicationChannelCode,
       applicationYearId: benefitRenewalDto.applicationYearId,
       changeIndicators: benefitRenewalDto.changeIndicators,
       children: benefitRenewalDto.children,
@@ -145,7 +147,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
           PersonContactInformation: [
             {
               Address: [this.toMailingAddress(contactInformation), this.toHomeAddress(contactInformation)],
-              EmailAddress: emailAddress.value && !validator.isEmpty(emailAddress.value) ? [{ EmailAddressID: emailAddress.value }] : [],
+              EmailAddress: emailAddress.value && validator.isEmail(emailAddress.value) ? [{ EmailAddressID: emailAddress.value }] : [],
               TelephoneNumber: this.toTelephoneNumber(contactInformation),
             },
           ],
@@ -208,7 +210,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     ];
   }
 
-  private toChangeIndicators(changeIndicators?: ChangeIndicatorsDto) {
+  private toChangeIndicators(changeIndicators?: BenefitRenewalChangeIndicatorsDto) {
     if (!changeIndicators) {
       return {};
     }
@@ -228,7 +230,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     };
   }
 
-  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: RenewalContactInformationDto) {
+  private toMailingAddress({ mailingAddress, mailingApartment, mailingCity, mailingCountry, mailingPostalCode, mailingProvince }: BenefitRenewalContactInformationDto) {
     return this.toAddress({
       address: mailingAddress,
       apartment: mailingApartment,
@@ -240,7 +242,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     });
   }
 
-  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: RenewalContactInformationDto) {
+  private toHomeAddress({ homeAddress, homeApartment, homeCity, homeCountry, homePostalCode, homeProvince }: BenefitRenewalContactInformationDto) {
     return this.toAddress({
       address: homeAddress,
       apartment: homeApartment,
@@ -276,7 +278,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     };
   }
 
-  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: RenewalContactInformationDto) {
+  private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: BenefitRenewalContactInformationDto) {
     const telephoneNumber = [];
 
     if (phoneNumber && !validator.isEmpty(phoneNumber)) {
@@ -300,7 +302,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     return telephoneNumber;
   }
 
-  private toRelatedPersons(partnerInformation: RenewalPartnerInformationDto | undefined, children: ReadonlyArray<RenewalChildDto>) {
+  private toRelatedPersons(partnerInformation: BenefitRenewalPartnerInformationDto | undefined, children: ReadonlyArray<BenefitRenewalChildDto>) {
     const relatedPersons = [];
 
     if (partnerInformation) {
@@ -313,7 +315,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     return relatedPersons;
   }
 
-  private toRelatedPersonSpouse(renewalPartnerInformation: RenewalPartnerInformationDto) {
+  private toRelatedPersonSpouse(renewalPartnerInformation: BenefitRenewalPartnerInformationDto) {
     return {
       ApplicantDetail: { ConsentToSharePersonalInformationIndicator: renewalPartnerInformation.consentToSharePersonalInformation },
       ClientIdentification: renewalPartnerInformation.clientId ? [{ IdentificationID: renewalPartnerInformation.clientId, IdentificationCategoryText: 'Client ID' }] : undefined,
@@ -323,7 +325,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     };
   }
 
-  private toRelatedPersonDependent(children: ReadonlyArray<RenewalChildDto>) {
+  private toRelatedPersonDependent(children: ReadonlyArray<BenefitRenewalChildDto>) {
     return children.map((child) => ({
       PersonBirthDate: this.toDate(child.information.dateOfBirth),
       PersonName: [
@@ -351,7 +353,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     }));
   }
 
-  private toBenefitApplicationCategoryCode(typeOfApplication: RenewalTypeOfApplicationDto) {
+  private toBenefitApplicationCategoryCode(typeOfApplication: BenefitRenewalTypeOfApplicationDto) {
     const { APPLICANT_CATEGORY_CODE_INDIVIDUAL, APPLICANT_CATEGORY_CODE_FAMILY, APPLICANT_CATEGORY_CODE_DEPENDENT_ONLY } = this.serverConfig;
     if (typeOfApplication === 'adult') return APPLICANT_CATEGORY_CODE_INDIVIDUAL;
     if (typeOfApplication === 'adult-child') return APPLICANT_CATEGORY_CODE_FAMILY;

--- a/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
+++ b/frontend/app/.server/domain/mappers/benefit-renewal.dto.mapper.ts
@@ -12,6 +12,7 @@ import type {
   RenewalChildDto,
   RenewalCommunicationPreferencesDto,
   RenewalContactInformationDto,
+  RenewalEmailDto,
   RenewalPartnerInformationDto,
   RenewalTypeOfApplicationDto,
 } from '~/.server/domain/dtos';
@@ -44,6 +45,7 @@ interface ToBenefitRenewalRequestEntityArgs {
   children: readonly RenewalChildDto[];
   communicationPreferences: RenewalCommunicationPreferencesDto;
   contactInformation: RenewalContactInformationDto;
+  emailAddress: RenewalEmailDto;
   dateOfBirth: string;
   dentalBenefits: readonly string[];
   dentalInsurance?: DentalInsuranceDto;
@@ -60,11 +62,6 @@ interface ToAddressArgs {
   country: string;
   postalCode?: string;
   province?: string;
-}
-
-interface ToEmailAddressArgs {
-  contactEmail?: string;
-  communicationEmail?: string;
 }
 
 @injectable()
@@ -95,6 +92,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
       children: benefitRenewalDto.children,
       communicationPreferences: benefitRenewalDto.communicationPreferences,
       contactInformation: benefitRenewalDto.contactInformation,
+      emailAddress: benefitRenewalDto.emailAddress,
       dateOfBirth: benefitRenewalDto.dateOfBirth,
       dentalBenefits: benefitRenewalDto.dentalBenefits,
       dentalInsurance: benefitRenewalDto.dentalInsurance,
@@ -113,6 +111,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
     children,
     communicationPreferences,
     contactInformation,
+    emailAddress,
     dateOfBirth,
     dentalBenefits,
     dentalInsurance,
@@ -133,7 +132,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
             SharingConsentIndicator: true,
             EligibilityAttestationIndicator: true,
             AccuracyConfirmationIndicator: true,
-            ApplicantEmailVerifiedIndicator: communicationPreferences.emailVerified,
+            ApplicantEmailVerifiedIndicator: emailAddress.verified,
             InsurancePlan: this.toInsurancePlan(dentalBenefits),
             ...this.toChangeIndicators(changeIndicators),
           },
@@ -146,7 +145,7 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
           PersonContactInformation: [
             {
               Address: [this.toMailingAddress(contactInformation), this.toHomeAddress(contactInformation)],
-              EmailAddress: this.toEmailAddress({ contactEmail: contactInformation.email, communicationEmail: communicationPreferences.email }),
+              EmailAddress: emailAddress.value && !validator.isEmpty(emailAddress.value) ? [{ EmailAddressID: emailAddress.value }] : [],
               TelephoneNumber: this.toTelephoneNumber(contactInformation),
             },
           ],
@@ -275,22 +274,6 @@ export class DefaultBenefitRenewalDtoMapper implements BenefitRenewalDtoMapper {
         StreetName: address,
       },
     };
-  }
-
-  private toEmailAddress({ contactEmail, communicationEmail }: ToEmailAddressArgs) {
-    const emailAddress = [];
-
-    if (contactEmail && !validator.isEmpty(contactEmail)) {
-      emailAddress.push({
-        EmailAddressID: contactEmail,
-      });
-    } else if (communicationEmail && !validator.isEmpty(communicationEmail)) {
-      emailAddress.push({
-        EmailAddressID: communicationEmail,
-      });
-    }
-
-    return emailAddress;
   }
 
   private toTelephoneNumber({ phoneNumber, phoneNumberAlt }: RenewalContactInformationDto) {

--- a/frontend/app/.server/domain/services/benefit-application.service.ts
+++ b/frontend/app/.server/domain/services/benefit-application.service.ts
@@ -15,15 +15,15 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitApplicationService {
   /**
-   * Submits benefit application request.
+   * Submits a public benefit application request.
    *
-   * @param benefitApplicationRequestDto The benefit application request dto
+   * @param benefitApplicationRequestDto The public benefit application request dto
    * @returns A Promise that resolves to the benefit application code
    */
-  createBenefitApplication(benefitApplicationRequestDto: BenefitApplicationDto): Promise<string>;
+  createPublicBenefitApplication(benefitApplicationRequestDto: BenefitApplicationDto): Promise<string>;
 
   /**
-   * Submits benefit application request for the protected route.
+   * Submits a protected benefit application request.
    *
    * @param protectedBenefitApplicationRequestDto The protected route benefit application request dto
    * @returns A Promise that resolves to the benefit application code
@@ -65,20 +65,25 @@ export class DefaultBenefitApplicationService implements BenefitApplicationServi
     this.log.debug('DefaultBenefitApplicationService initiated.');
   }
 
-  async createBenefitApplication(benefitApplicationRequestDto: BenefitApplicationDto): Promise<string> {
+  async createPublicBenefitApplication(benefitApplicationRequestDto: BenefitApplicationDto): Promise<string> {
     this.log.trace('Creating benefit application for request [%j]', benefitApplicationRequestDto);
 
     const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
 
     if (killswitchEngaged) {
       this.log.error('Request to create benefit application is unavailable (killswitch engaged).');
-      new AppError('Request to create benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      throw new AppError('Request to create benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
+    if (benefitApplicationRequestDto.applicationChannelCode !== 'public') {
+      this.log.error('Received request to create public benefit application with invalid application channel code: [%s]', benefitApplicationRequestDto.applicationChannelCode);
+      throw new AppError('Invalid application channel code', ErrorCodes.INVALID_REQUEST);
     }
 
     this.auditService.createAudit('application-submit.post', { userId: benefitApplicationRequestDto.userId });
 
     try {
-      const benefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationRequestDto, 'public');
+      const benefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationRequestDto);
       const benefitApplicationResponseEntity = await this.benefitApplicationRepository.createBenefitApplication(benefitApplicationRequestEntity);
       const applicationCode = this.benefitApplicationDtoMapper.mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity);
 
@@ -97,9 +102,14 @@ export class DefaultBenefitApplicationService implements BenefitApplicationServi
   async createProtectedBenefitApplication(protectedBenefitApplicationRequestDto: BenefitApplicationDto): Promise<string> {
     this.log.trace('Creating protected benefit application for request [%j]', protectedBenefitApplicationRequestDto);
 
+    if (protectedBenefitApplicationRequestDto.applicationChannelCode !== 'protected') {
+      this.log.error('Received request to create protected benefit application with invalid application channel code: [%s]', protectedBenefitApplicationRequestDto.applicationChannelCode);
+      throw new AppError('Invalid application channel code', ErrorCodes.INVALID_REQUEST);
+    }
+
     this.auditService.createAudit('protected-application-submit.post', { userId: protectedBenefitApplicationRequestDto.userId });
 
-    const protectedBenefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(protectedBenefitApplicationRequestDto, 'protected');
+    const protectedBenefitApplicationRequestEntity = this.benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(protectedBenefitApplicationRequestDto);
     const benefitApplicationResponseEntity = await this.benefitApplicationRepository.createBenefitApplication(protectedBenefitApplicationRequestEntity);
     const applicationCode = this.benefitApplicationDtoMapper.mapBenefitApplicationResponseEntityToApplicationCode(benefitApplicationResponseEntity);
 

--- a/frontend/app/.server/domain/services/benefit-renewal.service.ts
+++ b/frontend/app/.server/domain/services/benefit-renewal.service.ts
@@ -15,16 +15,18 @@ import { ErrorCodes } from '~/errors/error-codes';
 
 export interface BenefitRenewalService {
   /**
-   * Submits a benefit renewal request.
+   * Submits a public benefit renewal request.
    *
    * @param benefitRenewalDto The benefit renewal request dto
+   * @returns A Promise that resolves to the benefit renewal application code
    */
-  createBenefitRenewal(benefitRenewalDto: BenefitRenewalDto): Promise<string>;
+  createPublicBenefitRenewal(benefitRenewalDto: BenefitRenewalDto): Promise<string>;
 
   /**
-   * Submits benefit renewal request for protected route.
+   * Submits a protected benefit renewal request.
    *
-   * @param benefitRenewalDto The route benefit renewal request dto
+   * @param benefitRenewalDto The benefit renewal request dto
+   * @returns A Promise that resolves to the benefit renewal application code
    */
   createProtectedBenefitRenewal(benefitRenewalDto: BenefitRenewalDto): Promise<string>;
 }
@@ -63,20 +65,25 @@ export class DefaultBenefitRenewalService implements BenefitRenewalService {
     this.log.debug('DefaultBenefitRenewalService initiated.');
   }
 
-  async createBenefitRenewal(benefitRenewalDto: BenefitRenewalDto): Promise<string> {
+  async createPublicBenefitRenewal(benefitRenewalDto: BenefitRenewalDto): Promise<string> {
     this.log.trace('Creating benefit renewal for request [%j]', benefitRenewalDto);
 
     const killswitchEngaged = await this.redisService?.get(KILLSWITCH_KEY);
 
     if (killswitchEngaged) {
       this.log.error('Request to renew benefit application is unavailable (killswitch engaged).');
-      new AppError('Request to renew benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      throw new AppError('Request to renew benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
+    if (benefitRenewalDto.applicationChannelCode !== 'public') {
+      this.log.error('Received request to create public benefit renewal with invalid application channel code: [%s]', benefitRenewalDto.applicationChannelCode);
+      throw new AppError(`Invalid application channel code [${benefitRenewalDto.applicationChannelCode}]`, ErrorCodes.INVALID_REQUEST);
     }
 
     this.auditService.createAudit('benefit-renewal-submit.post', { userId: benefitRenewalDto.userId });
 
     try {
-      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'public');
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
       const benefitRenewalResponseEntity = await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
       const applicationCode = this.benefitRenewalDtoMapper.mapBenefitRenewalResponseEntityToApplicationCode(benefitRenewalResponseEntity);
 
@@ -99,13 +106,18 @@ export class DefaultBenefitRenewalService implements BenefitRenewalService {
 
     if (killswitchEngaged) {
       this.log.error('Request to renew protected benefit application is unavailable (killswitch engaged).');
-      new AppError('Request to renew protected benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+      throw new AppError('Request to renew protected benefit application is unavailable (killswitch engaged)', ErrorCodes.XAPI_TOO_MANY_REQUESTS);
+    }
+
+    if (benefitRenewalDto.applicationChannelCode !== 'protected') {
+      this.log.error('Received request to create protected benefit renewal with invalid application channel code: [%s]', benefitRenewalDto.applicationChannelCode);
+      throw new AppError('Invalid application channel code', ErrorCodes.INVALID_REQUEST);
     }
 
     this.auditService.createAudit('protected-renewal-submit.post', { userId: benefitRenewalDto.userId });
 
     try {
-      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'protected');
+      const benefitRenewalRequestEntity = this.benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
       const benefitRenewalResponseEntity = await this.benefitRenewalRepository.createBenefitRenewal(benefitRenewalRequestEntity);
       const applicationCode = this.benefitRenewalDtoMapper.mapBenefitRenewalResponseEntityToApplicationCode(benefitRenewalResponseEntity);
 

--- a/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/base-application-route-helpers.ts
@@ -1,5 +1,6 @@
 // Shared state field types for Public/Protected ApplicationState
 import type { PickDeep, ReadonlyDeep } from 'type-fest';
+import validator from 'validator';
 
 import type { ClientApplicationRenewalEligibleDto } from '~/.server/domain/dtos';
 import type { DeclaredChange } from '~/.server/routes/helpers/declared-change-type';
@@ -8,6 +9,12 @@ import { getEnv } from '~/.server/utils/env.utils';
 import type { EligibilityType } from '~/components/eligibility';
 import { getAgeFromDateString } from '~/utils/date-utils';
 import { formatSin, isValidSin } from '~/utils/sin-utils';
+
+/**
+ * The channel through which the application is being submitted, either 'protected' for authenticated
+ * users or 'public' for unauthenticated users.
+ */
+export type BaseApplicationChannelCodeState = 'protected' | 'public';
 
 /**
  * The context of the application, either 'intake' for new applications or 'renewal' for renewal applications.
@@ -92,8 +99,19 @@ export type BaseApplicationChildState = ReadonlyDeep<{
  * Communication preferences for the application state.
  */
 export type BaseApplicationCommunicationPreferencesState = ReadonlyDeep<{
+  /**
+   * The preferred language for the applicant to receive communications from Sun Life and the Government of Canada.
+   */
   preferredLanguage: string;
+
+  /**
+   * The preferred method for the applicant to receive communications from Sun Life.
+   */
   preferredMethod: string;
+
+  /**
+   * The preferred method for the applicant to receive communications from the Government of Canada.
+   */
   preferredNotificationMethod: string;
 }>;
 
@@ -386,4 +404,60 @@ export function isSinReserved(sin: string, reservedSins: ReadonlyArray<string | 
   });
 
   return formattedReserved.includes(formatSin(sin));
+}
+
+type IsEmailAddressRequiredArgs = {
+  /** The applicant's preferred method of communication with Sun Life. */
+  preferredMethodSunLife: string;
+  /** The applicant's preferred method of communication with the Government of Canada. */
+  preferredMethodGovernmentOfCanada: string;
+};
+
+/**
+ * Determines whether an email address is required based on the applicant's preferred communication methods.
+ *
+ * An email address is required if the applicant's preferred method of communication with Sun Life
+ * is "email" from config or if their preferred method of communication with the Government of
+ * Canada is "digital" from config.
+ *
+ * @returns `true` if an email address is required, `false` otherwise.
+ */
+export function isEmailAddressRequired({ preferredMethodSunLife, preferredMethodGovernmentOfCanada }: IsEmailAddressRequiredArgs): boolean {
+  const { COMMUNICATION_METHOD_GC_DIGITAL_ID, COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID } = getEnv();
+  return preferredMethodSunLife === COMMUNICATION_METHOD_SUNLIFE_EMAIL_ID || preferredMethodGovernmentOfCanada === COMMUNICATION_METHOD_GC_DIGITAL_ID;
+}
+
+type CheckValidAndVerifiedEmailAddressResult =
+  | {
+      success: true;
+      email: string;
+      emailVerified: true;
+    }
+  | {
+      success: false;
+      email: string | undefined;
+      emailVerified: boolean | undefined;
+    };
+
+type CheckValidAndVerifiedEmailAddressArgs = {
+  /** The email address to validate. */
+  email: string | undefined;
+  /** Indicates whether the email address has been verified. */
+  emailVerified: boolean | undefined;
+};
+
+/**
+ * Determines whether the provided email address is valid and verified.
+ *
+ * @returns An object indicating whether the email address is valid and verified, along with the
+ *  email address and its verification status.
+ */
+export function checkValidAndVerifiedEmailAddress({ email, emailVerified }: CheckValidAndVerifiedEmailAddressArgs): CheckValidAndVerifiedEmailAddressResult {
+  if (typeof email === 'string' && validator.isEmail(email) && emailVerified === true) {
+    // The email is valid and verified, return success with the email and verification status.
+    return { success: true, email, emailVerified };
+  }
+
+  // The email is either invalid or not verified, return failure with the email and verification status.
+  return { success: false, email, emailVerified };
 }

--- a/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/protected-application-route-helpers.ts
@@ -11,6 +11,7 @@ import { createLogger } from '~/.server/logging';
 import type {
   BaseApplicationAddressDeclaredChangeState,
   BaseApplicationApplicantInformationState,
+  BaseApplicationChannelCodeState,
   BaseApplicationChildState,
   BaseApplicationCommunicationPreferencesDeclaredChangeState,
   BaseApplicationContextState,
@@ -41,6 +42,7 @@ export type ProtectedApplicationState = ReadonlyDeep<{
    * The unique identifier for the protected application.
    */
   id: string;
+  channelCode: ExtractStrict<BaseApplicationChannelCodeState, 'protected'>;
   context: BaseApplicationContextState;
   lastUpdatedOn: string;
   applicantInformation?: BaseApplicationApplicantInformationState;
@@ -139,13 +141,24 @@ export function getProtectedApplicationState({ params, session }: LoadStateArgs)
     throw redirectDocument(cdcpWebsiteApplicationUrl);
   }
 
-  return state;
+  // Validate channelCode to ensure the session state is consistent with protected application expectations
+  const channelCode = state.channelCode as string | undefined;
+
+  if (channelCode !== undefined && channelCode !== 'protected') {
+    throw new Error(`Invalid channelCode in session state; expected 'protected' but got [${channelCode}]`);
+  }
+
+  return {
+    ...state,
+    // Default to 'protected' if channelCode is missing to maintain backward compatibility
+    channelCode: channelCode ?? 'protected',
+  };
 }
 
 interface SaveProtectedApplicationStateArgs {
   params: ApplicationStateParams;
   session: Session;
-  state: Partial<OmitStrict<ProtectedApplicationState, 'id' | 'lastUpdatedOn' | 'applicationYear' | 'context'>>;
+  state: Partial<OmitStrict<ProtectedApplicationState, 'id' | 'lastUpdatedOn' | 'applicationYear' | 'context' | 'channelCode'>>;
 }
 
 /**
@@ -161,6 +174,7 @@ export function saveProtectedApplicationState({ params, session, state }: SavePr
     ...currentState,
     ...state,
     lastUpdatedOn: new UTCDate().toISOString(),
+    channelCode: 'protected', // Ensure channelCode remains 'protected' regardless of input to maintain state integrity
   } satisfies ProtectedApplicationState;
 
   const sessionkey = getSessionKey(currentState.id);
@@ -227,6 +241,7 @@ export function startProtectedApplicationState({ applicationYear, clientApplicat
   // Create the initial state object
   const initialState = {
     id,
+    channelCode: 'protected',
     context,
     lastUpdatedOn: new UTCDate().toISOString(),
     applicationYear,

--- a/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
+++ b/frontend/app/.server/routes/helpers/public-application-route-helpers.ts
@@ -10,6 +10,7 @@ import { createLogger } from '~/.server/logging';
 import type {
   BaseApplicationAddressDeclaredChangeState,
   BaseApplicationApplicantInformationState,
+  BaseApplicationChannelCodeState,
   BaseApplicationChildState,
   BaseApplicationCommunicationPreferencesDeclaredChangeState,
   BaseApplicationContextState,
@@ -42,6 +43,7 @@ export type PublicApplicationState = ReadonlyDeep<{
    * The unique identifier for the public application.
    */
   id: string;
+  channelCode: ExtractStrict<BaseApplicationChannelCodeState, 'public'>;
   context: BaseApplicationContextState;
   inputModel?: PublicApplicationInputModelState;
   lastUpdatedOn: string;
@@ -107,7 +109,7 @@ interface LoadStateArgs {
 /**
  * Gets public application state.
  * @param args - The arguments.
- * @returns The public applicqation state.
+ * @returns The public application state.
  */
 export function getPublicApplicationState({ params, session }: LoadStateArgs): PublicApplicationState {
   const log = createLogger('application-route-helpers.server/loadApplicationState');
@@ -139,13 +141,24 @@ export function getPublicApplicationState({ params, session }: LoadStateArgs): P
     throw redirectDocument(cdcpWebsiteApplicationUrl);
   }
 
-  return state;
+  // Validate channelCode to ensure the session state is consistent with public application expectations
+  const channelCode = state.channelCode as string | undefined;
+
+  if (channelCode !== undefined && channelCode !== 'public') {
+    throw new Error(`Invalid channelCode in session state; expected 'public' but got [${channelCode}]`);
+  }
+
+  return {
+    ...state,
+    // Default to 'public' if channelCode is missing to maintain backward compatibility
+    channelCode: channelCode ?? 'public',
+  };
 }
 
 interface SavePublicApplicationStateArgs {
   params: ApplicationStateParams;
   session: Session;
-  state: Partial<OmitStrict<PublicApplicationState, 'id' | 'lastUpdatedOn' | 'applicationYear' | 'context'>>;
+  state: Partial<OmitStrict<PublicApplicationState, 'id' | 'lastUpdatedOn' | 'applicationYear' | 'context' | 'channelCode'>>;
 }
 
 /**
@@ -161,6 +174,7 @@ export function savePublicApplicationState({ params, session, state }: SavePubli
     ...currentState,
     ...state,
     lastUpdatedOn: new UTCDate().toISOString(),
+    channelCode: 'public', // Ensure channelCode remains 'public' regardless of input to maintain state integrity
   } satisfies PublicApplicationState;
 
   const sessionkey = getSessionKey(currentState.id);
@@ -203,6 +217,7 @@ export function startApplicationState({ applicationYear, session }: StartArgs): 
   const id = generateId();
   const initialState: PublicApplicationState = {
     id,
+    channelCode: 'public',
     context: isWithinRenewalPeriod() ? 'renewal' : 'intake',
     lastUpdatedOn: new UTCDate().toISOString(),
     applicationYear,

--- a/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-application.state.mapper.ts
@@ -2,12 +2,15 @@ import { invariant } from '@dts-stn/invariant';
 import { injectable } from 'inversify';
 import validator from 'validator';
 
-import type { ApplicantInformationDto, BenefitApplicationDto, CommunicationPreferencesDto } from '~/.server/domain/dtos';
+import type { BenefitApplicationApplicantInformationDto, BenefitApplicationCommunicationPreferencesDto, BenefitApplicationDto, BenefitApplicationEmailDto } from '~/.server/domain/dtos';
+import { checkValidAndVerifiedEmailAddress, isEmailAddressRequired } from '~/.server/routes/helpers/base-application-route-helpers';
 import type {
   BaseApplicationAddressDeclaredChangeState,
   BaseApplicationApplicantInformationState,
+  BaseApplicationChannelCodeState,
   BaseApplicationChildState,
   BaseApplicationCommunicationPreferencesDeclaredChangeState,
+  BaseApplicationContextState,
   BaseApplicationDentalBenefitsDeclaredChangeState,
   BaseApplicationDentalInsuranceState,
   BaseApplicationNewOrReturningMemberState,
@@ -19,7 +22,8 @@ import type {
 import { getContextualAgeCategoryFromDate } from '~/.server/routes/helpers/public-application-route-helpers';
 
 export interface ApplicationAdultState {
-  context: 'intake' | 'renewal';
+  channelCode: BaseApplicationChannelCodeState;
+  context: BaseApplicationContextState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
@@ -39,7 +43,8 @@ export interface ApplicationAdultState {
 }
 
 export interface ApplicationFamilyState {
-  context: 'intake' | 'renewal';
+  channelCode: BaseApplicationChannelCodeState;
+  context: BaseApplicationContextState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   children: BaseApplicationChildState[];
@@ -60,7 +65,8 @@ export interface ApplicationFamilyState {
 }
 
 export interface ApplicationChildrenState {
-  context: 'intake' | 'renewal';
+  channelCode: BaseApplicationChannelCodeState;
+  context: BaseApplicationContextState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   children: BaseApplicationChildState[];
@@ -79,7 +85,8 @@ export interface ApplicationChildrenState {
 }
 
 interface ToBenefitApplicationDtoArgs {
-  context: 'intake' | 'renewal';
+  channelCode: BaseApplicationChannelCodeState;
+  context: BaseApplicationContextState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   children?: BaseApplicationChildState[];
@@ -114,8 +121,6 @@ interface ToHomeAddressArgs {
 
 interface ToCommunicationPreferencesArgs {
   communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
-  email?: string;
-  emailVerified?: boolean;
 }
 
 interface ToContactInformationArgs {
@@ -123,6 +128,24 @@ interface ToContactInformationArgs {
   homeAddress?: BaseApplicationAddressDeclaredChangeState;
   isHomeAddressSameAsMailingAddress?: boolean;
   mailingAddress?: BaseApplicationAddressDeclaredChangeState;
+}
+
+interface ToEmailAddressArgs {
+  applicationChannelCode: 'protected' | 'public';
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+}
+
+interface ToEmailAddressProtectedChannelArgs {
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+}
+
+interface ToEmailAddressPublicChannelArgs {
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  email: string | undefined;
+  emailVerified: boolean | undefined;
 }
 
 export interface BenefitApplicationStateMapper {
@@ -142,6 +165,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     }
 
     return this.toBenefitApplicationDto({
+      channelCode: applicationAdultState.channelCode,
       applicantInformation: applicationAdultState.applicantInformation,
       applicationYear: applicationAdultState.applicationYear,
       communicationPreferences: applicationAdultState.communicationPreferences,
@@ -172,6 +196,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     invariant(applicationFamilyState.children.length > 0, 'Expected children to be non-empty for a family application');
 
     return this.toBenefitApplicationDto({
+      channelCode: applicationFamilyState.channelCode,
       applicantInformation: applicationFamilyState.applicantInformation,
       applicationYear: applicationFamilyState.applicationYear,
       children: applicationFamilyState.children,
@@ -203,6 +228,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     invariant(applicationChildrenState.children.length > 0, 'Expected children to be non-empty for a child application');
 
     return this.toBenefitApplicationDto({
+      channelCode: applicationChildrenState.channelCode,
       applicantInformation: applicationChildrenState.applicantInformation,
       applicationYear: applicationChildrenState.applicationYear,
       children: applicationChildrenState.children,
@@ -224,6 +250,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
   }
 
   private toBenefitApplicationDto({
+    channelCode,
     applicantInformation,
     applicationYear,
     children,
@@ -242,8 +269,9 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     termsAndConditions,
     typeOfApplication,
     newOrReturningMember,
-  }: ToBenefitApplicationDtoArgs) {
+  }: ToBenefitApplicationDtoArgs): BenefitApplicationDto {
     return {
+      applicationChannelCode: channelCode,
       applicantInformation: this.toApplicantInformation({
         applicantInformation,
         maritalStatus,
@@ -251,10 +279,10 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       }),
       applicationYearId: applicationYear.applicationYearId,
       children: this.toChildren(children),
-      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences, email, emailVerified }),
+      communicationPreferences: this.toCommunicationPreferences({ communicationPreferences }),
       contactInformation: this.toContactInformation({ phoneNumber, isHomeAddressSameAsMailingAddress, homeAddress, mailingAddress }),
       dateOfBirth: applicantInformation.dateOfBirth,
-      maritalStatus,
+      emailAddress: this.toEmailAddress({ applicationChannelCode: channelCode, communicationPreferences, email, emailVerified }),
       dentalBenefits: this.toDentalBenefits(dentalBenefits),
       dentalInsurance,
       livingIndependently,
@@ -265,7 +293,7 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     };
   }
 
-  private toApplicantInformation({ applicantInformation, maritalStatus, newOrReturningMember }: ToApplicantInformationArgs): ApplicantInformationDto {
+  private toApplicantInformation({ applicantInformation, maritalStatus, newOrReturningMember }: ToApplicantInformationArgs): BenefitApplicationApplicantInformationDto {
     invariant(maritalStatus, 'Expected maritalStatus to be defined');
     return {
       ...applicantInformation,
@@ -296,20 +324,10 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
     });
   }
 
-  private toCommunicationPreferences({ communicationPreferences, email, emailVerified }: ToCommunicationPreferencesArgs): CommunicationPreferencesDto {
+  private toCommunicationPreferences({ communicationPreferences }: ToCommunicationPreferencesArgs): BenefitApplicationCommunicationPreferencesDto {
     invariant(communicationPreferences.value, 'Expected communicationPreferences.value to be defined');
 
-    // Only include the email if the user has verified it. This handles the case where the user entered
-    // an email, then navigated back and switched to a non-digital method.
-    const effectiveEmail = emailVerified ? email : undefined;
-
-    // Keep emailVerified aligned with the email value emitted by this mapper: when no effective email is
-    // sent, omit emailVerified as well so we do not send a stale or contradictory false value.
-    const effectiveEmailVerified = effectiveEmail ? true : undefined;
-
     return {
-      email: effectiveEmail,
-      emailVerified: effectiveEmailVerified,
       preferredLanguage: communicationPreferences.value.preferredLanguage,
       preferredMethod: communicationPreferences.value.preferredMethod,
       preferredMethodGovernmentOfCanada: communicationPreferences.value.preferredNotificationMethod,
@@ -374,5 +392,67 @@ export class DefaultBenefitApplicationStateMapper implements BenefitApplicationS
       mailingPostalCode: mailingAddress.value?.postalCode ?? '',
       mailingProvince: mailingAddress.value?.province ?? '',
     };
+  }
+
+  /**
+   * Maps email address fields to an {@link BenefitApplicationEmailDto} using channel-specific validation rules.
+   * Delegates to {@link toEmailAddressProtectedChannel} for protected-channel applications
+   * and to {@link toEmailAddressPublicChannel} for public-channel applications.
+   */
+  private toEmailAddress({ applicationChannelCode, communicationPreferences, email, emailVerified }: ToEmailAddressArgs): BenefitApplicationEmailDto {
+    if (applicationChannelCode === 'protected') {
+      return this.toEmailAddressProtectedChannel({ email, emailVerified });
+    }
+
+    return this.toEmailAddressPublicChannel({ communicationPreferences, email, emailVerified });
+  }
+
+  /**
+   * Maps email address fields for a protected-channel application.
+   * Protected-channel applications always require a valid, verified email address;
+   * throws if the email is absent or unverified.
+   */
+  private toEmailAddressProtectedChannel({ email, emailVerified }: ToEmailAddressProtectedChannelArgs): BenefitApplicationEmailDto {
+    const result = checkValidAndVerifiedEmailAddress({ email, emailVerified });
+
+    if (!result.success) {
+      throw new Error('Expected a valid and verified email for protected application channel');
+    }
+
+    return { value: result.email, verified: result.emailVerified };
+  }
+
+  /**
+   * Maps email address fields for a public-channel application.
+   * Because this is a new application (intake), the applicant always enters their communication
+   * preferences from scratch — there is no prior data to preserve. The spoke therefore always
+   * sets `communicationPreferences.hasChanged` to `true`, which is enforced here as an invariant.
+   * An email is only required when at least one of the applicant's chosen communication methods
+   * (Sun Life and/or Government of Canada) necessitates one. If neither method requires email,
+   * both {@link BenefitApplicationEmailDto.value} and {@link BenefitApplicationEmailDto.verified}
+   * are returned as `undefined`. Otherwise a valid, verified email is required and throws if
+   * absent or unverified.
+   */
+  private toEmailAddressPublicChannel({ communicationPreferences, email, emailVerified }: ToEmailAddressPublicChannelArgs): BenefitApplicationEmailDto {
+    invariant(communicationPreferences.hasChanged === true, 'Expected communicationPreferences.hasChanged to be true for public application channel when mapping email address');
+
+    if (
+      !isEmailAddressRequired({
+        preferredMethodSunLife: communicationPreferences.value.preferredMethod,
+        preferredMethodGovernmentOfCanada: communicationPreferences.value.preferredNotificationMethod,
+      })
+    ) {
+      // If no selected communication method requires email, both fields remain undefined.
+      return { value: undefined, verified: undefined };
+    }
+
+    // If a selected communication method requires email, it must be valid and verified.
+    const result = checkValidAndVerifiedEmailAddress({ email, emailVerified });
+
+    if (!result.success) {
+      throw new Error('Expected a valid and verified email for public application channel when at least one communication method requires email');
+    }
+
+    return { value: result.email, verified: result.emailVerified };
   }
 }

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -15,6 +15,7 @@ import type {
   RenewalChildDto,
   RenewalCommunicationPreferencesDto,
   RenewalContactInformationDto,
+  RenewalEmailDto,
   RenewalPartnerInformationDto,
 } from '~/.server/domain/dtos';
 import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
@@ -105,8 +106,13 @@ interface ToChildrenArgs {
 interface ToCommunicationPreferencesArgs {
   existingCommunicationPreferences: ReadonlyDeep<ClientCommunicationPreferencesDto>;
   communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
-  email?: string;
-  emailVerified?: boolean;
+}
+
+interface ToEmailAddressArgs {
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+  existingEmail: string | undefined;
+  existingEmailVerified: boolean | undefined;
 }
 
 interface ToContactInformationArgs {
@@ -115,8 +121,6 @@ interface ToContactInformationArgs {
   renewedContactInformation: BaseApplicationPhoneNumberDeclaredChangeState | undefined;
   renewedHomeAddress: BaseApplicationAddressDeclaredChangeState | undefined;
   renewedMailingAddress: BaseApplicationAddressDeclaredChangeState | undefined;
-  renewedEmailVerified: boolean | undefined;
-  renewedEmail: string | undefined;
 }
 
 interface ToDentalBenefitsArgs {
@@ -197,8 +201,12 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
-        email,
-        emailVerified,
+      }),
+      emailAddress: this.toEmailAddress({
+        email: email,
+        emailVerified: emailVerified,
+        existingEmail: clientApplication.contactInformation.email,
+        existingEmailVerified: clientApplication.contactInformation.emailVerified,
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
@@ -206,8 +214,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
-        renewedEmailVerified: emailVerified,
-        renewedEmail: email,
       }),
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
@@ -279,8 +285,12 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
-        email,
-        emailVerified,
+      }),
+      emailAddress: this.toEmailAddress({
+        email: email,
+        emailVerified: emailVerified,
+        existingEmail: clientApplication.contactInformation.email,
+        existingEmailVerified: clientApplication.contactInformation.emailVerified,
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
@@ -288,8 +298,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
-        renewedEmailVerified: emailVerified,
-        renewedEmail: email,
       }),
       dentalBenefits: this.toDentalBenefits({
         existingDentalBenefits: clientApplication.dentalBenefits,
@@ -359,8 +367,12 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       communicationPreferences: this.toCommunicationPreferences({
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
-        email,
-        emailVerified,
+      }),
+      emailAddress: this.toEmailAddress({
+        email: email,
+        emailVerified: emailVerified,
+        existingEmail: clientApplication.contactInformation.email,
+        existingEmailVerified: clientApplication.contactInformation.emailVerified,
       }),
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
@@ -368,8 +380,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         renewedContactInformation: phoneNumber,
         renewedHomeAddress: homeAddress,
         renewedMailingAddress: mailingAddress,
-        renewedEmailVerified: emailVerified,
-        renewedEmail: email,
       }),
       dentalBenefits: [],
       dentalInsurance: undefined,
@@ -459,15 +469,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     });
   }
 
-  private toContactInformation({
-    existingContactInformation,
-    isHomeAddressSameAsMailingAddress,
-    renewedContactInformation,
-    renewedHomeAddress,
-    renewedMailingAddress,
-    renewedEmailVerified,
-    renewedEmail,
-  }: ToContactInformationArgs): RenewalContactInformationDto {
+  private toContactInformation({ existingContactInformation, isHomeAddressSameAsMailingAddress, renewedContactInformation, renewedHomeAddress, renewedMailingAddress }: ToContactInformationArgs): RenewalContactInformationDto {
     // If the phone number has changed, use the new phone number values. Otherwise, use the existing phone number values.
     const phoneNumbers = renewedContactInformation?.hasChanged
       ? {
@@ -479,12 +481,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
           phoneNumberAlt: existingContactInformation.phoneNumberAlt,
         };
 
-    const hasEmailChanged = this.hasEmailChanged({
-      emailVerified: renewedEmailVerified,
-      email: renewedEmail,
-      existingEmail: existingContactInformation.email,
-    });
-
     // Determine if the home address is the same as the mailing address. If either address has changed, use the
     // isHomeAddressSameAsMailingAddress value provided by the user. If neither address has changed, use the existing
     // copyMailingAddress value to maintain consistency with the existing data.
@@ -492,7 +488,6 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     const resolvedIsHomeAddressSameAsMailingAddress = haveAddressesChanged ? isHomeAddressSameAsMailingAddress : existingContactInformation.copyMailingAddress;
 
     return {
-      email: hasEmailChanged && renewedEmail ? renewedEmail : existingContactInformation.email,
       copyMailingAddress: !!resolvedIsHomeAddressSameAsMailingAddress,
       ...this.toHomeAddress({ existingContactInformation, isHomeAddressSameAsMailingAddress: resolvedIsHomeAddressSameAsMailingAddress, homeAddress: renewedHomeAddress, mailingAddress: renewedMailingAddress }),
       ...this.toMailingAddress({ existingContactInformation, mailingAddress: renewedMailingAddress }),
@@ -579,13 +574,11 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toCommunicationPreferences({ existingCommunicationPreferences, communicationPreferences, email, emailVerified }: ToCommunicationPreferencesArgs): RenewalCommunicationPreferencesDto {
+  private toCommunicationPreferences({ existingCommunicationPreferences, communicationPreferences }: ToCommunicationPreferencesArgs): RenewalCommunicationPreferencesDto {
     invariant(communicationPreferences, 'Expected communicationPreferences to be defined');
 
     if (communicationPreferences.hasChanged) {
       return {
-        email,
-        emailVerified,
         preferredLanguage: communicationPreferences.value.preferredLanguage,
         preferredMethod: communicationPreferences.value.preferredMethod,
         preferredMethodGovernmentOfCanada: communicationPreferences.value.preferredNotificationMethod,
@@ -597,11 +590,16 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     invariant(existingCommunicationPreferences.preferredMethodGovernmentOfCanada, 'Expected existingCommunicationPreferences.preferredMethodGovernmentOfCanada to be defined');
 
     return {
-      email,
-      emailVerified,
       preferredLanguage: existingCommunicationPreferences.preferredLanguage,
       preferredMethod: existingCommunicationPreferences.preferredMethodSunLife,
       preferredMethodGovernmentOfCanada: existingCommunicationPreferences.preferredMethodGovernmentOfCanada,
+    };
+  }
+
+  private toEmailAddress({ email, emailVerified, existingEmail, existingEmailVerified }: ToEmailAddressArgs): RenewalEmailDto {
+    return {
+      value: email ?? existingEmail,
+      verified: emailVerified ?? existingEmailVerified,
     };
   }
 

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -4,24 +4,25 @@ import type { ReadonlyDeep } from 'type-fest';
 import validator from 'validator';
 
 import type {
+  BenefitRenewalApplicantInformationDto,
+  BenefitRenewalChildDto,
+  BenefitRenewalCommunicationPreferencesDto,
+  BenefitRenewalContactInformationDto,
   BenefitRenewalDto,
+  BenefitRenewalEmailDto,
+  BenefitRenewalPartnerInformationDto,
   ClientApplicantInformationDto,
   ClientApplicationDto,
   ClientChildDto,
   ClientCommunicationPreferencesDto,
   ClientContactInformationDto,
   ClientPartnerInformationDto,
-  RenewalApplicantInformationDto,
-  RenewalChildDto,
-  RenewalCommunicationPreferencesDto,
-  RenewalContactInformationDto,
-  RenewalEmailDto,
-  RenewalPartnerInformationDto,
 } from '~/.server/domain/dtos';
-import { maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
+import { checkValidAndVerifiedEmailAddress, isEmailAddressRequired, maritalStatusHasPartner } from '~/.server/routes/helpers/base-application-route-helpers';
 import type {
   BaseApplicationAddressDeclaredChangeState,
   BaseApplicationApplicantInformationState,
+  BaseApplicationChannelCodeState,
   BaseApplicationChildState,
   BaseApplicationCommunicationPreferencesDeclaredChangeState,
   BaseApplicationDentalBenefitsDeclaredChangeState,
@@ -33,6 +34,7 @@ import type {
 } from '~/.server/routes/helpers/base-application-route-helpers';
 
 export interface BenefitRenewalAdultState {
+  channelCode: BaseApplicationChannelCodeState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
@@ -51,6 +53,7 @@ export interface BenefitRenewalAdultState {
 }
 
 export interface BenefitRenewalFamilyState {
+  channelCode: BaseApplicationChannelCodeState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   children: BaseApplicationChildState[];
@@ -70,6 +73,7 @@ export interface BenefitRenewalFamilyState {
 }
 
 export interface BenefitRenewalChildState {
+  channelCode: BaseApplicationChannelCodeState;
   applicantInformation: BaseApplicationApplicantInformationState;
   applicationYear: BaseApplicationYearState;
   clientApplication?: ClientApplicationDto & { applicationCategoryCodeName: 'New' | 'Renewal' };
@@ -87,9 +91,9 @@ export interface BenefitRenewalChildState {
 }
 
 export interface BenefitRenewalStateMapper {
-  mapBenefitRenewalAdultStateToBenefitRenewalDto(benefitrenewalAdultState: BenefitRenewalAdultState, userId?: string): BenefitRenewalDto;
-  mapBenefitRenewalFamilyStateToBenefitRenewalDto(benefitrenewalFamilyState: BenefitRenewalFamilyState, userId?: string): BenefitRenewalDto;
-  mapBenefitRenewalChildStateToBenefitRenewalDto(benefitRenewalChildState: BenefitRenewalChildState, userId?: string): BenefitRenewalDto;
+  mapBenefitRenewalAdultStateToBenefitRenewalDto(benefitrenewalAdultState: BenefitRenewalAdultState, options?: { userId?: string }): BenefitRenewalDto;
+  mapBenefitRenewalFamilyStateToBenefitRenewalDto(benefitrenewalFamilyState: BenefitRenewalFamilyState, options?: { userId?: string }): BenefitRenewalDto;
+  mapBenefitRenewalChildStateToBenefitRenewalDto(benefitRenewalChildState: BenefitRenewalChildState, options?: { userId?: string }): BenefitRenewalDto;
 }
 
 interface ToApplicantInformationArgs {
@@ -109,6 +113,21 @@ interface ToCommunicationPreferencesArgs {
 }
 
 interface ToEmailAddressArgs {
+  applicationChannelCode: 'protected' | 'public';
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+  existingEmail: string | undefined;
+  existingEmailVerified: boolean | undefined;
+}
+
+interface ToEmailAddressProtectedChannelArgs {
+  email: string | undefined;
+  emailVerified: boolean | undefined;
+}
+
+interface ToEmailAddressPublicChannelArgs {
+  communicationPreferences: BaseApplicationCommunicationPreferencesDeclaredChangeState;
   email: string | undefined;
   emailVerified: boolean | undefined;
   existingEmail: string | undefined;
@@ -146,16 +165,11 @@ interface ToPartnerInformationArgs {
   renewedPartnerInformation?: BaseApplicationPartnerInformationState;
 }
 
-interface HasEmailChangedArgs {
-  emailVerified: boolean | undefined;
-  email: string | undefined;
-  existingEmail: string | undefined;
-}
-
 @injectable()
 export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapper {
   mapBenefitRenewalAdultStateToBenefitRenewalDto(
     {
+      channelCode,
       applicantInformation,
       applicationYear,
       clientApplication,
@@ -172,8 +186,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       phoneNumber,
       termsAndConditions,
     }: BenefitRenewalAdultState,
-    userId: string = 'anonymous',
+    options?: { userId?: string },
   ): BenefitRenewalDto {
+    const userId = options?.userId ?? 'anonymous';
+
     if (communicationPreferences === undefined) {
       throw new Error('Expected communicationPreferences to be defined');
     }
@@ -182,13 +198,17 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       throw new Error('Expected clientApplication to be defined');
     }
 
-    const hasEmailChanged = this.hasEmailChanged({
-      emailVerified,
-      email,
+    const emailAddress = this.toEmailAddress({
+      applicationChannelCode: channelCode,
+      communicationPreferences: communicationPreferences,
+      email: email,
+      emailVerified: emailVerified,
       existingEmail: clientApplication.contactInformation.email,
+      existingEmailVerified: clientApplication.contactInformation.emailVerified,
     });
 
     return {
+      applicationChannelCode: channelCode,
       applicationCategoryCodeName: clientApplication.applicationCategoryCodeName,
       dateOfBirth: clientApplication.dateOfBirth,
       applicantInformation: this.toApplicantInformation({
@@ -202,12 +222,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
       }),
-      emailAddress: this.toEmailAddress({
-        email: email,
-        emailVerified: emailVerified,
-        existingEmail: clientApplication.contactInformation.email,
-        existingEmailVerified: clientApplication.contactInformation.emailVerified,
-      }),
+      emailAddress,
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         isHomeAddressSameAsMailingAddress,
@@ -233,13 +248,14 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged,
+        hasEmailChanged: emailAddress.value !== clientApplication.contactInformation.email,
       },
     };
   }
 
   mapBenefitRenewalFamilyStateToBenefitRenewalDto(
     {
+      channelCode,
       applicantInformation,
       applicationYear,
       children,
@@ -257,8 +273,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       communicationPreferences,
       termsAndConditions,
     }: BenefitRenewalFamilyState,
-    userId: string = 'anonymous',
+    options?: { userId?: string },
   ): BenefitRenewalDto {
+    const userId = options?.userId ?? 'anonymous';
+
     if (communicationPreferences === undefined) {
       throw new Error('Expected communicationPreferences to be defined');
     }
@@ -269,7 +287,17 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
 
     invariant(children.length > 0, 'Expected children to be non-empty for a family renewal');
 
+    const emailAddress = this.toEmailAddress({
+      applicationChannelCode: channelCode,
+      communicationPreferences: communicationPreferences,
+      email: email,
+      emailVerified: emailVerified,
+      existingEmail: clientApplication.contactInformation.email,
+      existingEmailVerified: clientApplication.contactInformation.emailVerified,
+    });
+
     return {
+      applicationChannelCode: channelCode,
       applicationCategoryCodeName: clientApplication.applicationCategoryCodeName,
       dateOfBirth: clientApplication.dateOfBirth,
       applicantInformation: this.toApplicantInformation({
@@ -286,12 +314,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
       }),
-      emailAddress: this.toEmailAddress({
-        email: email,
-        emailVerified: emailVerified,
-        existingEmail: clientApplication.contactInformation.email,
-        existingEmailVerified: clientApplication.contactInformation.emailVerified,
-      }),
+      emailAddress,
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         isHomeAddressSameAsMailingAddress,
@@ -317,13 +340,14 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged: this.hasEmailChanged({ emailVerified, email, existingEmail: clientApplication.contactInformation.email }),
+        hasEmailChanged: emailAddress.value !== clientApplication.contactInformation.email,
       },
     };
   }
 
   mapBenefitRenewalChildStateToBenefitRenewalDto(
     {
+      channelCode,
       applicantInformation,
       applicationYear,
       children,
@@ -339,8 +363,10 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
       communicationPreferences,
       termsAndConditions,
     }: BenefitRenewalChildState,
-    userId: string = 'anonymous',
+    options?: { userId?: string },
   ): BenefitRenewalDto {
+    const userId = options?.userId ?? 'anonymous';
+
     if (communicationPreferences === undefined) {
       throw new Error('Expected communicationPreferences to be defined');
     }
@@ -351,7 +377,17 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
 
     invariant(children.length > 0, 'Expected children to be non-empty for a child renewal');
 
+    const emailAddress = this.toEmailAddress({
+      applicationChannelCode: channelCode,
+      communicationPreferences: communicationPreferences,
+      email: email,
+      emailVerified: emailVerified,
+      existingEmail: clientApplication.contactInformation.email,
+      existingEmailVerified: clientApplication.contactInformation.emailVerified,
+    });
+
     return {
+      applicationChannelCode: channelCode,
       applicationCategoryCodeName: clientApplication.applicationCategoryCodeName,
       dateOfBirth: clientApplication.dateOfBirth,
       applicantInformation: this.toApplicantInformation({
@@ -368,12 +404,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         existingCommunicationPreferences: clientApplication.communicationPreferences,
         communicationPreferences,
       }),
-      emailAddress: this.toEmailAddress({
-        email: email,
-        emailVerified: emailVerified,
-        existingEmail: clientApplication.contactInformation.email,
-        existingEmailVerified: clientApplication.contactInformation.emailVerified,
-      }),
+      emailAddress,
       contactInformation: this.toContactInformation({
         existingContactInformation: clientApplication.contactInformation,
         isHomeAddressSameAsMailingAddress,
@@ -396,20 +427,9 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
         hasMaritalStatusChanged: !!maritalStatus,
         hasAddressChanged: mailingAddress?.hasChanged,
         hasPhoneChanged: phoneNumber.hasChanged,
-        hasEmailChanged: this.hasEmailChanged({ emailVerified, email, existingEmail: clientApplication.contactInformation.email }),
+        hasEmailChanged: emailAddress.value !== clientApplication.contactInformation.email,
       },
     };
-  }
-
-  /**
-   * Determines if the email has changed based on the emailVerified flag, the new email value, and the existing email
-   * value. The email is considered changed if it is verified, not empty, and different from the existing email.
-   *
-   * @param param0 - An object containing the emailVerified flag, the new email value, and the existing email value.
-   * @returns A boolean indicating whether the email has changed.
-   */
-  private hasEmailChanged({ emailVerified, email, existingEmail }: HasEmailChangedArgs): boolean {
-    return emailVerified === true && email !== undefined && email.trim().length > 0 && email !== existingEmail;
   }
 
   /**
@@ -422,7 +442,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
    * @param param0 - An object containing the existing applicant information, the renewed social insurance number, and the renewed marital status.
    * @returns A RenewalApplicantInformationDto object containing the merged applicant information for the renewal application.
    */
-  private toApplicantInformation({ existingApplicantInformation, renewedSocialInsuranceNumber, renewedMaritalStatus }: ToApplicantInformationArgs): RenewalApplicantInformationDto {
+  private toApplicantInformation({ existingApplicantInformation, renewedSocialInsuranceNumber, renewedMaritalStatus }: ToApplicantInformationArgs): BenefitRenewalApplicantInformationDto {
     // If the renewed marital status is provided, use it. Otherwise, use the existing marital status.
     const maritalStatus = renewedMaritalStatus ?? existingApplicantInformation.maritalStatus;
 
@@ -440,7 +460,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs): RenewalChildDto[] {
+  private toChildren({ existingChildren, renewedChildren }: ToChildrenArgs): BenefitRenewalChildDto[] {
     return renewedChildren.map((renewedChild) => {
       const existingChild = existingChildren.find((existingChild) => existingChild.information.clientNumber === renewedChild.information?.memberId);
       invariant(existingChild, 'Expected existingChild to be defined');
@@ -469,7 +489,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     });
   }
 
-  private toContactInformation({ existingContactInformation, isHomeAddressSameAsMailingAddress, renewedContactInformation, renewedHomeAddress, renewedMailingAddress }: ToContactInformationArgs): RenewalContactInformationDto {
+  private toContactInformation({ existingContactInformation, isHomeAddressSameAsMailingAddress, renewedContactInformation, renewedHomeAddress, renewedMailingAddress }: ToContactInformationArgs): BenefitRenewalContactInformationDto {
     // If the phone number has changed, use the new phone number values. Otherwise, use the existing phone number values.
     const phoneNumbers = renewedContactInformation?.hasChanged
       ? {
@@ -574,7 +594,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toCommunicationPreferences({ existingCommunicationPreferences, communicationPreferences }: ToCommunicationPreferencesArgs): RenewalCommunicationPreferencesDto {
+  private toCommunicationPreferences({ existingCommunicationPreferences, communicationPreferences }: ToCommunicationPreferencesArgs): BenefitRenewalCommunicationPreferencesDto {
     invariant(communicationPreferences, 'Expected communicationPreferences to be defined');
 
     if (communicationPreferences.hasChanged) {
@@ -596,11 +616,61 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     };
   }
 
-  private toEmailAddress({ email, emailVerified, existingEmail, existingEmailVerified }: ToEmailAddressArgs): RenewalEmailDto {
-    return {
-      value: email ?? existingEmail,
-      verified: emailVerified ?? existingEmailVerified,
-    };
+  /**
+   * Maps email address fields to a {@link BenefitRenewalEmailDto} using channel-specific validation rules.
+   * Delegates to {@link toEmailAddressProtectedChannel} for protected-channel renewals
+   * and to {@link toEmailAddressPublicChannel} for public-channel renewals.
+   */
+  private toEmailAddress({ applicationChannelCode, communicationPreferences, email, emailVerified, existingEmail, existingEmailVerified }: ToEmailAddressArgs): BenefitRenewalEmailDto {
+    if (applicationChannelCode === 'protected') {
+      return this.toEmailAddressProtectedChannel({ email, emailVerified });
+    }
+
+    return this.toEmailAddressPublicChannel({ communicationPreferences, email, emailVerified, existingEmail, existingEmailVerified });
+  }
+
+  /**
+   * Maps email address fields for a protected-channel renewal.
+   * Protected-channel renewals always require a valid, verified email address;
+   * throws if the email is absent or unverified.
+   */
+  private toEmailAddressProtectedChannel({ email, emailVerified }: ToEmailAddressProtectedChannelArgs): BenefitRenewalEmailDto {
+    const result = checkValidAndVerifiedEmailAddress({ email, emailVerified });
+
+    if (!result.success) {
+      throw new Error('Expected a valid and verified email for protected application channel');
+    }
+
+    return { value: result.email, verified: result.emailVerified };
+  }
+
+  /**
+   * Maps email address fields for a public-channel renewal.
+   * If the communication preferences have not changed, or have changed but do not require an
+   * email, the existing email and verification status are preserved to avoid data loss.
+   * If the preferences have changed and a selected communication method requires email,
+   * a valid, verified email is enforced and throws if absent or unverified.
+   */
+  private toEmailAddressPublicChannel({ communicationPreferences, email, emailVerified, existingEmail, existingEmailVerified }: ToEmailAddressPublicChannelArgs): BenefitRenewalEmailDto {
+    if (
+      !communicationPreferences.hasChanged ||
+      !isEmailAddressRequired({
+        preferredMethodSunLife: communicationPreferences.value.preferredMethod,
+        preferredMethodGovernmentOfCanada: communicationPreferences.value.preferredNotificationMethod,
+      })
+    ) {
+      // Preferences unchanged, or changed but email not required — retain existing email to avoid data loss.
+      return { value: existingEmail, verified: existingEmailVerified };
+    }
+
+    // Preferences changed and a selected communication method requires email — must be valid and verified.
+    const result = checkValidAndVerifiedEmailAddress({ email, emailVerified });
+
+    if (!result.success) {
+      throw new Error('Expected a valid and verified email for public application channel when communication preferences have changed and require an email');
+    }
+
+    return { value: result.email, verified: result.emailVerified };
   }
 
   private toDentalBenefits({ existingDentalBenefits, renewedDentalBenefits }: ToDentalBenefitsArgs): readonly string[] {
@@ -626,7 +696,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
     return dentalBenefits;
   }
 
-  private toPartnerInformation({ effectiveMaritalStatus, existingPartnerInformation, renewedPartnerInformation }: ToPartnerInformationArgs): RenewalPartnerInformationDto | undefined {
+  private toPartnerInformation({ effectiveMaritalStatus, existingPartnerInformation, renewedPartnerInformation }: ToPartnerInformationArgs): BenefitRenewalPartnerInformationDto | undefined {
     if (!maritalStatusHasPartner(effectiveMaritalStatus)) {
       return undefined;
     }

--- a/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
+++ b/frontend/app/.server/routes/mappers/benefit-renewal.state.mapper.ts
@@ -440,7 +440,7 @@ export class DefaultBenefitRenewalStateMapper implements BenefitRenewalStateMapp
    * insurance number is retained.
    *
    * @param param0 - An object containing the existing applicant information, the renewed social insurance number, and the renewed marital status.
-   * @returns A RenewalApplicantInformationDto object containing the merged applicant information for the renewal application.
+   * @returns A BenefitRenewalApplicantInformationDto object containing the merged applicant information for the renewal application.
    */
   private toApplicantInformation({ existingApplicantInformation, renewedSocialInsuranceNumber, renewedMaritalStatus }: ToApplicantInformationArgs): BenefitRenewalApplicantInformationDto {
     // If the renewed marital status is provided, use it. Otherwise, use the existing marital status.

--- a/frontend/app/errors/error-codes.ts
+++ b/frontend/app/errors/error-codes.ts
@@ -3,6 +3,9 @@ export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];
 export const ErrorCodes = {
   UNCAUGHT_ERROR: 'UNC-0000',
 
+  // validation error codes
+  INVALID_REQUEST: 'VAL-0001',
+
   // instance error codes
   NO_FACTORY_PROVIDED: 'INST-0001',
 

--- a/frontend/app/routes/protected/application/intake-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-adult/submit.tsx
@@ -58,7 +58,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapApplicationAdultStateToBenefitApplicationDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'protected');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
 
   return {
     state: {

--- a/frontend/app/routes/protected/application/intake-children/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-children/submit.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapApplicationChildrenStateToBenefitApplicationDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'protected');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
 
   return {
     state: {

--- a/frontend/app/routes/protected/application/intake-family/submit.tsx
+++ b/frontend/app/routes/protected/application/intake-family/submit.tsx
@@ -64,7 +64,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapApplicationFamilyStateToBenefitApplicationDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'protected');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
 
   return {
     state: {

--- a/frontend/app/routes/protected/application/renewal-adult/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-adult/submit.tsx
@@ -59,8 +59,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const userInfoToken = session.get('userInfoToken');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
-  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalAdultStateToBenefitRenewalDto(state, userInfoToken.sub);
-  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'protected');
+  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalAdultStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
+  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
 
   return {
     state: {
@@ -107,7 +107,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const userInfoToken = session.get('userInfoToken');
-  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalAdultStateToBenefitRenewalDto(state, userInfoToken.sub);
+  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalAdultStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
   const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createProtectedBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   saveProtectedApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });

--- a/frontend/app/routes/protected/application/renewal-children/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/submit.tsx
@@ -64,8 +64,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const userInfoToken = session.get('userInfoToken');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
-  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalChildStateToBenefitRenewalDto(state, userInfoToken.sub);
-  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'protected');
+  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalChildStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
+  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
 
   return {
     state: {
@@ -111,7 +111,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const userInfoToken = session.get('userInfoToken');
-  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalChildStateToBenefitRenewalDto(state, userInfoToken.sub);
+  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalChildStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
   const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createProtectedBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   saveProtectedApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });

--- a/frontend/app/routes/protected/application/renewal-family/submit.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/submit.tsx
@@ -64,8 +64,8 @@ export async function loader({ context: { appContainer, session }, request, para
   const userInfoToken = session.get('userInfoToken');
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
-  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalFamilyStateToBenefitRenewalDto(state, userInfoToken.sub);
-  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'protected');
+  const benefitRenewalDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalFamilyStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
+  const payload = benefitRenewalDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
 
   return {
     state: {
@@ -113,7 +113,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const userInfoToken = session.get('userInfoToken');
-  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalFamilyStateToBenefitRenewalDto(state, userInfoToken.sub);
+  const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalFamilyStateToBenefitRenewalDto(state, { userId: userInfoToken.sub });
   const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createProtectedBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   saveProtectedApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });

--- a/frontend/app/routes/public/application/full-adult/submit.tsx
+++ b/frontend/app/routes/public/application/full-adult/submit.tsx
@@ -58,12 +58,12 @@ export async function loader({ context: { appContainer, session }, request, para
     const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
     const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
     const benefitApplicationDto = benefitApplicationStateMapper.mapApplicationAdultStateToBenefitApplicationDto(state);
-    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'public');
+    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
   } else {
     const benefitRenewalDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
     const benefitRenewalStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
     const benefitRenewalDto = benefitRenewalStateMapper.mapBenefitRenewalAdultStateToBenefitRenewalDto(state);
-    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'public');
+    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
   }
 
   return {
@@ -109,12 +109,12 @@ export async function action({ context: { appContainer, session }, request, para
 
   if (state.context === 'intake') {
     const benefitApplicationDto = appContainer.get(TYPES.BenefitApplicationStateMapper).mapApplicationAdultStateToBenefitApplicationDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createPublicBenefitApplication(benefitApplicationDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   } else {
     const benefitRenewalDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalAdultStateToBenefitRenewalDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitRenewalDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitRenewalDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   }

--- a/frontend/app/routes/public/application/full-children/submit.tsx
+++ b/frontend/app/routes/public/application/full-children/submit.tsx
@@ -63,12 +63,12 @@ export async function loader({ context: { appContainer, session }, request, para
     const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
     const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
     const benefitApplicationDto = benefitApplicationStateMapper.mapApplicationChildrenStateToBenefitApplicationDto(state);
-    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'public');
+    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
   } else {
     const benefitRenewalDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
     const benefitRenewalStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
     const benefitRenewalDto = benefitRenewalStateMapper.mapBenefitRenewalChildStateToBenefitRenewalDto(state);
-    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'public');
+    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
   }
 
   return {
@@ -114,12 +114,12 @@ export async function action({ context: { appContainer, session }, request, para
 
   if (state.context === 'intake') {
     const benefitApplicationDto = appContainer.get(TYPES.BenefitApplicationStateMapper).mapApplicationChildrenStateToBenefitApplicationDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createPublicBenefitApplication(benefitApplicationDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   } else {
     const benefitRenewalDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalChildStateToBenefitRenewalDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitRenewalDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitRenewalDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   }

--- a/frontend/app/routes/public/application/full-family/submit.tsx
+++ b/frontend/app/routes/public/application/full-family/submit.tsx
@@ -63,12 +63,12 @@ export async function loader({ context: { appContainer, session }, request, para
     const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitApplicationDtoMapper);
     const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitApplicationStateMapper);
     const benefitApplicationDto = benefitApplicationStateMapper.mapApplicationFamilyStateToBenefitApplicationDto(state);
-    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto, 'public');
+    payload = viewPayloadEnabled && benefitApplicationDtoMapper.mapBenefitApplicationDtoToBenefitApplicationRequestEntity(benefitApplicationDto);
   } else {
     const benefitRenewalDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
     const benefitRenewalStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
     const benefitRenewalDto = benefitRenewalStateMapper.mapBenefitRenewalFamilyStateToBenefitRenewalDto(state);
-    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto, 'public');
+    payload = viewPayloadEnabled && benefitRenewalDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitRenewalDto);
   }
 
   return {
@@ -115,12 +115,12 @@ export async function action({ context: { appContainer, session }, request, para
 
   if (state.context === 'intake') {
     const benefitApplicationDto = appContainer.get(TYPES.BenefitApplicationStateMapper).mapApplicationFamilyStateToBenefitApplicationDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createBenefitApplication(benefitApplicationDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitApplicationService).createPublicBenefitApplication(benefitApplicationDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   } else {
     const benefitRenewalDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalFamilyStateToBenefitRenewalDto(state);
-    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitRenewalDto);
+    const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitRenewalDto);
     const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
     savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
   }

--- a/frontend/app/routes/public/application/simplified-adult/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-adult/submit.tsx
@@ -56,7 +56,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalAdultStateToBenefitRenewalDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto, 'public');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto);
 
   return {
     state: {
@@ -100,7 +100,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalAdultStateToBenefitRenewalDto(state);
-  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitApplicationDto);
+  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
 

--- a/frontend/app/routes/public/application/simplified-children/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-children/submit.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalChildStateToBenefitRenewalDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto, 'public');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto);
 
   return {
     state: {
@@ -105,7 +105,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalChildStateToBenefitRenewalDto(state);
-  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitApplicationDto);
+  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
 

--- a/frontend/app/routes/public/application/simplified-family/submit.tsx
+++ b/frontend/app/routes/public/application/simplified-family/submit.tsx
@@ -61,7 +61,7 @@ export async function loader({ context: { appContainer, session }, request, para
   const benefitApplicationDtoMapper = appContainer.get(TYPES.BenefitRenewalDtoMapper);
   const benefitApplicationStateMapper = appContainer.get(TYPES.BenefitRenewalStateMapper);
   const benefitApplicationDto = viewPayloadEnabled && benefitApplicationStateMapper.mapBenefitRenewalFamilyStateToBenefitRenewalDto(state);
-  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto, 'public');
+  const payload = benefitApplicationDto && benefitApplicationDtoMapper.mapBenefitRenewalDtoToBenefitRenewalRequestEntity(benefitApplicationDto);
 
   return {
     state: {
@@ -106,7 +106,7 @@ export async function action({ context: { appContainer, session }, request, para
   }
 
   const benefitApplicationDto = appContainer.get(TYPES.BenefitRenewalStateMapper).mapBenefitRenewalFamilyStateToBenefitRenewalDto(state);
-  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createBenefitRenewal(benefitApplicationDto);
+  const confirmationCode = await appContainer.get(TYPES.BenefitRenewalService).createPublicBenefitRenewal(benefitApplicationDto);
   const submissionInfo = { confirmationCode, submittedOn: new UTCDate().toISOString() };
   savePublicApplicationState({ params, session, state: { submitTerms: parsedDataResult.data, submissionInfo } });
 


### PR DESCRIPTION
## Description


**Email Address Mapping Logic**

Both mappers share the same three-method pattern but differ in their public-channel behavior, reflecting the fundamental difference between **intake** (new application) and **renewal**.

---

### `toEmailAddress` (dispatcher)
Branches on `applicationChannelCode`. Protected channel → strict validation. Public channel → context-aware validation.

---

### `toEmailAddressProtectedChannel` (identical in both)
Protected-channel submissions (agent-assisted) **always** require a valid, verified email regardless of communication preferences. Throws if absent or unverified.

---

### `toEmailAddressPublicChannel` — the key difference

| | **Benefit Application** (intake) | **Benefit Renewal** |
|---|---|---|
| Prior data exists? | No | Yes (`existingEmail` / `existingEmailVerified`) |
| `hasChanged` always true? | Yes — applicant enters prefs from scratch; spoke enforces this as an `invariant` | No — applicant may leave prefs unchanged |
| If no email required by prefs | Returns `{ value: undefined, verified: undefined }` | Returns existing email/verification (preserves prior data) |
| If email required by prefs | Requires valid + verified; throws otherwise | Requires valid + verified; throws otherwise |

**Application:** Since there is no prior state, `hasChanged === true` is a hard invariant. Email is either required (and must be valid/verified) or omitted entirely.

**Renewal:** `hasChanged` can be `false` (user kept existing prefs), in which case the existing email is passed through unchanged to avoid data loss. Only when prefs changed *and* require email is fresh validation enforced.