### PR TITLE
feat(frontend): Add Documents submitted confirmation page

### DIFF
--- a/frontend/app/.server/locales/en/documents.ts
+++ b/frontend/app/.server/locales/en/documents.ts
@@ -78,6 +78,18 @@ const ns = {
     letters: "Access your <lettersLink>letters</lettersLink> from the Canadian Dental Care Plan",
     returnButton: "Return to dashboard",
   },
+  submitted: {
+    pageTitle: "Documents submitted",
+    alertHeading: "We received your documents",
+    youSubmitted: "You submitted:",
+    delayNote: "There could be a short delay with your documents appearing in your account.",
+    nextStepsHeading: "Next steps",
+    nextSteps: {
+      review: "We'll review the documents submitted.",
+      letter: "We'll send you a letter to let you know whether or not you are eligible for the Canadian Dental Care Plan.",
+    },
+    returnButton: "Return to dashboard",
+  },
 } as const;
 
 export default ns;

--- a/frontend/app/.server/locales/fr/documents.ts
+++ b/frontend/app/.server/locales/fr/documents.ts
@@ -74,8 +74,20 @@ const ns = {
       cancelled: "votre demande a été annulée parce que la date limite est dépassée et vous recevrez une lettre",
     },
     whatYouCanDoHeading: "Ce que vous pouvez faire",
-    statusChecker: "<statusCheckerLink>Vérifier l’état de votre demande</statusCheckerLink>",
+    statusChecker: "<statusCheckerLink>Vérifier l'état de votre demande</statusCheckerLink>",
     letters: "Consulter vos <lettersLink>lettres</lettersLink> du Régime canadien de soins dentaires",
+    returnButton: "Retour au tableau de bord",
+  },
+  submitted: {
+    pageTitle: "Vos documents sont soumis",
+    alertHeading: "Nous avons reçu vos documents",
+    youSubmitted: "Vous avez soumis :",
+    delayNote: "Il pourrait y avoir un court délai avant que vos documents n’apparaissent dans votre compte.",
+    nextStepsHeading: "Prochaines étapes",
+    nextSteps: {
+      review: "Nous examinerons les documents soumis.",
+      letter: "Nous vous enverrons une lettre pour vous informer si vous êtes admissible ou non au Régime canadien de soins dentaires.",
+    },
     returnButton: "Retour au tableau de bord",
   },
 } as const;

--- a/frontend/app/.server/web/session.ts
+++ b/frontend/app/.server/web/session.ts
@@ -32,6 +32,7 @@ type SessionTypeMap = {
   idToken: IdToken;
   lastAccessTime: string;
   letters: ReadonlyArray<LetterDto>;
+  submittedDocuments: ReadonlyArray<string>;
   userInfoToken: UserinfoToken;
   profileEmailAddressFlowState: {
     emailAddress: string;

--- a/frontend/app/page-ids.ts
+++ b/frontend/app/page-ids.ts
@@ -91,6 +91,7 @@ export const pageIds = {
       index: 'CDCP-PROT-DOCS-0001',
       upload: 'CDCP-PROT-DOCS-0002',
       notRequired: 'CDCP-PROT-DOCS-0003',
+      submitted: 'CDCP-PROT-DOCS-0004',
     },
     letters: {
       index: 'CDCP-PROT-0015',

--- a/frontend/app/routes/protected/documents/submitted.tsx
+++ b/frontend/app/routes/protected/documents/submitted.tsx
@@ -1,0 +1,111 @@
+import type { JSX } from 'react';
+
+import { redirect } from 'react-router';
+
+import { useTranslation } from 'react-i18next';
+
+import type { Route } from './+types/submitted';
+
+import { TYPES } from '~/.server/constants';
+import { appContext } from '~/.server/context';
+import { getFixedT } from '~/.server/utils/locale-utils';
+import type { IdToken } from '~/.server/utils/raoidc-utils';
+import { AppPageTitle } from '~/components/app-page-title';
+import { ProtectedBreadcrumbs } from '~/components/breadcrumbs';
+import { ButtonLink } from '~/components/buttons';
+import { ContextualAlert } from '~/components/contextual-alert';
+import { pageIds } from '~/page-ids';
+import { mergeMeta } from '~/utils/meta-utils';
+import type { RouteHandleData } from '~/utils/route-utils';
+import { getPathById } from '~/utils/route-utils';
+import { getTitleMetaTags } from '~/utils/seo-utils';
+
+export const handle = {
+  i18nPreloadNamespace: ['documents', 'gcweb'],
+  layoutOptions: { breadcrumbs: <LayoutBreadcrumbs /> },
+  pageIdentifier: pageIds.protected.documents.submitted,
+} as const satisfies RouteHandleData;
+
+function LayoutBreadcrumbs(): JSX.Element {
+  const { t } = useTranslation('documents');
+  return (
+    <ProtectedBreadcrumbs
+      items={[
+        {
+          content: t(($) => $.index.pageTitle),
+          routeId: 'protected/documents/index',
+        },
+      ]}
+    />
+  );
+}
+
+export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMetaTags(loaderData.meta.title));
+
+export async function loader({ context, params, url }: Route.LoaderArgs) {
+  const { appContainer, session } = context.get(appContext);
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  securityHandler.validateFeatureEnabled('doc-upload');
+  await securityHandler.validateAuthSession({ requestUrl: url, session });
+
+  const submittedDocuments = session.find('submittedDocuments').unwrapOr([]);
+
+  if (submittedDocuments.length === 0) {
+    throw redirect(getPathById('protected/documents/index', params));
+  }
+
+  const t = await getFixedT(url, ['documents', 'gcweb']);
+  const meta = {
+    title: t(($) => $.meta.title.mscaTemplate, { ns: 'gcweb', title: t(($) => $.submitted.pageTitle) }),
+  };
+
+  const { SCCH_BASE_URI } = appContainer.get(TYPES.ClientConfig);
+
+  const idToken: IdToken = session.get('idToken');
+  appContainer.get(TYPES.AuditService).createAudit('page-view.documents-submitted', { userId: idToken.sub });
+
+  return { meta, submittedDocuments, SCCH_BASE_URI };
+}
+
+export default function DocumentsSubmitted({ loaderData }: Route.ComponentProps) {
+  const { t } = useTranslation(['documents', 'gcweb']);
+  const { submittedDocuments, SCCH_BASE_URI } = loaderData;
+
+  return (
+    <>
+      <AppPageTitle>{t(($) => $.submitted.pageTitle)}</AppPageTitle>
+      <div className="max-w-prose space-y-6">
+        <ContextualAlert type="success">
+          <h2 className="mb-2 font-bold">{t(($) => $.submitted.alertHeading)}</h2>
+          <p className="mb-2">{t(($) => $.submitted.youSubmitted)}</p>
+          <ul className="list-none space-y-1">
+            {submittedDocuments.map((document) => (
+              <li key={document}>{document}</li>
+            ))}
+          </ul>
+          <p className="mt-2">{t(($) => $.submitted.delayNote)}</p>
+        </ContextualAlert>
+        <section className="space-y-4">
+          <h2 className="font-lato text-2xl font-bold">{t(($) => $.submitted.nextStepsHeading)}</h2>
+          <ul className="list-disc space-y-1 pl-7">
+            <li>{t(($) => $.submitted.nextSteps.review)}</li>
+            <li>{t(($) => $.submitted.nextSteps.letter)}</li>
+          </ul>
+        </section>
+        <div className="flex flex-wrap items-center gap-3">
+          <ButtonLink
+            id="return-button"
+            variant="primary"
+            to={t(($) => $.header.menuDashboardHref, {
+              baseUri: SCCH_BASE_URI,
+              ns: 'gcweb',
+            })}
+            data-gc-analytics-customclick="ESDC-EDSC:CDCP Applicant Documents-Protected:Return to dashboard - Documents submitted button click"
+          >
+            {t(($) => $.submitted.returnButton)}
+          </ButtonLink>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -181,7 +181,12 @@ export async function action({ context, params, request, url }: Route.ActionArgs
     return { errors: uploadResult.errors };
   }
 
-  return redirect(getPathById('protected/documents/index', params));
+  session.set(
+    'submittedDocuments',
+    Object.values(files).map(({ file }) => file.name),
+  );
+
+  return redirect(getPathById('protected/documents/submitted', params));
 }
 
 async function validateUploadForm(

--- a/frontend/app/routes/protected/routes.ts
+++ b/frontend/app/routes/protected/routes.ts
@@ -341,6 +341,11 @@ export const routes = [
         paths: { en: '/:lang/protected/documents/not-required', fr: '/:lang/protege/documents/non-requis' },
       },
       {
+        id: 'protected/documents/submitted',
+        file: 'routes/protected/documents/submitted.tsx',
+        paths: { en: '/:lang/protected/documents/submitted', fr: '/:lang/protege/documents/soumis' },
+      },
+      {
         id: 'protected/unable-to-process-request',
         file: 'routes/protected/unable-to-process-request.tsx',
         paths: { en: '/:lang/protected/unable-to-process-request', fr: '/:lang/protege/impossible-de-traiter-la-demande' },


### PR DESCRIPTION
### Description
Adds a new confirmation page to the document upload flow that is shown after a user successfully submits their documents.

### Related Azure Boards Work Items
[AB#8721](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8721)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->