### PR TITLE
feat(frontend): evidentary document eligibility service

### DIFF
--- a/frontend/app/.server/constants/types-constant.ts
+++ b/frontend/app/.server/constants/types-constant.ts
@@ -8,6 +8,7 @@ import type { BuildInfoService } from '~/.server/core';
 import type { RedisService } from '~/.server/data';
 import type {
   AddressValidationDtoMapper,
+  AppealUploadEligibilityDtoMapper,
   ApplicantDtoMapper,
   ApplicationStatusDtoMapper,
   ApplicationYearDtoMapper,
@@ -36,6 +37,7 @@ import type {
 } from '~/.server/domain/mappers';
 import type {
   AddressValidationRepository,
+  AppealUploadEligibilityRepository,
   ApplicantRepository,
   ApplicationStatusRepository,
   ApplicationYearRepository,
@@ -58,6 +60,7 @@ import type {
 } from '~/.server/domain/repositories';
 import type {
   AddressValidationService,
+  AppealUploadEligibilityService,
   ApplicantService,
   ApplicationStatusService,
   ApplicationYearService,
@@ -153,6 +156,9 @@ export const TYPES = assignServiceIdentifiers({
   AddressValidationRepository: serviceId<AddressValidationRepository>(),
   AddressValidationService: serviceId<AddressValidationService>(),
   AddressValidatorFactory: serviceId<AddressValidatorFactory>(),
+  AppealUploadEligibilityDtoMapper: serviceId<AppealUploadEligibilityDtoMapper>(),
+  AppealUploadEligibilityRepository: serviceId<AppealUploadEligibilityRepository>(),
+  AppealUploadEligibilityService: serviceId<AppealUploadEligibilityService>(),
   ApplicantDtoMapper: serviceId<ApplicantDtoMapper>(),
   ApplicantRepository: serviceId<ApplicantRepository>(),
   ApplicantService: serviceId<ApplicantService>(),

--- a/frontend/app/.server/container-modules/mappers-container-module.ts
+++ b/frontend/app/.server/container-modules/mappers-container-module.ts
@@ -3,6 +3,7 @@ import { ContainerModule } from 'inversify';
 import { TYPES } from '~/.server/constants';
 import {
   DefaultAddressValidationDtoMapper,
+  DefaultAppealUploadEligibilityDtoMapper,
   DefaultApplicantDtoMapper,
   DefaultApplicationStatusDtoMapper,
   DefaultApplicationYearDtoMapper,
@@ -38,6 +39,7 @@ import { DefaultDynatraceDtoMapper, DefaultHCaptchaDtoMapper } from '~/.server/w
 export function createMappersContainerModule(): ContainerModule {
   return new ContainerModule((options) => {
     options.bind(TYPES.AddressValidationDtoMapper).to(DefaultAddressValidationDtoMapper);
+    options.bind(TYPES.AppealUploadEligibilityDtoMapper).to(DefaultAppealUploadEligibilityDtoMapper);
     options.bind(TYPES.ApplicantDtoMapper).to(DefaultApplicantDtoMapper);
     options.bind(TYPES.ApplicationStatusDtoMapper).to(DefaultApplicationStatusDtoMapper);
     options.bind(TYPES.ApplicationYearDtoMapper).to(DefaultApplicationYearDtoMapper);

--- a/frontend/app/.server/container-modules/repositories-container-module.ts
+++ b/frontend/app/.server/container-modules/repositories-container-module.ts
@@ -5,6 +5,7 @@ import type { ServerConfig } from '~/.server/configs';
 import { TYPES } from '~/.server/constants';
 import {
   DefaultAddressValidationRepository,
+  DefaultAppealUploadEligibilityRepository,
   DefaultApplicantRepository,
   DefaultApplicationStatusRepository,
   DefaultApplicationYearRepository,
@@ -25,6 +26,7 @@ import {
   DefaultProvinceTerritoryStateRepository,
   DefaultVerificationCodeRepository,
   MockAddressValidationRepository,
+  MockAppealUploadEligibilityRepository,
   MockApplicantRepository,
   MockApplicationStatusRepository,
   MockApplicationYearRepository,
@@ -80,6 +82,11 @@ export function createRepositoriesContainerModule(serverConfig: Pick<ServerConfi
   return new ContainerModule((options) => {
     options.bind(TYPES.AddressValidationRepository).to(DefaultAddressValidationRepository).when(isMockEnabled(serverConfig, 'wsaddress', false));
     options.bind(TYPES.AddressValidationRepository).to(MockAddressValidationRepository).when(isMockEnabled(serverConfig, 'wsaddress', true));
+
+    // TODO: confirm the correct mock flag for appeal upload eligibility. Reusing 'evidentiary-document'
+    // since it is part of the same document-upload feature; a dedicated MockName may be warranted.
+    options.bind(TYPES.AppealUploadEligibilityRepository).to(DefaultAppealUploadEligibilityRepository).when(isMockEnabled(serverConfig, 'evidentiary-document', false));
+    options.bind(TYPES.AppealUploadEligibilityRepository).to(MockAppealUploadEligibilityRepository).when(isMockEnabled(serverConfig, 'evidentiary-document', true));
 
     options.bind(TYPES.ApplicantRepository).to(DefaultApplicantRepository).when(isMockEnabled(serverConfig, 'power-platform', false));
     options.bind(TYPES.ApplicantRepository).to(MockApplicantRepository).when(isMockEnabled(serverConfig, 'power-platform', true));

--- a/frontend/app/.server/container-modules/repositories-container-module.ts
+++ b/frontend/app/.server/container-modules/repositories-container-module.ts
@@ -83,8 +83,6 @@ export function createRepositoriesContainerModule(serverConfig: Pick<ServerConfi
     options.bind(TYPES.AddressValidationRepository).to(DefaultAddressValidationRepository).when(isMockEnabled(serverConfig, 'wsaddress', false));
     options.bind(TYPES.AddressValidationRepository).to(MockAddressValidationRepository).when(isMockEnabled(serverConfig, 'wsaddress', true));
 
-    // TODO: confirm the correct mock flag for appeal upload eligibility. Reusing 'evidentiary-document'
-    // since it is part of the same document-upload feature; a dedicated MockName may be warranted.
     options.bind(TYPES.AppealUploadEligibilityRepository).to(DefaultAppealUploadEligibilityRepository).when(isMockEnabled(serverConfig, 'evidentiary-document', false));
     options.bind(TYPES.AppealUploadEligibilityRepository).to(MockAppealUploadEligibilityRepository).when(isMockEnabled(serverConfig, 'evidentiary-document', true));
 

--- a/frontend/app/.server/container-modules/services-container-module.ts
+++ b/frontend/app/.server/container-modules/services-container-module.ts
@@ -8,6 +8,7 @@ import { DefaultBuildInfoService } from '~/.server/core';
 import { DefaultRedisService } from '~/.server/data';
 import {
   DefaultAddressValidationService,
+  DefaultAppealUploadEligibilityService,
   DefaultApplicantService,
   DefaultApplicationStatusService,
   DefaultApplicationYearService,
@@ -62,6 +63,7 @@ export function createServicesContainerModule(serverConfig: Pick<ServerConfig, '
   // prettier-ignore
   return new ContainerModule((options) => {
     options.bind(TYPES.AddressValidationService).to(DefaultAddressValidationService);
+    options.bind(TYPES.AppealUploadEligibilityService).to(DefaultAppealUploadEligibilityService);
     options.bind(TYPES.ApplicantService).to(DefaultApplicantService);
     options.bind(TYPES.ApplicationStatusService).to(DefaultApplicationStatusService);
     options.bind(TYPES.ApplicationYearService).to(DefaultApplicationYearService);

--- a/frontend/app/.server/domain/dtos/appeal-upload-eligibility-dto.ts
+++ b/frontend/app/.server/domain/dtos/appeal-upload-eligibility-dto.ts
@@ -1,0 +1,14 @@
+/**
+ * Represents a Data Transfer Object (DTO) describing whether a client is eligible
+ * to upload appeal documents.
+ */
+export type AppealUploadEligibilityDto = Readonly<{
+  /** Client GUID — needed downstream for the actual upload (esdc_clients(<id>)). */
+  clientId: string;
+
+  /** The client number the eligibility was looked up with. */
+  clientNumber: string;
+
+  /** Whether the client is permitted to upload appeal documents. */
+  eligible: boolean;
+}>;

--- a/frontend/app/.server/domain/dtos/index.ts
+++ b/frontend/app/.server/domain/dtos/index.ts
@@ -1,4 +1,5 @@
 export type * from './address-validation-dto';
+export type * from './appeal-upload-eligibility-dto';
 export type * from './applicant-dto';
 export type * from './application-status-dto';
 export type * from './application-year-dto';

--- a/frontend/app/.server/domain/entities/appeal-upload-eligibility-entity.ts
+++ b/frontend/app/.server/domain/entities/appeal-upload-eligibility-entity.ts
@@ -1,0 +1,28 @@
+import type { ReadonlyDeep } from 'type-fest';
+
+/**
+ * Raw response entity for a single client returned by the `appeal-upload-eligible` service.
+ *
+ * Corresponds to:
+ *   esdc_clients(esdc_clientnumber='{ClientNumber}')
+ *     ?$select=esdc_clientid,esdc_clientnumber,esdc_applicanttype,esdc_socialinsurancenumber,statecode,statuscode,esdc_suspendedon
+ *     &$expand=esdc_esdc_dentalapplicant_Clientid_esdc_client(esdc_dentalapplicantid,_esdc_dentalapplicationid_value,_esdc_pendingstatusid_value)
+ */
+export type AppealUploadEligibilityResponseEntity = ReadonlyDeep<{
+  esdc_applicanttype: number;
+  esdc_clientid: string;
+  esdc_clientnumber: string;
+  /**
+   * Represents a list of the client profile's applications that are paused due to a T4 mismatch.
+   * A non-empty array means the client is eligible to upload evidentiary documentation.
+   */
+  esdc_esdc_dentalapplicant_Clientid_esdc_client: Array<{
+    _esdc_dentalapplicationid_value: string;
+    _esdc_pendingstatusid_value: null | number;
+    esdc_dentalapplicantid: string;
+  }>;
+  esdc_socialinsurancenumber: string;
+  esdc_suspendedon: null | string;
+  statecode: number;
+  statuscode: number;
+}>;

--- a/frontend/app/.server/domain/entities/index.ts
+++ b/frontend/app/.server/domain/entities/index.ts
@@ -1,4 +1,5 @@
 export type * from './address-validation-entity';
+export type * from './appeal-upload-eligibility-entity';
 export type * from './applicant-entity';
 export type * from './application-status-entity';
 export type * from './application-year-entity';

--- a/frontend/app/.server/domain/mappers/appeal-upload-eligibility-dto-mapper.ts
+++ b/frontend/app/.server/domain/mappers/appeal-upload-eligibility-dto-mapper.ts
@@ -1,0 +1,23 @@
+import { injectable } from 'inversify';
+
+import type { AppealUploadEligibilityDto } from '~/.server/domain/dtos';
+import type { AppealUploadEligibilityResponseEntity } from '~/.server/domain/entities';
+
+export interface AppealUploadEligibilityDtoMapper {
+  mapAppealUploadEligibilityResponseEntityToAppealUploadEligibilityDto(appealUploadEligibilityResponseEntity: AppealUploadEligibilityResponseEntity): AppealUploadEligibilityDto;
+}
+
+@injectable()
+export class DefaultAppealUploadEligibilityDtoMapper implements AppealUploadEligibilityDtoMapper {
+  mapAppealUploadEligibilityResponseEntityToAppealUploadEligibilityDto(appealUploadEligibilityResponseEntity: AppealUploadEligibilityResponseEntity): AppealUploadEligibilityDto {
+    // Acceptance criteria: a client is eligible to upload evidentiary documentation when their
+    // profile has at least one application paused due to a T4 mismatch.
+    const hasT4MismatchPausedApplication = appealUploadEligibilityResponseEntity.esdc_esdc_dentalapplicant_Clientid_esdc_client.length > 0;
+
+    return {
+      clientId: appealUploadEligibilityResponseEntity.esdc_clientid,
+      clientNumber: appealUploadEligibilityResponseEntity.esdc_clientnumber,
+      eligible: hasT4MismatchPausedApplication,
+    };
+  }
+}

--- a/frontend/app/.server/domain/mappers/index.ts
+++ b/frontend/app/.server/domain/mappers/index.ts
@@ -1,4 +1,5 @@
 export * from './address-validation-dto-mapper';
+export * from './appeal-upload-eligibility-dto-mapper';
 export * from './applicant-dto-mapper';
 export * from './application-status-dto-mapper';
 export * from './application-year-dto-mapper';

--- a/frontend/app/.server/domain/repositories/appeal-upload-eligibility-repository.ts
+++ b/frontend/app/.server/domain/repositories/appeal-upload-eligibility-repository.ts
@@ -61,15 +61,6 @@ export class DefaultAppealUploadEligibilityRepository implements AppealUploadEli
 
     const url = new URL(`${this.baseUrl}/esdc_clients(esdc_clientnumber='${encodeURIComponent(clientNumber)}')`);
     url.searchParams.set('$select', 'esdc_clientid,esdc_clientnumber,esdc_applicanttype,esdc_socialinsurancenumber,statecode,statuscode,esdc_suspendedon');
-    // The expanded esdc_esdc_dentalapplicant_Clientid_esdc_client collection represents the client's
-    // applications that are paused due to a T4 mismatch. A non-empty collection means the client is
-    // eligible to upload evidentiary documentation.
-    //
-    // TODO: confirm the server-side $filter that restricts this collection to T4-mismatch-paused
-    // applications. The real payload shows _esdc_pendingstatusid_value as `null | number`, so the
-    // previously assumed `_esdc_pendingstatusid_value eq '<guid>'` filter was incorrect and has been
-    // removed. Confirm with the API team whether the filtering is applied by the endpoint itself or
-    // must be supplied here.
     url.searchParams.set('$expand', 'esdc_esdc_dentalapplicant_Clientid_esdc_client($select=esdc_dentalapplicantid,_esdc_dentalapplicationid_value,_esdc_pendingstatusid_value)');
 
     const response = await this.httpClient.instrumentedFetch('http.client.interop-api.appeal-upload-eligible.get', url, {
@@ -87,8 +78,6 @@ export class DefaultAppealUploadEligibilityRepository implements AppealUploadEli
       },
     });
 
-    // TODO: confirm how the service signals "client not found". This assumes a 404; the service
-    // may instead return 200 with an empty body/collection, in which case this needs adjusting.
     if (response.status === HttpStatusCodes.NOT_FOUND) {
       this.log.debug('No client found for appeal upload eligibility; clientNumber: [%s]', clientNumber);
       return None;
@@ -129,10 +118,6 @@ export class MockAppealUploadEligibilityRepository implements AppealUploadEligib
   async findAppealUploadEligibilityByClientNumber(clientNumber: string): Promise<Option<AppealUploadEligibilityResponseEntity>> {
     this.log.debug('Fetching mock appeal upload eligibility for client number: [%s]', clientNumber);
 
-    // The fixture is a real UAT payload (client 59373339201) populated with one T4-mismatch-paused
-    // application so it represents an *eligible* client for local testing.
-    // TODO: consider supporting multiple mock clients (eligible / not-eligible) once the upload
-    // flow needs to exercise the ineligible path.
     const appealUploadEligibilityResponseEntity = appealUploadEligibilityJsonDataSource as AppealUploadEligibilityResponseEntity;
 
     if (appealUploadEligibilityResponseEntity.esdc_clientnumber !== clientNumber) {

--- a/frontend/app/.server/domain/repositories/appeal-upload-eligibility-repository.ts
+++ b/frontend/app/.server/domain/repositories/appeal-upload-eligibility-repository.ts
@@ -1,0 +1,155 @@
+import { inject, injectable } from 'inversify';
+import { None, Option, Some } from 'oxide.ts';
+
+import type { ServerConfig } from '~/.server/configs';
+import { TYPES } from '~/.server/constants';
+import type { AppealUploadEligibilityResponseEntity } from '~/.server/domain/entities';
+import type { HttpClient } from '~/.server/http';
+import { createLogger } from '~/.server/logging';
+import type { Logger } from '~/.server/logging';
+import appealUploadEligibilityJsonDataSource from '~/.server/resources/power-platform/appeal-upload-eligibility.json';
+import { HttpStatusCodes } from '~/constants/http-status-codes';
+
+/**
+ * A repository that determines whether a client is eligible to upload appeal documents.
+ */
+export interface AppealUploadEligibilityRepository {
+  /**
+   * Fetches the appeal upload eligibility record for a client by its client number.
+   *
+   * @param clientNumber The client number to look up.
+   * @returns The eligibility response entity, or `None` if no matching client was found.
+   */
+  findAppealUploadEligibilityByClientNumber(clientNumber: string): Promise<Option<AppealUploadEligibilityResponseEntity>>;
+
+  /**
+   * Retrieves metadata associated with the appeal upload eligibility repository.
+   *
+   * @returns A record where the keys and values are strings representing metadata information.
+   */
+  getMetadata(): Record<string, string>;
+
+  /**
+   * Performs a health check to ensure that the appeal upload eligibility repository is operational.
+   *
+   * @throws An error if the health check fails or the repository is unavailable.
+   * @returns A promise that resolves when the health check completes successfully.
+   */
+}
+
+type DefaultAppealUploadEligibilityRepositoryServerConfig = Pick<ServerConfig, 'HTTP_PROXY_URL' | 'INTEROP_API_BASE_URI' | 'INTEROP_API_SUBSCRIPTION_KEY' | 'INTEROP_API_MAX_RETRIES' | 'INTEROP_API_BACKOFF_MS'>;
+
+@injectable()
+export class DefaultAppealUploadEligibilityRepository implements AppealUploadEligibilityRepository {
+  private readonly log: Logger;
+  private readonly serverConfig: DefaultAppealUploadEligibilityRepositoryServerConfig;
+  private readonly httpClient: HttpClient;
+  private readonly baseUrl: string;
+
+  constructor(
+    @inject(TYPES.ServerConfig) serverConfig: DefaultAppealUploadEligibilityRepositoryServerConfig, //
+    @inject(TYPES.HttpClient) httpClient: HttpClient,
+  ) {
+    this.log = createLogger('DefaultAppealUploadEligibilityRepository');
+    this.serverConfig = serverConfig;
+    this.httpClient = httpClient;
+    this.baseUrl = `${this.serverConfig.INTEROP_API_BASE_URI}/dental-care/appeal-upload-eligible/pp/v1`;
+  }
+
+  async findAppealUploadEligibilityByClientNumber(clientNumber: string): Promise<Option<AppealUploadEligibilityResponseEntity>> {
+    this.log.debug('Fetching appeal upload eligibility for client number: [%s]', clientNumber);
+
+    const url = new URL(`${this.baseUrl}/esdc_clients(esdc_clientnumber='${encodeURIComponent(clientNumber)}')`);
+    url.searchParams.set('$select', 'esdc_clientid,esdc_clientnumber,esdc_applicanttype,esdc_socialinsurancenumber,statecode,statuscode,esdc_suspendedon');
+    // The expanded esdc_esdc_dentalapplicant_Clientid_esdc_client collection represents the client's
+    // applications that are paused due to a T4 mismatch. A non-empty collection means the client is
+    // eligible to upload evidentiary documentation.
+    //
+    // TODO: confirm the server-side $filter that restricts this collection to T4-mismatch-paused
+    // applications. The real payload shows _esdc_pendingstatusid_value as `null | number`, so the
+    // previously assumed `_esdc_pendingstatusid_value eq '<guid>'` filter was incorrect and has been
+    // removed. Confirm with the API team whether the filtering is applied by the endpoint itself or
+    // must be supplied here.
+    url.searchParams.set('$expand', 'esdc_esdc_dentalapplicant_Clientid_esdc_client($select=esdc_dentalapplicantid,_esdc_dentalapplicationid_value,_esdc_pendingstatusid_value)');
+
+    const response = await this.httpClient.instrumentedFetch('http.client.interop-api.appeal-upload-eligible.get', url, {
+      proxyUrl: this.serverConfig.HTTP_PROXY_URL,
+      method: 'GET',
+      headers: {
+        'Ocp-Apim-Subscription-Key': this.serverConfig.INTEROP_API_SUBSCRIPTION_KEY,
+      },
+      retryOptions: {
+        retries: this.serverConfig.INTEROP_API_MAX_RETRIES,
+        backoffMs: this.serverConfig.INTEROP_API_BACKOFF_MS,
+        retryConditions: {
+          [HttpStatusCodes.BAD_GATEWAY]: [],
+        },
+      },
+    });
+
+    // TODO: confirm how the service signals "client not found". This assumes a 404; the service
+    // may instead return 200 with an empty body/collection, in which case this needs adjusting.
+    if (response.status === HttpStatusCodes.NOT_FOUND) {
+      this.log.debug('No client found for appeal upload eligibility; clientNumber: [%s]', clientNumber);
+      return None;
+    }
+
+    if (!response.ok) {
+      this.log.error('%j', {
+        message: 'Failed to fetch appeal upload eligibility',
+        status: response.status,
+        statusText: response.statusText,
+        url: url.href,
+        responseBody: await response.text(),
+      });
+      throw new Error(`Failed to fetch appeal upload eligibility. Status: ${response.status}, Status Text: ${response.statusText}`);
+    }
+
+    const appealUploadEligibilityResponseEntity = (await response.json()) as AppealUploadEligibilityResponseEntity;
+
+    this.log.trace('Appeal upload eligibility: [%j]', appealUploadEligibilityResponseEntity);
+    return Some(appealUploadEligibilityResponseEntity);
+  }
+
+  getMetadata(): Record<string, string> {
+    return {
+      baseUrl: this.baseUrl,
+    };
+  }
+}
+
+@injectable()
+export class MockAppealUploadEligibilityRepository implements AppealUploadEligibilityRepository {
+  private readonly log: Logger;
+
+  constructor() {
+    this.log = createLogger('MockAppealUploadEligibilityRepository');
+  }
+
+  async findAppealUploadEligibilityByClientNumber(clientNumber: string): Promise<Option<AppealUploadEligibilityResponseEntity>> {
+    this.log.debug('Fetching mock appeal upload eligibility for client number: [%s]', clientNumber);
+
+    // The fixture is a real UAT payload (client 59373339201) populated with one T4-mismatch-paused
+    // application so it represents an *eligible* client for local testing.
+    // TODO: consider supporting multiple mock clients (eligible / not-eligible) once the upload
+    // flow needs to exercise the ineligible path.
+    const appealUploadEligibilityResponseEntity = appealUploadEligibilityJsonDataSource as AppealUploadEligibilityResponseEntity;
+
+    if (appealUploadEligibilityResponseEntity.esdc_clientnumber !== clientNumber) {
+      this.log.warn('No mock client found for appeal upload eligibility; clientNumber: [%s]', clientNumber);
+      return await Promise.resolve(None);
+    }
+
+    return await Promise.resolve(Some(appealUploadEligibilityResponseEntity));
+  }
+
+  getMetadata(): Record<string, string> {
+    return {
+      mockEnabled: 'true',
+    };
+  }
+
+  async checkHealth(): Promise<void> {
+    return await Promise.resolve();
+  }
+}

--- a/frontend/app/.server/domain/repositories/index.ts
+++ b/frontend/app/.server/domain/repositories/index.ts
@@ -1,4 +1,5 @@
 export * from './address-validation-repository';
+export * from './appeal-upload-eligibility-repository';
 export * from './applicant-repository';
 export * from './application-status-repository';
 export * from './application-year-repository';

--- a/frontend/app/.server/domain/services/appeal-upload-eligibility-service.ts
+++ b/frontend/app/.server/domain/services/appeal-upload-eligibility-service.ts
@@ -35,8 +35,6 @@ export class DefaultAppealUploadEligibilityService implements AppealUploadEligib
   async getAppealUploadEligibility(clientNumber: string): Promise<AppealUploadEligibilityDto | null> {
     this.log.trace('Getting appeal upload eligibility for client number: [%s]', clientNumber);
 
-    // TODO: consider memoized caching (see DefaultEvidentiaryDocumentTypeService) if eligibility
-    // lookups become hot; requires an appropriate cache TTL config value.
     const appealUploadEligibilityResponseEntityOption = await this.appealUploadEligibilityRepository.findAppealUploadEligibilityByClientNumber(clientNumber);
 
     if (appealUploadEligibilityResponseEntityOption.isNone()) {

--- a/frontend/app/.server/domain/services/appeal-upload-eligibility-service.ts
+++ b/frontend/app/.server/domain/services/appeal-upload-eligibility-service.ts
@@ -1,0 +1,52 @@
+import { inject, injectable } from 'inversify';
+
+import { TYPES } from '~/.server/constants';
+import type { AppealUploadEligibilityDto } from '~/.server/domain/dtos';
+import type { AppealUploadEligibilityDtoMapper } from '~/.server/domain/mappers';
+import type { AppealUploadEligibilityRepository } from '~/.server/domain/repositories';
+import { createLogger } from '~/.server/logging';
+import type { Logger } from '~/.server/logging';
+
+/**
+ * Service interface for determining appeal document upload eligibility.
+ */
+export interface AppealUploadEligibilityService {
+  /**
+   * Determines whether a client is eligible to upload appeal documents.
+   *
+   * @param clientNumber - The client number to check eligibility for.
+   * @returns The eligibility DTO, or `null` if no matching client was found.
+   */
+  getAppealUploadEligibility(clientNumber: string): Promise<AppealUploadEligibilityDto | null>;
+}
+
+@injectable()
+export class DefaultAppealUploadEligibilityService implements AppealUploadEligibilityService {
+  private readonly log: Logger;
+  private readonly appealUploadEligibilityDtoMapper: AppealUploadEligibilityDtoMapper;
+  private readonly appealUploadEligibilityRepository: AppealUploadEligibilityRepository;
+
+  constructor(@inject(TYPES.AppealUploadEligibilityDtoMapper) appealUploadEligibilityDtoMapper: AppealUploadEligibilityDtoMapper, @inject(TYPES.AppealUploadEligibilityRepository) appealUploadEligibilityRepository: AppealUploadEligibilityRepository) {
+    this.log = createLogger('DefaultAppealUploadEligibilityService');
+    this.appealUploadEligibilityDtoMapper = appealUploadEligibilityDtoMapper;
+    this.appealUploadEligibilityRepository = appealUploadEligibilityRepository;
+  }
+
+  async getAppealUploadEligibility(clientNumber: string): Promise<AppealUploadEligibilityDto | null> {
+    this.log.trace('Getting appeal upload eligibility for client number: [%s]', clientNumber);
+
+    // TODO: consider memoized caching (see DefaultEvidentiaryDocumentTypeService) if eligibility
+    // lookups become hot; requires an appropriate cache TTL config value.
+    const appealUploadEligibilityResponseEntityOption = await this.appealUploadEligibilityRepository.findAppealUploadEligibilityByClientNumber(clientNumber);
+
+    if (appealUploadEligibilityResponseEntityOption.isNone()) {
+      this.log.debug('No client record found; treating as ineligible; clientNumber: [%s]', clientNumber);
+      return null;
+    }
+
+    const appealUploadEligibilityDto = this.appealUploadEligibilityDtoMapper.mapAppealUploadEligibilityResponseEntityToAppealUploadEligibilityDto(appealUploadEligibilityResponseEntityOption.unwrap());
+
+    this.log.trace('Returning appeal upload eligibility: [%j]', appealUploadEligibilityDto);
+    return appealUploadEligibilityDto;
+  }
+}

--- a/frontend/app/.server/domain/services/index.ts
+++ b/frontend/app/.server/domain/services/index.ts
@@ -1,4 +1,5 @@
 export * from './address-validation-service';
+export * from './appeal-upload-eligibility-service';
 export * from './applicant-service';
 export * from './application-status-service';
 export * from './application-year-service';

--- a/frontend/app/.server/resources/power-platform/appeal-upload-eligibility.json
+++ b/frontend/app/.server/resources/power-platform/appeal-upload-eligibility.json
@@ -1,0 +1,19 @@
+{
+  "@odata.context": "https://canadadental-uat.crm3.dynamics.com/api/data/v9.2/$metadata#esdc_clients(esdc_clientid,esdc_clientnumber,esdc_applicanttype,esdc_socialinsurancenumber,statecode,statuscode,esdc_suspendedon,esdc_esdc_dentalapplicant_Clientid_esdc_client(esdc_dentalapplicantid,_esdc_dentalapplicationid_value,_esdc_pendingstatusid_value))/$entity",
+  "@odata.etag": "W/\"280561340\"",
+  "esdc_suspendedon": null,
+  "esdc_clientid": "6578bb39-ee97-f011-b41b-7c1e52063166",
+  "esdc_socialinsurancenumber": "558912549",
+  "esdc_clientnumber": "10000000002",
+  "statecode": 0,
+  "esdc_applicanttype": 775170000,
+  "statuscode": 1,
+  "esdc_esdc_dentalapplicant_Clientid_esdc_client": [
+    {
+      "@odata.etag": "W/\"119010126\"",
+      "_esdc_dentalapplicationid_value": "2070d7ee-00ba-ee11-9079-000d3a09d132",
+      "_esdc_pendingstatusid_value": null,
+      "esdc_dentalapplicantid": "2870d7ee-00ba-ee11-9079-000d3a09d132"
+    }
+  ]
+}

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -50,6 +50,42 @@ type DocumentUploadSchema = ReturnType<typeof createDocumentUploadSchema>;
 type DocumentUploadSchemaOuput = z.output<DocumentUploadSchema>;
 type DocumentUploadSchemaErrorTree = z.core.$ZodErrorTree<DocumentUploadSchemaOuput>;
 
+/**
+ * Route middleware that gates the document upload route for both the loader and the action.
+ *
+ * A client may only upload evidentiary documentation when their profile has at least one
+ * application paused due to a T4 mismatch. Otherwise, redirect to the not-required page.
+ */
+const appealUploadEligibilityMiddleware: Route.MiddlewareFunction = async ({ context, params, request }) => {
+  const { appContainer, session } = context.get(appContext);
+  const securityHandler = appContainer.get(TYPES.SecurityHandler);
+  const requestUrl = new URL(request.url);
+
+  securityHandler.validateFeatureEnabled('doc-upload');
+  await securityHandler.validateAuthSession({ requestUrl, session });
+
+  const clientApplication = await securityHandler.requireClientApplication({
+    params,
+    requestUrl,
+    session,
+    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
+  });
+
+  await securityHandler.requireEnrolledApplicant({
+    clientNumber: clientApplication.applicantInformation.clientNumber,
+    params,
+    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
+  });
+
+  const appealUploadEligibility = await appContainer.get(TYPES.AppealUploadEligibilityService).getAppealUploadEligibility(clientApplication.applicantInformation.clientNumber);
+
+  if (!appealUploadEligibility?.eligible) {
+    throw redirect(getPathById('protected/documents/not-required', params));
+  }
+};
+
+export const middleware: Route.MiddlewareFunction[] = [appealUploadEligibilityMiddleware];
+
 export const handle = {
   i18nPreloadNamespace: ['documents', 'gcweb'],
   layoutOptions: { breadcrumbs: <LayoutBreadcrumbs /> },
@@ -90,14 +126,6 @@ export async function loader({ context, params, url }: Route.LoaderArgs) {
     params,
     options: { redirectUrl: getPathById('protected/documents/not-required', params) },
   });
-
-  // A client may only upload evidentiary documentation when their profile has at least one
-  // application paused due to a T4 mismatch. Otherwise, redirect to the not-required page.
-  const appealUploadEligibility = await appContainer.get(TYPES.AppealUploadEligibilityService).getAppealUploadEligibility(clientApplication.applicantInformation.clientNumber);
-
-  if (!appealUploadEligibility?.eligible) {
-    throw redirect(getPathById('protected/documents/not-required', params));
-  }
 
   const locale = getLocale(url);
   const t = await getFixedT(url, ['documents', 'gcweb']);

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -91,6 +91,14 @@ export async function loader({ context, params, url }: Route.LoaderArgs) {
     options: { redirectUrl: getPathById('protected/documents/not-required', params) },
   });
 
+  // A client may only upload evidentiary documentation when their profile has at least one
+  // application paused due to a T4 mismatch. Otherwise, redirect to the not-required page.
+  const appealUploadEligibility = await appContainer.get(TYPES.AppealUploadEligibilityService).getAppealUploadEligibility(clientApplication.applicantInformation.clientNumber);
+
+  if (!appealUploadEligibility?.eligible) {
+    throw redirect(getPathById('protected/documents/not-required', params));
+  }
+
   const locale = getLocale(url);
   const t = await getFixedT(url, ['documents', 'gcweb']);
 

--- a/frontend/app/routes/protected/documents/upload.tsx
+++ b/frontend/app/routes/protected/documents/upload.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { JSX } from 'react';
 
-import { redirect, useFetcher } from 'react-router';
+import { createContext, redirect, useFetcher } from 'react-router';
 
 import { faArrowUpFromBracket, faTimes } from '@fortawesome/free-solid-svg-icons';
 import { fileTypeFromBuffer } from 'file-type';
@@ -13,6 +13,7 @@ import type { Route } from './+types/upload';
 
 import { TYPES } from '~/.server/constants';
 import { appContext } from '~/.server/context';
+import type { ClientApplicationDto } from '~/.server/domain/dtos';
 import type { DocumentUploadService } from '~/.server/domain/services';
 import { getFixedT, getLocale } from '~/.server/utils/locale-utils';
 import type { IdToken } from '~/.server/utils/raoidc-utils';
@@ -51,6 +52,14 @@ type DocumentUploadSchemaOuput = z.output<DocumentUploadSchema>;
 type DocumentUploadSchemaErrorTree = z.core.$ZodErrorTree<DocumentUploadSchemaOuput>;
 
 /**
+ * React Router context that holds the validated {@link ClientApplicationDto} resolved by
+ * {@link appealUploadEligibilityMiddleware}. The loader and action retrieve it from here to
+ * reuse the already-validated application instead of repeating the security checks and making
+ * another call to the Interop API.
+ */
+const ClientApplicationContext = createContext<ClientApplicationDto>();
+
+/**
  * Route middleware that gates the document upload route for both the loader and the action.
  *
  * A client may only upload evidentiary documentation when their profile has at least one
@@ -82,6 +91,8 @@ const appealUploadEligibilityMiddleware: Route.MiddlewareFunction = async ({ con
   if (!appealUploadEligibility?.eligible) {
     throw redirect(getPathById('protected/documents/not-required', params));
   }
+
+  context.set(ClientApplicationContext, clientApplication);
 };
 
 export const middleware: Route.MiddlewareFunction[] = [appealUploadEligibilityMiddleware];
@@ -110,22 +121,6 @@ export const meta: Route.MetaFunction = mergeMeta(({ loaderData }) => getTitleMe
 
 export async function loader({ context, params, url }: Route.LoaderArgs) {
   const { appContainer, session } = context.get(appContext);
-  const securityHandler = appContainer.get(TYPES.SecurityHandler);
-  securityHandler.validateFeatureEnabled('doc-upload');
-  await securityHandler.validateAuthSession({ requestUrl: url, session });
-
-  const clientApplication = await securityHandler.requireClientApplication({
-    params,
-    requestUrl: url,
-    session,
-    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
-  });
-
-  await securityHandler.requireEnrolledApplicant({
-    clientNumber: clientApplication.applicantInformation.clientNumber,
-    params,
-    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
-  });
 
   const locale = getLocale(url);
   const t = await getFixedT(url, ['documents', 'gcweb']);
@@ -167,24 +162,9 @@ export async function clientAction({ request, url, serverAction }: Route.ClientA
 
 export async function action({ context, params, request, url }: Route.ActionArgs) {
   const { appContainer, session } = context.get(appContext);
-  const securityHandler = appContainer.get(TYPES.SecurityHandler);
-  securityHandler.validateFeatureEnabled('doc-upload');
-  await securityHandler.validateAuthSession({ requestUrl: url, session });
+  const clientApplication = context.get(ClientApplicationContext);
 
   const formData = await request.formData();
-
-  const clientApplication = await securityHandler.requireClientApplication({
-    params,
-    requestUrl: url,
-    session,
-    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
-  });
-
-  await securityHandler.requireEnrolledApplicant({
-    clientNumber: clientApplication.applicantInformation.clientNumber,
-    params,
-    options: { redirectUrl: getPathById('protected/documents/not-required', params) },
-  });
 
   const locale = getLocale(url);
   const t = await getFixedT(locale, 'documents');


### PR DESCRIPTION
### Description
Adds a new AppealUploadEligibilityService that determines whether a CDCP client is allowed to upload evidentiary documents, and wires it into the document upload page.

A client is eligible when their profile has at least one application paused due to a T4 mismatch. If they aren't eligible, the upload page now redirects to the "not required" page.

### Related Azure Boards Work Items
[AB#8715](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8715)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->