### PR TITLE
chore(gitops): bump prod frontend image to 7.3.3

### DIFF
--- a/gitops/overlays/prod/patches/deployments-frontend.yaml
+++ b/gitops/overlays/prod/patches/deployments-frontend.yaml
@@ -13,7 +13,7 @@ spec:
     spec:
       containers:
         - name: canada-dental-care-plan-frontend
-          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.2
+          image: dtsrhpprodscedspokeacr.azurecr.io/canada-dental-care-plan/canada-dental-care-plan-frontend:7.3.3
           envFrom:
             - configMapRef:
                 name: frontend


### PR DESCRIPTION
> [!WARNING]
> **SCHEDULED MERGE — DO NOT MERGE EARLY**  
> This PR must be merged **no sooner than Tuesday, June 23, 2026 at 7:00 a.m. EDT**.  
> Merging before scheduled window will trigger frontend change prematurely in production.

### Description

This PR updates production deployment config for frontend by bumping container image version.

Deployment configuration update:

Updated frontend container image to version [7.3.3](https://github.com/STN-DTS/canadian-dental-care-plan/releases/tag/v7.3.3) in `gitops/overlays/prod/patches/deployments-frontend.yaml` to deploy latest release, including Node 26.3.1 security-release changes.