### PR TITLE
fix(a11y): convey spouse/common-law section context to screen readers on marital status page

### DIFF
--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -219,8 +219,10 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
               />
 
               {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-                <>
-                  <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</h2>
+                <section aria-labelledby="spouse-or-commonlaw-heading">
+                  <h2 id="spouse-or-commonlaw-heading" className="font-lato mb-6 text-2xl font-bold">
+                    {t(($) => $.maritalStatus.spouseOrCommonlaw)}
+                  </h2>
                   <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
                   <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
                   <InputPatternField
@@ -257,7 +259,7 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
                   >
                     {t(($) => $.maritalStatus.confirmCheckbox)}
                   </InputCheckbox>
-                </>
+                </section>
               )}
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">

--- a/frontend/app/routes/protected/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/protected/application/spokes/marital-status.tsx
@@ -219,10 +219,8 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
               />
 
               {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-                <section aria-labelledby="spouse-or-commonlaw-heading">
-                  <h2 id="spouse-or-commonlaw-heading" className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.maritalStatus.spouseOrCommonlaw)}
-                  </h2>
+                <fieldset className="mb-6 space-y-4">
+                  <legend className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</legend>
                   <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
                   <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
                   <InputPatternField
@@ -259,7 +257,7 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
                   >
                     {t(($) => $.maritalStatus.confirmCheckbox)}
                   </InputCheckbox>
-                </section>
+                </fieldset>
               )}
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -215,10 +215,8 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
               />
 
               {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-                <section aria-labelledby="spouse-or-commonlaw-heading">
-                  <h2 id="spouse-or-commonlaw-heading" className="font-lato mb-6 text-2xl font-bold">
-                    {t(($) => $.maritalStatus.spouseOrCommonlaw)}
-                  </h2>
+                <fieldset className="mb-6 space-y-4">
+                  <legend className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</legend>
                   <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
                   <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
                   <InputPatternField
@@ -255,7 +253,7 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
                   >
                     {t(($) => $.maritalStatus.confirmCheckbox)}
                   </InputCheckbox>
-                </section>
+                </fieldset>
               )}
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">

--- a/frontend/app/routes/public/application/spokes/marital-status.tsx
+++ b/frontend/app/routes/public/application/spokes/marital-status.tsx
@@ -215,8 +215,10 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
               />
 
               {(selectedMaritalStatus === MARITAL_STATUS_CODE_COMMON_LAW || selectedMaritalStatus === MARITAL_STATUS_CODE_MARRIED) && (
-                <>
-                  <h2 className="font-lato mb-6 text-2xl font-bold">{t(($) => $.maritalStatus.spouseOrCommonlaw)}</h2>
+                <section aria-labelledby="spouse-or-commonlaw-heading">
+                  <h2 id="spouse-or-commonlaw-heading" className="font-lato mb-6 text-2xl font-bold">
+                    {t(($) => $.maritalStatus.spouseOrCommonlaw)}
+                  </h2>
                   <p className="mb-4">{t(($) => $.maritalStatus.provideSin)}</p>
                   <p className="mb-6">{t(($) => $.maritalStatus.requiredInformation)}</p>
                   <InputPatternField
@@ -253,7 +255,7 @@ export default function ApplicationSpokeMaritalStatus({ loaderData, params }: Ro
                   >
                     {t(($) => $.maritalStatus.confirmCheckbox)}
                   </InputCheckbox>
-                </>
+                </section>
               )}
             </div>
             <div className="flex flex-row-reverse flex-wrap items-center justify-end gap-3">


### PR DESCRIPTION
### Description

screen reader users may not realize the
fields shown after selecting "Married" or "Common-law" belong to the
spouse/common-law partner section.

- Wrapped the spouse/common-law fields in a
  `<section aria-labelledby="spouse-or-commonlaw-heading">`.
- Added a matching `id` to the existing "Spouse or common-law partner
  information" `<h2>` so it labels the section.


### Related Azure Boards Work Items
[AB#8729](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8729)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->