### PR TITLE
fix(a11y): prevent progress stepper labels from truncating at narrow widths

### DIFF
--- a/frontend/__tests__/components/__snapshots__/progress-stepper.test.tsx.snap
+++ b/frontend/__tests__/components/__snapshots__/progress-stepper.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -67,7 +67,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Second Step
         <span
@@ -99,7 +99,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Third Step
         <span
@@ -145,7 +145,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
+        class="text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         First Step
       </span>
@@ -176,7 +176,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Second Step
         <span
@@ -208,7 +208,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Third Step
         <span
@@ -253,7 +253,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -289,7 +289,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Second Step
         <span
@@ -322,7 +322,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
+        class="text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Third Step
       </span>
@@ -362,7 +362,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -399,7 +399,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
+        class="text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Second Step
       </span>
@@ -426,7 +426,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Third Step
         <span

--- a/frontend/__tests__/components/__snapshots__/progress-stepper.test.tsx.snap
+++ b/frontend/__tests__/components/__snapshots__/progress-stepper.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -67,7 +67,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Second Step
         <span
@@ -99,7 +99,7 @@ exports[`ProgressStepper > renders correctly when all steps are completed (activ
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Third Step
         <span
@@ -145,7 +145,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap font-semibold text-blue-600"
+        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         First Step
       </span>
@@ -176,7 +176,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Second Step
         <span
@@ -208,7 +208,7 @@ exports[`ProgressStepper > renders correctly with the first step active > expect
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Third Step
         <span
@@ -253,7 +253,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -289,7 +289,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Second Step
         <span
@@ -322,7 +322,7 @@ exports[`ProgressStepper > renders correctly with the last step active > expecte
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap font-semibold text-blue-600"
+        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Third Step
       </span>
@@ -362,7 +362,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         First Step
         <span
@@ -399,7 +399,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap font-semibold text-blue-600"
+        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Second Step
       </span>
@@ -426,7 +426,7 @@ exports[`ProgressStepper > renders correctly with the second step active > expec
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Third Step
         <span

--- a/frontend/__tests__/components/__snapshots__/stepper.test.tsx.snap
+++ b/frontend/__tests__/components/__snapshots__/stepper.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Step 1
         <span
@@ -67,7 +67,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Step 2
         <span
@@ -99,7 +99,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Step 3
         <span
@@ -145,7 +145,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap font-semibold text-blue-600"
+        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Step 1
       </span>
@@ -176,7 +176,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 2
         <span
@@ -208,7 +208,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 3
         <span
@@ -253,7 +253,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
       >
         Step 1
         <span
@@ -290,7 +290,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap font-semibold text-blue-600"
+        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Step 2
       </span>
@@ -317,7 +317,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap text-black/60"
+        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 3
         <span

--- a/frontend/__tests__/components/__snapshots__/stepper.test.tsx.snap
+++ b/frontend/__tests__/components/__snapshots__/stepper.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Step 1
         <span
@@ -67,7 +67,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Step 2
         <span
@@ -99,7 +99,7 @@ exports[`Stepper > renders correctly when all steps are completed > expected htm
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Step 3
         <span
@@ -145,7 +145,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
+        class="text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Step 1
       </span>
@@ -176,7 +176,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 2
         <span
@@ -208,7 +208,7 @@ exports[`Stepper > renders correctly with active step 1 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 3
         <span
@@ -253,7 +253,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200"
+        class="text-sm font-medium transition-colors duration-200"
       >
         Step 1
         <span
@@ -290,7 +290,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm transition-colors duration-200 font-semibold text-blue-600"
+        class="text-sm transition-colors duration-200 font-semibold text-blue-600"
       >
         Step 2
       </span>
@@ -317,7 +317,7 @@ exports[`Stepper > renders correctly with active step 2 > expected html 1`] = `
         </svg>
       </div>
       <span
-        class="wrap-break-words grow text-left text-sm font-medium transition-colors duration-200 text-black/60"
+        class="text-sm font-medium transition-colors duration-200 text-black/60"
       >
         Step 3
         <span

--- a/frontend/app/components/stepper.tsx
+++ b/frontend/app/components/stepper.tsx
@@ -93,7 +93,7 @@ function StepItem({ label, status, isLast, customIcon }: StepItemProps) {
         )}
       </div>
       {/* Label */}
-      <span className={cn('wrap-break-words grow text-left text-sm font-medium transition-colors duration-200', status === 'upcoming' && 'text-black/60', status === 'current' && 'font-semibold text-blue-600')}>
+      <span className={cn('text-sm font-medium transition-colors duration-200', status === 'upcoming' && 'text-black/60', status === 'current' && 'font-semibold text-blue-600')}>
         {label}
         {status === 'completed' && <span className="sr-only">{t(($) => $.stepper.status.completed)}</span>}
         {status === 'upcoming' && <span className="sr-only">{t(($) => $.stepper.status.upcoming)}</span>}

--- a/frontend/app/components/stepper.tsx
+++ b/frontend/app/components/stepper.tsx
@@ -93,13 +93,7 @@ function StepItem({ label, status, isLast, customIcon }: StepItemProps) {
         )}
       </div>
       {/* Label */}
-      <span
-        className={cn(
-          'grow overflow-hidden text-left text-sm font-medium text-nowrap text-ellipsis transition-colors duration-200 sm:overflow-auto sm:text-wrap',
-          status === 'upcoming' && 'text-black/60',
-          status === 'current' && 'font-semibold text-blue-600',
-        )}
-      >
+      <span className={cn('wrap-break-words grow text-left text-sm font-medium transition-colors duration-200', status === 'upcoming' && 'text-black/60', status === 'current' && 'font-semibold text-blue-600')}>
         {label}
         {status === 'completed' && <span className="sr-only">{t(($) => $.stepper.status.completed)}</span>}
         {status === 'upcoming' && <span className="sr-only">{t(($) => $.stepper.status.upcoming)}</span>}


### PR DESCRIPTION
### Description
ixes an accessibility issue where progress navigation labels were truncated at
reduced widths (e.g. 320px). Long labels such as "Renseignements sur le parent
ou le tuteur légal" were clipped with an ellipsis and could not be fully read.

### Related Azure Boards Work Items
[AB#8732](https://dev.azure.com/DTS-STN/1fc40a8f-28cf-47bc-b6e4-1c234bd06177/_workitems/edit/8732)

### Screenshots (if applicable)
<!-- Include screenshots or GIFs if the changes are visual. -->

### Checklist
<!-- Go through each item and check it with an "x" inside the square brackets. -->
- [ ] I have tested the changes locally
- [ ] I have updated the documentation if necessary
- [ ] I have added/updated tests that prove my fix is effective or that my feature works
- [ ] I have checked that my code follows the project's coding style by running `npm run format:check`
- [ ] I have checked that my code contains no linting errors by running `npm run lint`
- [ ] I have checked that my code contains no type errors by running `npm run typecheck`
- [ ] I have checked that all unit tests pass by running `npm run test:unit -- run`
- [ ] I have checked that all e2e tests pass by running `npm run test:e2e`

### Test Instructions
<!-- Provide step-by-step instructions on how to test the changes made in this PR. Include any specific setup or prerequisites needed for testing. -->

### Additional Notes
<!-- Include any additional information or context about the PR that might be helpful for reviewers. -->