### PR TITLE
refactor(frontend): Document upload - disconnect metadata creation from loader

### DIFF
--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -12,7 +12,6 @@ import * as z from 'zod';
 
 import type { Route } from './+types/upload';
 
-import type { AppContainerProvider } from '~/.server/app-container-provider';
 import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
 import type { DocumentUploadService } from '~/.server/domain/services';
@@ -203,8 +202,6 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { errors: uploadResult.errors };
   }
 
-  await createMetadata({ appContainer, clientId: applicant, files, userId: idToken.sub });
-
   return redirect(getPathById('protected/documents/index', params));
 }
 
@@ -389,31 +386,6 @@ function processBatchResults(results: ReadonlyArray<{ id: string; error?: string
   }
 
   return { success: false, errors };
-}
-
-interface CreateMetadataArgs {
-  appContainer: AppContainerProvider;
-  clientId: string;
-  files: DocumentUploadSchemaOuput['files'];
-  userId: string;
-}
-
-async function createMetadata({ appContainer, clientId, files, userId }: CreateMetadataArgs) {
-  const reasons = await appContainer.get(TYPES.DocumentUploadReasonService).listDocumentUploadReasons();
-  const reasonId = expectDefined(reasons[0], 'Expected at least one document upload reason').id;
-  const recordSource = Number(appContainer.get(TYPES.ServerConfig).EWDU_RECORD_SOURCE_MSCA);
-  const evidentiaryDocumentService = appContainer.get(TYPES.EvidentiaryDocumentService);
-  return await evidentiaryDocumentService.createEvidentiaryDocumentMetadata({
-    clientId: clientId,
-    documents: Object.entries(files).map(([fileId, { file, documentType }]) => ({
-      fileName: file.name,
-      evidentiaryDocumentTypeId: documentType,
-      documentUploadReasonId: reasonId,
-      recordSource,
-      uploadDate: new Date(),
-    })),
-    userId: userId,
-  });
 }
 
 type CreateDocumentUploadSchemaArgs = {


### PR DESCRIPTION
### Description

[AB#8716](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8716)

Stops the document upload route from creating evidentiary document metadata. The server-side services are left intact for now

- Remove the `createMetadata` call and helper from `protected/documents/upload.tsx`
- No server-side code was removed — the `EvidentiaryDocument` and `DocumentUploadReason` services, repositories, mappers, and DTOs remain in place.
- Files are still uploaded, only the metadata registration step is disabled.

### Related Azure Boards Work Items
<!--
  Mention any Azure Boards work items that are related to this pull request.
  https://dev.azure.com/dts-stn/canada%20dental%20care%20plan/_backlogs/

  Use AB# to link from GitHub to Azure Boards work items. For example: "AB#{id}".
  https://learn.microsoft.com/en-ca/azure/devops/boards/github/link-to-from-github?view=azure-devops#use-ab-to-link-from-github-to-azure-boards-work-items
-->

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->