### PR TITLE
fix(a11y): correct heading hierarchy on children's application pages

### DIFF
--- a/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-children/childrens-application.tsx
@@ -180,11 +180,11 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -223,7 +223,7 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -267,7 +267,7 @@ export default function ProtectedNewChildChildrensApplication({ loaderData, para
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/intake-family/childrens-application.tsx
@@ -180,11 +180,11 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -223,7 +223,7 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -256,7 +256,7 @@ export default function ProtectedNewFamilyChildrensApplication({ loaderData, par
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-children/childrens-application.tsx
@@ -215,7 +215,7 @@ export default function ProtectedRenewChildChildrensApplication({ loaderData, pa
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.sinCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.sinCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>
                     <StatusTag status="optional" />
@@ -227,7 +227,7 @@ export default function ProtectedRenewChildChildrensApplication({ loaderData, pa
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.parentGuardianCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.parentGuardianCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.parentGuardian.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -237,7 +237,7 @@ export default function ProtectedRenewChildChildrensApplication({ loaderData, pa
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -247,7 +247,7 @@ export default function ProtectedRenewChildChildrensApplication({ loaderData, pa
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
+++ b/frontend/app/routes/protected/application/renewal-family/childrens-application.tsx
@@ -215,7 +215,7 @@ export default function ProtectedRenewFamilyChildrensApplication({ loaderData, p
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.sinCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.sinCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>
                     <StatusTag status="optional" />
@@ -227,7 +227,7 @@ export default function ProtectedRenewFamilyChildrensApplication({ loaderData, p
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.parentGuardianCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.parentGuardianCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.parentGuardian.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -237,7 +237,7 @@ export default function ProtectedRenewFamilyChildrensApplication({ loaderData, p
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -247,7 +247,7 @@ export default function ProtectedRenewFamilyChildrensApplication({ loaderData, p
               <Card className="my-4">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/public/application/full-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-children/childrens-application.tsx
@@ -179,11 +179,11 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -222,7 +222,7 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -266,7 +266,7 @@ export default function NewChildChildrensApplication({ loaderData, params }: Rou
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/public/application/full-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/full-family/childrens-application.tsx
@@ -180,11 +180,11 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -223,7 +223,7 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -256,7 +256,7 @@ export default function NewFamilyChildrensApplication({ loaderData, params }: Ro
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.childDentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-children/childrens-application.tsx
@@ -201,11 +201,11 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -244,7 +244,7 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -278,7 +278,7 @@ export default function RenewChildChildrensApplication({ loaderData, params }: R
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>

--- a/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
+++ b/frontend/app/routes/public/application/simplified-family/childrens-application.tsx
@@ -200,11 +200,11 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>
+                    <h3>
                       {t(($) => $.childrensApplication.childInformationCardTitle, {
                         childNumber: index + 1,
                       })}
-                    </h2>
+                    </h3>
                   </CardTitle>
                   <CardAction>{sections.childInformation.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -243,7 +243,7 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalInsuranceCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalInsurance.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>
@@ -277,7 +277,7 @@ export default function RenewFamilyChildrensApplication({ loaderData, params }: 
               <Card className="my-2">
                 <CardHeader>
                   <CardTitle asChild>
-                    <h2>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h2>
+                    <h3>{t(($) => $.childrensApplication.childDentalBenefitsCardTitle)}</h3>
                   </CardTitle>
                   <CardAction>{sections.dentalBenefits.completed && <StatusTag status="complete" />}</CardAction>
                 </CardHeader>


### PR DESCRIPTION
### Description
- Changed the card sub-headings (child information, SIN, parent/guardian, dental
  insurance, dental benefits) from `h2` to `h3` so headings follow a logical
  `h2 (child) → h3 (sections)` order.
- Applied across all eight `childrens-application.tsx` pages (public + protected,
  full/simplified/intake/renewal) for consistency.

### Related Azure Boards Work Items
[AB#8732](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8732)

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->